### PR TITLE
eo-math: release 0.1.3

### DIFF
--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2022 Yegor Bugayenko
+# Copyright (c) 2021-2022 Max Trunnikov
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,50 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
-+rt jvm org.eolang:eo-runtime:0.23.18
++home https://github.com/objectionary/eo-math
++version 0.1.3
++alias org.eolang.math.nan
++alias org.eolang.math.pi
++rt jvm org.eolang:eo-math:0.1.3
 
+# The angle in radians
 [f] > angle
+  f > @
 
-  # Sine of f
+  # Sine of $
   [] > sin /float
 
-  # Cosine of f
+  # Cosine of $
   [] > cos /float
+
+  # Tangent of $
+  [] > tan
+    ^.cos > cosine!
+    if. > @
+      cosine.eq 0.0
+      nan
+      div.
+        ^.sin
+        cosine
+
+  # Cotangent of $
+  [] > ctan
+    ^.sin > sine!
+    if. > @
+      sine.eq 0.0
+      nan
+      div.
+        ^.cos
+        sine
+
+  # Converts this from radians to degrees
+  [] > as-degrees
+    div. > @
+      ^.times 180.0
+      pi
+
+  # Converts this from degrees to radians
+  [] > as-radians
+    div. > @
+      ^.times pi
+      180.0

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -22,8 +22,8 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
-+rt jvm org.eolang:eo-math:0.1.2
++version 0.1.3
++rt jvm org.eolang:eo-math:0.1.3
 
 # The Euler's number
 [] > e

--- a/objects/org/eolang/math/nan.eo
+++ b/objects/org/eolang/math/nan.eo
@@ -22,8 +22,8 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
-+rt jvm org.eolang:eo-math:0.1.2
++version 0.1.3
++rt jvm org.eolang:eo-math:0.1.3
 
 # Not a number
 [] > nan

--- a/objects/org/eolang/math/negative-infinity.eo
+++ b/objects/org/eolang/math/negative-infinity.eo
@@ -22,10 +22,10 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
++version 0.1.3
 +alias org.eolang.math.nan
 +alias org.eolang.math.positive-infinity
-+rt jvm org.eolang:eo-math:0.1.2
++rt jvm org.eolang:eo-math:0.1.3
 
 # Negative infinity
 [] > negative-infinity

--- a/objects/org/eolang/math/number.eo
+++ b/objects/org/eolang/math/number.eo
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2022 Yegor Bugayenko
+# Copyright (c) 2021-2022 Max Trunnikov
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,9 +21,9 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
-+rt jvm org.eolang:eo-runtime:0.23.18
++home https://github.com/objectionary/eo-math
++version 0.1.3
++rt jvm org.eolang:eo-math:0.1.3
 
 [n] > number
 
@@ -54,6 +54,12 @@
           ^.n
           ^.n
         1.0
+
+  # Checking if number is NaN
+  [] > is-nan
+    eq. > @
+      ^.n.as-bytes
+      7F-C0-00-00
 
   [x] > xor
     if. > @

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -22,8 +22,8 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
-+rt jvm org.eolang:eo-math:0.1.2
++version 0.1.3
++rt jvm org.eolang:eo-math:0.1.3
 
 # The PI number
 [] > pi

--- a/objects/org/eolang/math/positive-infinity.eo
+++ b/objects/org/eolang/math/positive-infinity.eo
@@ -22,10 +22,10 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
++version 0.1.3
 +alias org.eolang.math.nan
 +alias org.eolang.math.negative-infinity
-+rt jvm org.eolang:eo-math:0.1.2
++rt jvm org.eolang:eo-math:0.1.3
 
 # Positive infinity
 [] > positive-infinity

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2022 Yegor Bugayenko
+# Copyright (c) 2021-2022 Max Trunnikov
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,10 +21,10 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
++home https://github.com/objectionary/eo-math
++version 0.1.3
 +alias org.eolang.math.number
-+rt jvm org.eolang:eo-runtime:0.23.18
++rt jvm org.eolang:eo-math:0.1.3
 
 [seed] > random
 

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -21,8 +21,8 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
++home https://github.com/objectionary/eo-math
++version 0.1.3
 +alias org.eolang.math.angle
 +alias org.eolang.math.number
 +alias org.eolang.hamcrest.assert-that
@@ -67,4 +67,3 @@
     angle 3.141592653589793
     .cos
     $.equal-to -1.0
-

--- a/tests/org/eolang/math/e-tests.eo
+++ b/tests/org/eolang/math/e-tests.eo
@@ -22,7 +22,7 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
++version 0.1.3
 +alias org.eolang.math.e
 +junit
 

--- a/tests/org/eolang/math/nan-tests.eo
+++ b/tests/org/eolang/math/nan-tests.eo
@@ -22,7 +22,7 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
++version 0.1.3
 +alias org.eolang.math.nan
 +junit
 

--- a/tests/org/eolang/math/number-tests.eo
+++ b/tests/org/eolang/math/number-tests.eo
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
-+alias org.eolang.math.number
++home https://github.com/objectionary/eo-math
++version 0.1.3
 +alias org.eolang.collections.list
++alias org.eolang.math.number
++alias org.eolang.math.nan
 +alias org.eolang.hamcrest.assert-that
 +junit
 
@@ -39,6 +40,12 @@
     (number -4623).is-int
     $.equal-to TRUE
     "check is-int of negative int"
+
+[] > check-is-nan
+  assert-that > @
+    (number nan).is-nan
+    $.equal-to TRUE
+    "check is nan of nan"
 
 [] > check-is-int-with-zero
   assert-that > @
@@ -411,4 +418,3 @@
     number 0
     .signum
     $.equal-to 0
-

--- a/tests/org/eolang/math/pi-tests.eo
+++ b/tests/org/eolang/math/pi-tests.eo
@@ -22,7 +22,7 @@
 
 +package org.eolang.math
 +home https://github.com/objectionary/eo-math
-+version 0.1.2
++version 0.1.3
 +alias org.eolang.math.pi
 +junit
 

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -21,8 +21,8 @@
 # SOFTWARE.
 
 +package org.eolang.math
-+home https://github.com/objectionary/eo
-+version 0.23.18
++home https://github.com/objectionary/eo-math
++version 0.1.3
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.random
 +junit


### PR DESCRIPTION
I made changes to `eo-math` accordingly to new 0.23.18 `eo` release.
Should merge this PR before [this one](https://github.com/objectionary/eo/pull/862)