### PR TITLE
Updated eo-hamcrest version to 0.3.0

### DIFF
--- a/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objects/org/eolang/hamcrest/assert-that.eo
@@ -20,14 +20,32 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias number org.eolang.math.number
++alias org.eolang.hamcrest.matchers.all-of-matcher
++alias org.eolang.hamcrest.matchers.any-of-matcher
++alias org.eolang.hamcrest.matchers.anything-matcher
++alias org.eolang.hamcrest.matchers.array-each-matcher
++alias org.eolang.hamcrest.matchers.blank-string-matcher
++alias org.eolang.hamcrest.matchers.close-to-matcher
++alias org.eolang.hamcrest.matchers.contains-string-matcher
++alias org.eolang.hamcrest.matchers.described-as-matcher
++alias org.eolang.hamcrest.matchers.empty-string-matcher
++alias org.eolang.hamcrest.matchers.equal-to-matcher
++alias org.eolang.hamcrest.matchers.greater-than-matcher
++alias org.eolang.hamcrest.matchers.has-item-matcher
++alias org.eolang.hamcrest.matchers.has-items-matcher
++alias org.eolang.hamcrest.matchers.is-matcher
++alias org.eolang.hamcrest.matchers.is-substring-matcher
++alias org.eolang.hamcrest.matchers.less-than-matcher
++alias org.eolang.hamcrest.matchers.not-matcher
++alias org.eolang.hamcrest.matchers.matches-regex-matcher
++alias org.eolang.hamcrest.matchers.string-ends-with-matcher
++alias org.eolang.hamcrest.matchers.string-starts-with-matcher
 +alias org.eolang.collections.list
-+alias org.eolang.txt.text
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.2.12
-+version 0.2.12
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
 
 # Main object for assertions
 [actual matcher reasons...] > assert-that
@@ -48,350 +66,107 @@
         matcher
       describe-mismatch.
         matcher
+        act
 
   # Is the value equal to another value
   [x] > equal-to
-
-    [a] > match
-      eq. > @
-        x
-        a
-
-    [] > describe-mismatch
-      sprintf > @
-        "was <%s>"
-        act
-
-    [] > description-of
-      sprintf > @
-        "<%s> equal to value"
-        x
+    equal-to-matcher x > @
 
   # Calculates the logical negation of a matcher
   [matcher] > not
-
-    [a] > match
-      not. > @
-        matcher.match a
-
-    [] > describe-mismatch
-      sprintf > @
-        "%s"
-        matcher.describe-mismatch
-
-    [] > description-of
-      sprintf > @
-        "not %s"
-        description-of.
-          matcher
+    not-matcher matcher > @
 
   # Calculates the logical conjunction of multiple matchers.
   # Evaluation is shortcut, so subsequent matchers are not called
   # if an earlier matcher returns false.
   [matchers...] > all-of
-
-    memory 0 > mismatch
-
-    [a] > match
-      memory 0 > count
-      seq > @
-        count.write 0
-        while.
-          and.
-            count.lt (matchers.length)
-            count.gte 0
-          [i]
-            if. > @
-              (matchers.at i).match a
-              count.write (i.plus 1)
-              seq
-                mismatch.write
-                  describe-mismatch.
-                    matchers.at i
-                count.write -1
-        count.gt 0
-
-    [] > describe-mismatch
-      sprintf > @
-        "a value %s"
-        mismatch
-
-    [] > description-of
-      joined. > @
-        text " and "
-        mapped.
-          list
-            matchers
-          [i]
-            i.description-of > @
+    all-of-matcher (...matchers) > @
 
   # Calculates the logical disjunction of multiple matchers.
   # Evaluation is shortcut, so subsequent matchers are not called
   # if an earlier matcher returns true.
   [matchers...] > any-of
-
-    [a] > match
-      memory 0 > count
-      seq > @
-        count.write 0
-        while.
-          and.
-            count.lt (matchers.length)
-            count.gte 0
-          [i]
-            if. > @
-              (matchers.at i).match a
-              count.write -1
-              count.write (i.plus 1)
-        count.lt 0
-
-    [] > describe-mismatch
-      sprintf > @
-        "a value was <%s>"
-        actual
-
-    [] > description-of
-      joined. > @
-        text " or "
-        mapped.
-          list
-            matchers
-          [i]
-            i.description-of > @
+    any-of-matcher (...matchers) > @
 
   # Compare object that matches when the examined object
   # is greater than the specified value
   [x] > greater-than
-
-    [a] > match
-      gt. > @
-        a
-        x
-
-    [] > describe-mismatch
-      sprintf > @
-        "was less than <%s>"
-        act
-
-    [] > description-of
-      sprintf > @
-        "<%s> less than value"
-        x
+    greater-than-matcher x > @
 
   # Compare object that matches when the examined object
   # is less than the specified value
   [x] > less-than
-
-    [a] > match
-      lt. > @
-        a
-        x
-
-    [] > describe-mismatch
-      sprintf > @
-        "<%s> was greater than <%s>"
-        act
-        x
-
-    [] > description-of
-      sprintf > @
-        "<%s> greater than value"
-        x
+    less-than-matcher x > @
 
   # Compare object that matches when an examined float
   # is equal to the specified operand, within a range of +/- error.
   [operand err] > close-to
-
-    memory 0 > mismatch
-
-    [a] > match
-      seq > @
-        mismatch.write actual-delta
-        actual-delta.lte 0.0
-      [] > actual-delta
-        minus. > @
-          abs.
-            number (a.minus operand)
-          err
-
-    [] > describe-mismatch
-      sprintf > @
-        "<%s> differed by <%.4s> more than delta <%s>"
-        act
-        mismatch
-        err
-
-    [] > description-of
-      sprintf > @
-        "a numeric value within <%s> of <%s>"
-        operand
-        err
+    close-to-matcher > @
+      operand
+      err
 
   # Decorates another Matcher, retaining the behaviour
   # but allowing tests to be slightly more expressive.
   [matcher] > is
-
-    matcher > @
-
-    [] > description-of
-      sprintf > @
-        "is %s"
-        description-of.
-          matcher
+    is-matcher matcher > @
 
   # A matcher that always returns true.
   [] > anything
-
-    [a] > match
-      TRUE > @
-
-    [] > describe-mismatch
-      "anything" > @
-
-    [] > description-of
-      "anything" > @
+    anything-matcher > @
 
   # Wraps an existing matcher, overriding its description with that specified.
   # All other functions are delegated to the decorated matcher,
   # including its mismatch description.
   [matcher format args...] > described-as
-
-    matcher > @
-
-    [] > description-of
-      sprintf > @
-        format
-        args
+    described-as-matcher > @
+      matcher
+      format
+      ...args
 
   # Wraps an existing matcher and apply it to every item in array.
   [matcher] > has-item
-    memory 0 > mismatches
-
-    [a] > match
-      [s] > apply
-        if. > @
-          matcher.match s
-          TRUE
-          seq
-            mismatches.write
-              mismatches.with
-                matcher.describe-mismatch
-            FALSE
-      seq > @
-        mismatches.write *
-        reducedi.
-          list
-            act
-          FALSE
-          [acc i x]
-            or. > @
-              acc
-              apply x
-
-    [] > describe-mismatch
-      sprintf > @
-        "mismatches: [%s]"
-        (text "").joined mismatches
-
-    [] > description-of
-      sprintf > @
-        "an array containing %s"
-        description-of.
-          matcher
+    has-item-matcher matcher > @
 
   # Wraps an array of matchers and apply them to every item in array.
   [matchers...] > has-items
-    memory 0 > mismatches
-
-    [a] > all-match
-      memory 0 > count
-      seq > @
-        count.write 0
-        while.
-          and.
-            count.lt (matchers.length)
-            count.gte 0
-          [i]
-            if. > @
-              (matchers.at i).match a
-              count.write (i.plus 1)
-              seq
-                mismatches.write
-                  mismatches.with
-                    describe-mismatch.
-                      matchers.at i
-                count.write -1
-        count.gt 0
-
-    [a] > match
-      seq > @
-        mismatches.write *
-        reducedi.
-          list
-            act
-          FALSE
-          [acc i el]
-            or. > @
-              acc
-              all-match el
-
-    [] > describe-mismatch
-      sprintf > @
-        "mismatches: [%s]"
-        (text ", ").joined mismatches
-
-    [] > description-of
-      joined. > @
-        text " and "
-        mapped.
-          list
-            matchers
-          [i]
-            i.description-of > @
+    has-items-matcher > @
+      ...matchers
 
   # Matcher for array whose elements satisfy a sequence of matchers.
   # The array size must equal the number of element matchers.
   [matchers...] > array-each
+    array-each-matcher > @
+      ...matchers
 
-    memory 0 > mismatches
+  # Matcher that matches if the examined string contains the specified string anywhere.
+  [str] > contains-string
+    contains-string-matcher > @
+      str
 
-    [] > check-length
-      eq. > @
-        matchers.length
-        act.length
+  # Tests if the argument is a string that ends with a specific substring.
+  [str] > string-ends-with
+    string-ends-with-matcher > @
+      str
 
-    [a] > match
-      if. > @
-        check-length
-        seq
-          mismatches.write *
-          reducedi.
-            list
-              a
-            TRUE
-            [acc i el]
-              and. > @
-                acc
-                if.
-                  (matchers.at i).match el
-                  TRUE
-                  seq
-                    mismatches.write
-                      mismatches.with
-                        describe-mismatch.
-                          matchers.at i
-                    FALSE
-        FALSE
+  # Tests if the argument is a string that starts with a specific substring.
+  [str] > string-starts-with
+    string-starts-with-matcher > @
+      str
 
-    [] > describe-mismatch
-      sprintf > @
-        "mismatches: [%s]"
-        (text ", ").joined mismatches
+  # Tests if the argument can be generated by the given regular expression.
+  [str] > matches-regex
+    matches-regex-matcher > @
+      str
 
-    [] > description-of
-      (text " and ").joined > @
-        mapped.
-          list
-            matchers
-          [i]
-            i.description-of > @
+  # Tests if the argument is a substring of the actual string.
+  [str] > is-substring
+    is-substring-matcher > @
+      str
+
+  # Tests if the examined string contains zero or more whitespace characters and nothing else.
+  [] > blank-string
+    blank-string-matcher > @
+
+  # Tests if the examined string contains zero characters and nothing else.
+  [] > empty-string
+    empty-string-matcher > @

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -1,0 +1,176 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.matchers.all-of-matcher
++alias org.eolang.hamcrest.matchers.any-of-matcher
++alias org.eolang.hamcrest.matchers.anything-matcher
++alias org.eolang.hamcrest.matchers.array-each-matcher
++alias org.eolang.hamcrest.matchers.blank-string-matcher
++alias org.eolang.hamcrest.matchers.close-to-matcher
++alias org.eolang.hamcrest.matchers.contains-string-matcher
++alias org.eolang.hamcrest.matchers.described-as-matcher
++alias org.eolang.hamcrest.matchers.equal-to-matcher
++alias org.eolang.hamcrest.matchers.greater-than-matcher
++alias org.eolang.hamcrest.matchers.has-item-matcher
++alias org.eolang.hamcrest.matchers.has-items-matcher
++alias org.eolang.hamcrest.matchers.is-matcher
++alias org.eolang.hamcrest.matchers.is-substring-matcher
++alias org.eolang.hamcrest.matchers.less-than-matcher
++alias org.eolang.hamcrest.matchers.not-matcher
++alias org.eolang.hamcrest.matchers.matches-regex-matcher
++alias org.eolang.hamcrest.matchers.string-ends-with-matcher
++alias org.eolang.hamcrest.matchers.string-starts-with-matcher
++alias org.eolang.collections.list
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Main object for assertions with multiply dataization of actual object.
+# It should dataize twice only when we get FALSE mathcing result from the first dataization.
+[actual matcher reasons...] > assert-twice-that
+  actual > act!
+
+  [cond m a] > assert
+    if. > @
+      m.match a
+      TRUE
+      if.
+        cond
+        assert FALSE m a
+        FALSE
+  if. > @
+    assert TRUE matcher actual
+    TRUE
+    sprintf
+      "%s\nExpected: %s\n     but: %s"
+      if.
+        is-empty.
+          list
+            reasons
+        ""
+        reasons.at 0
+      description-of.
+        matcher
+      describe-mismatch.
+        matcher
+        act
+
+  # Is the value equal to another value
+  [x] > equal-to
+    equal-to-matcher x > @
+
+  # Calculates the logical negation of a matcher
+  [matcher] > not
+    not-matcher matcher > @
+
+  # Calculates the logical conjunction of multiple matchers.
+  # Evaluation is shortcut, so subsequent matchers are not called
+  # if an earlier matcher returns false.
+  [matchers...] > all-of
+    all-of-matcher (...matchers) > @
+
+  # Calculates the logical disjunction of multiple matchers.
+  # Evaluation is shortcut, so subsequent matchers are not called
+  # if an earlier matcher returns true.
+  [matchers...] > any-of
+    any-of-matcher (...matchers) > @
+
+  # Compare object that matches when the examined object
+  # is greater than the specified value
+  [x] > greater-than
+    greater-than-matcher x > @
+
+  # Compare object that matches when the examined object
+  # is less than the specified value
+  [x] > less-than
+    less-than-matcher x > @
+
+  # Compare object that matches when an examined float
+  # is equal to the specified operand, within a range of +/- error.
+  [operand err] > close-to
+    close-to-matcher > @
+      operand
+      err
+
+  # Decorates another Matcher, retaining the behaviour
+  # but allowing tests to be slightly more expressive.
+  [matcher] > is
+    is-matcher matcher > @
+
+  # A matcher that always returns true.
+  [] > anything
+    anything-matcher > @
+
+  # Wraps an existing matcher, overriding its description with that specified.
+  # All other functions are delegated to the decorated matcher,
+  # including its mismatch description.
+  [matcher format args...] > described-as
+    described-as-matcher > @
+      matcher
+      format
+      ...args
+
+  # Wraps an existing matcher and apply it to every item in array.
+  [matcher] > has-item
+    has-item-matcher matcher > @
+
+  # Wraps an array of matchers and apply them to every item in array.
+  [matchers...] > has-items
+    has-items-matcher > @
+      ...matchers
+
+  # Matcher for array whose elements satisfy a sequence of matchers.
+  # The array size must equal the number of element matchers.
+  [matchers...] > array-each
+    array-each-matcher > @
+      ...matchers
+
+  # Matcher that matches if the examined string contains the specified string anywhere.
+  [str] > contains-string
+    contains-string-matcher > @
+      str
+
+  # Tests if the argument is a string that ends with a specific substring.
+  [str] > string-ends-with
+    string-ends-with-matcher > @
+      str
+
+  # Tests if the argument is a string that starts with a specific substring.
+  [str] > string-starts-with
+    string-starts-with-matcher > @
+      str
+
+  # Tests if the argument can be generated by the given regular expression.
+  [str] > matches-regex
+    matches-regex-matcher > @
+      str
+
+  # Tests if the argument is a substring of the actual string.
+  [str] > is-substring
+    is-substring-matcher > @
+      str
+
+  # Tests if the examined string contains zero or more whitespace characters and nothing else.
+  [] > blank-string
+    blank-string-matcher > @

--- a/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
@@ -1,0 +1,60 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Calculates the logical conjunction of multiple matchers.
+# Evaluation is shortcut, so subsequent matchers are not called
+# if an earlier matcher returns false.
+[matchers...] > all-of-matcher
+
+  memory 0 > mismatch
+
+  [a] > match
+    reduced. > @
+      list matchers
+      TRUE
+      [acc x]
+        and. > @
+          acc
+          x.match a
+
+  [act] > describe-mismatch
+    sprintf > @
+      "a value was <%s>"
+      act
+
+  [] > description-of
+    joined. > @
+      text " and "
+      mapped.
+        list
+          matchers
+        [i]
+          i.description-of > @
+

--- a/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Calculates the logical disjunction of multiple matchers.
+# Evaluation is shortcut, so subsequent matchers are not called
+# if an earlier matcher returns true.
+[matchers...] > any-of-matcher
+
+  [a] > match
+    reduced. > @
+      list matchers
+      FALSE
+      [acc x]
+        or. > @
+          acc
+          x.match a
+
+  [act] > describe-mismatch
+    sprintf > @
+      "a value was <%s>"
+      act
+
+  [] > description-of
+    joined. > @
+      text " or "
+      mapped.
+        list
+          matchers
+        [i]
+          i.description-of > @

--- a/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
@@ -1,0 +1,38 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# A matcher that always returns true.
+[] > anything-matcher
+
+  [a] > match
+    TRUE > @
+
+  [a] > describe-mismatch
+    "anything" > @
+
+  [] > description-of
+    "anything" > @

--- a/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
@@ -1,0 +1,75 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Matcher for array whose elements satisfy a sequence of matchers.
+# The array size must equal the number of element matchers.
+[matchers...] > array-each-matcher
+
+  memory 0 > mismatches
+
+  [a] > match
+    a > act!
+    if. > @
+      eq.
+        matchers.length
+        act.length
+      seq
+        mismatches.write *
+        reducedi.
+          list
+            act
+          TRUE
+          [acc i el]
+            and. > @
+              acc
+              if.
+                (matchers.at i).match el
+                TRUE
+                seq
+                  mismatches.write
+                    mismatches.with
+                      describe-mismatch.
+                        matchers.at i
+                        act
+                  FALSE
+      FALSE
+
+  [act] > describe-mismatch
+    sprintf > @
+      "mismatches: [%s]"
+      (text ", ").joined mismatches
+
+  [] > description-of
+    (text " and ").joined > @
+      mapped.
+        list
+          matchers
+        [i]
+          i.description-of > @

--- a/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
@@ -1,0 +1,49 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Tests if the examined string contains zero or more whitespace characters and nothing else.
+[] > blank-string-matcher
+
+  [a] > match
+    text a > str!
+    or. > @
+      eq.
+        str
+        ""
+      eq.
+        str
+        " "
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    "blank string" > @

--- a/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias number org.eolang.math.number
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Compare object that matches when an examined float
+# is equal to the specified operand, within a range of +/- error.
+[operand err] > close-to-matcher
+
+  memory 0 > mismatch
+
+  [a] > match
+    seq > @
+      mismatch.write actual-delta
+      actual-delta.lte 0.0
+    [] > actual-delta
+      minus. > @
+        abs.
+          number (a.minus operand)
+        err
+
+  [act] > describe-mismatch
+    sprintf > @
+      "<%s> differed by <%.4s> more than delta <%s>"
+      act
+      mismatch
+      err
+
+  [] > description-of
+    sprintf > @
+      "a numeric value within <%s> of <%s>"
+      operand
+      err

--- a/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Matcher that matches if the examined string contains the specified string anywhere.
+[str] > contains-string-matcher
+
+  [a] > match
+    contains. > @
+      text a
+      str
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "string contains: <%s>"
+      str

--- a/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
@@ -1,0 +1,39 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Wraps an existing matcher, overriding its description with that specified.
+# All other functions are delegated to the decorated matcher,
+# including its mismatch description.
+[matcher format args...] > described-as-matcher
+
+  matcher > @
+
+  [] > description-of
+    sprintf > @
+      format
+      args

--- a/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
@@ -1,0 +1,45 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Tests if the examined string contains zero characters and nothing else.
+[] > empty-string-matcher
+
+  [a] > match
+    text a > str!
+    eq. > @
+      str
+      ""
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    "empty string" > @

--- a/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
@@ -1,0 +1,45 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Is the value equal to another value
+[x] > equal-to-matcher
+
+  [a] > match
+    eq. > @
+      x
+      a
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "<%s> equal to value"
+      x

--- a/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Compare object that matches when the examined object
+# is greater than the specified value
+[x] > greater-than-matcher
+
+  [a] > match
+    gt. > @
+      a
+      x
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was less than <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "<%s> less than value"
+      x

--- a/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
@@ -1,0 +1,65 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Wraps an existing matcher and apply it to every item in array.
+[matcher] > has-item-matcher
+  memory 0 > mismatches
+
+  [a] > match
+    [s] > apply
+      if. > @
+        matcher.match s
+        TRUE
+        seq
+          mismatches.write
+            mismatches.with
+              matcher.describe-mismatch a
+          FALSE
+    seq > @
+      mismatches.write *
+      reducedi.
+        list
+          a
+        FALSE
+        [acc i x]
+          or. > @
+            acc
+            apply x
+
+  [act] > describe-mismatch
+    sprintf > @
+      "mismatches: [%s]"
+      (text "").joined mismatches
+
+  [] > description-of
+    sprintf > @
+      "an array containing %s"
+      description-of.
+        matcher

--- a/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
@@ -1,0 +1,77 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Wraps an array of matchers and apply them to every item in array.
+[matchers...] > has-items-matcher
+  memory 0 > mismatches
+
+  [a] > all-match
+    a > act!
+    reduced. > @
+      list matchers
+      FALSE
+      [acc x]
+        if. > @
+          x.match act
+          TRUE
+          seq
+            mismatches.write
+              mismatches.with
+                describe-mismatch.
+                  x
+                  act
+            acc
+
+  [a] > match
+    a > act!
+    seq > @
+      mismatches.write *
+      reducedi.
+        list
+          act
+        FALSE
+        [acc i el]
+          or. > @
+            acc
+            all-match el
+
+  [act] > describe-mismatch
+    sprintf > @
+      "mismatches: [%s]"
+      (text ", ").joined mismatches
+
+  [] > description-of
+    joined. > @
+      text " and "
+      mapped.
+        list
+          matchers
+        [i]
+          i.description-of > @

--- a/objects/org/eolang/hamcrest/matchers/is-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-matcher.eo
@@ -1,0 +1,40 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Decorates another Matcher, retaining the behaviour
+# but allowing tests to be slightly more expressive.
+[matcher] > is-matcher
+
+  matcher > @
+
+  [] > description-of
+    sprintf > @
+      "is %s"
+      description-of.
+        matcher
+

--- a/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Tests if the argument is a substring of the actual string.
+[str] > is-substring-matcher
+
+  [a] > match
+    contains. > @
+      text a
+      str
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "string contains: <%s>"
+      str

--- a/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
@@ -1,0 +1,47 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Compare object that matches when the examined object
+# is less than the specified value
+[x] > less-than-matcher
+
+  [a] > match
+    lt. > @
+      a
+      x
+
+  [act] > describe-mismatch
+    sprintf > @
+      "<%s> was greater than <%s>"
+      act
+      x
+
+  [] > description-of
+    sprintf > @
+      "<%s> greater than value"
+      x

--- a/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
@@ -1,0 +1,48 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.regex
++alias org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Checks if given string can be generated
+# by the regular expression.
+[str] > matches-regex-matcher
+
+  [a] > match
+    matches. > @
+      compile.
+        regex str
+      a
+
+  [act] > describe-mismatch
+    sprintf > @
+      "the string was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "a string matching the pattern <%s>"
+      str

--- a/objects/org/eolang/hamcrest/matchers/not-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/not-matcher.eo
@@ -1,0 +1,45 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Calculates the logical negation of a matcher
+[matcher] > not-matcher
+
+  [a] > match
+    not. > @
+      matcher.match a
+
+  [act] > describe-mismatch
+    sprintf > @
+      "%s"
+      matcher.describe-mismatch act
+
+  [] > description-of
+    sprintf > @
+      "not %s"
+      description-of.
+        matcher

--- a/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Tests if the argument is a string that ends with a specific substring.
+[str] > string-ends-with-matcher
+
+  [a] > match
+    ends-with. > @
+      text a
+      str
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "string ends with: <%s>"
+      str

--- a/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.text
++alias sprintf org.eolang.txt.sprintf
++home https://github.com/objectionary/eo-hamcrest
++package org.eolang.hamcrest.matchers
++rt jvm org.eolang:eo-hamcrest:0.3.0
++version 0.3.0
+
+# Tests if the argument is a string that starts with a specific substring.
+[str] > string-starts-with-matcher
+
+  [a] > match
+    starts-with. > @
+      text a
+      str
+
+  [act] > describe-mismatch
+    sprintf > @
+      "was <%s>"
+      act
+
+  [] > description-of
+    sprintf > @
+      "string starts with: <%s>"
+      str

--- a/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -25,34 +25,31 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > all-of-numbers-test
-  nop > @
-    assert-that
-      150.minus 50
-      $.all-of
-        $.equal-to 100
-      "all of numbers conditions"
+  assert-that > @
+    150.minus 50
+    $.all-of
+      $.equal-to 100
+    "all of numbers conditions"
 
 [] > all-of-several
-  nop > @
-    assert-that
-      15.times 3
-      $.all-of
-        $.equal-to 45
-        $.greater-than 40
-        $.less-than 100
-      "all of conditions"
+  assert-that > @
+    15.times 3
+    $.all-of
+      $.equal-to 45
+      $.greater-than 40
+      $.less-than 100
+    "all of conditions"
 
 [] > all-of-close-to
-  nop > @
-    assert-that
-      22.0
-      $.all-of
-        $.equal-to
-          number 22
-          .as-float
-        $.greater-than 10.0
-        $.close-to 20.0 2.2
-      "all of conditions"
+  assert-that > @
+    22.0
+    $.all-of
+      $.equal-to
+        number 22
+        .as-float
+      $.greater-than 10.0
+      $.close-to 20.0 2.2
+    "all of conditions"

--- a/tests/org/eolang/hamcrest/any-of-tests.eo
+++ b/tests/org/eolang/hamcrest/any-of-tests.eo
@@ -25,34 +25,31 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > any-of-numbers-test
-  nop > @
-    assert-that
-      150.div 3
-      $.any-of
-        $.equal-to 50
-      "any of number conditions"
+  assert-that > @
+    150.div 3
+    $.any-of
+      $.equal-to 50
+    "any of number conditions"
 
 [] > any-of-several
-  nop > @
-    assert-that
-      100.minus 5
-      $.any-of
-        $.equal-to 45
-        $.greater-than 40
-        $.less-than -111
-      "any of conditions"
+  assert-that > @
+    100.minus 5
+    $.any-of
+      $.equal-to 45
+      $.greater-than 40
+      $.less-than -111
+    "any of conditions"
 
 [] > any-of-close-to
-  nop > @
-    assert-that
-      30.0
-      $.any-of
-        $.equal-to
-          number 1000
-          .as-float
-        $.greater-than 777.0
-        $.close-to 30.0 0.1
-      "any of conditions"
+  assert-that > @
+    30.0
+    $.any-of
+      $.equal-to
+        number 1000
+        .as-float
+      $.greater-than 777.0
+      $.close-to 30.0 0.1
+    "any of conditions"

--- a/tests/org/eolang/hamcrest/anything-tests.eo
+++ b/tests/org/eolang/hamcrest/anything-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > anything-two-sum-test
   assert-that > @
@@ -48,15 +48,13 @@
     "sum of two floats of anything is always true"
 
 [] > anything-all-of-test
-  nop > @
-    assert-that
-      FALSE
-      $.all-of
-        $.anything
+  assert-that > @
+    FALSE
+    $.all-of
+      $.anything
 
 [] > anything-any-of-test
-  nop > @
-    assert-that
-      FALSE
-      $.any-of
-        $.anything
+  assert-that > @
+    FALSE
+    $.any-of
+      $.anything

--- a/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -25,14 +25,13 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > has-item-int-test
-  nop > @
-    assert-that
-      * 1 2 3
-      $.has-item
-        $.equal-to 2
+  assert-that > @
+    * 1 2 3
+    $.has-item
+      $.equal-to 2
 
 [] > has-item-string-test
   assert-that > @
@@ -48,18 +47,16 @@
         $.greater-than 10.0
 
 [] > has-items-int-test
-  nop > @
-    assert-that
-      * 99 101
-      $.has-items
-        $.greater-than 100
+  assert-that > @
+    * 99 101
+    $.has-items
+      $.greater-than 100
 
 [] > nested-has-items
-  nop > @
-    assert-that
-      * "a" "b" "c" "d"
-      $.has-items
-        $.equal-to "c"
+  assert-that > @
+    * "a" "b" "c" "d"
+    $.has-items
+      $.equal-to "c"
 
 [] > arrays-each-items
   assert-that > @

--- a/tests/org/eolang/hamcrest/blank-string-tests.eo
+++ b/tests/org/eolang/hamcrest/blank-string-tests.eo
@@ -1,0 +1,42 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-blank-string
+  assert-that > @
+    ""
+    $.blank-string
+    "simple-blank-string"
+
+[] > simple-blank-string-with-space
+  assert-that > @
+    " "
+    $.is
+      $.blank-string
+    "simple-blank-string-with-space"
+
+

--- a/tests/org/eolang/hamcrest/close-to-tests.eo
+++ b/tests/org/eolang/hamcrest/close-to-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > float-is-close-to-float-with-delta-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-contains-string
+  assert-that > @
+    "Привет, 世界"
+    $.contains-string "世"
+    "constains-string"
+
+[] > check-all-contains-string
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.contains-string "界"
+    "constains-all-of-string"
+
+[] > check-any-contains-string
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.contains-string "f"
+    "constains-any-of-string"
+

--- a/tests/org/eolang/hamcrest/described-as-tests.eo
+++ b/tests/org/eolang/hamcrest/described-as-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > two-sum-described-as-equal-to-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/empty-string-tests.eo
+++ b/tests/org/eolang/hamcrest/empty-string-tests.eo
@@ -1,0 +1,32 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-empty-string
+  assert-that > @
+    ""
+    $.empty-string

--- a/tests/org/eolang/hamcrest/equal-to-tests.eo
+++ b/tests/org/eolang/hamcrest/equal-to-tests.eo
@@ -21,15 +21,31 @@
 # SOFTWARE.
 
 +alias org.eolang.hamcrest.assert-that
++alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > two-sum-test
   assert-that > @
     4.plus 4
     $.equal-to 8
+    "sum of two numbers"
+
+[] > two-sum-assert-twice-that
+  assert-twice-that > @
+    4.plus 4
+    $.equal-to 8
+    "sum of two numbers"
+
+[] > two-sum-assert-twice-that-pass
+  memory 0 > count
+  [] > foo
+    count.write (count.plus 1) > @
+  assert-twice-that > @
+    foo
+    $.equal-to 2
     "sum of two numbers"
 
 [] > two-strings-test

--- a/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -25,46 +25,43 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > all-of-number-test-failed-output
-  nop > @
-    [] > suggestion
-      assert-that > @
-        150.minus 50
-        $.all-of
-          $.equal-to 1
-        "all of numbers conditions"
-    assert-that
-      suggestion
-      $.equal-to "all of numbers conditions\nExpected: <1> equal to value\n     but: a value was <100>"
+  [] > suggestion
+    assert-that > @
+      150.minus 50
+      $.all-of
+        $.equal-to 1
+      "all of numbers conditions"
+  assert-that > @
+    suggestion
+    $.equal-to "all of numbers conditions\nExpected: <1> equal to value\n     but: a value was <100>"
 
 [] > all-of-several-failed-output
-  nop > @
-    [] > suggestion
-      assert-that > @
-        3.times 1
-        $.all-of
-          $.equal-to 1
-          $.greater-than 100
-          $.less-than 2
-        "all of conditions"
-    assert-that
-      suggestion
-      $.equal-to "all of conditions\nExpected: <1> equal to value and <100> less than value and <2> greater than value\n     but: a value was <3>"
+  [] > suggestion
+    assert-that > @
+      3.times 1
+      $.all-of
+        $.equal-to 1
+        $.greater-than 100
+        $.less-than 2
+      "all of conditions"
+  assert-that > @
+    suggestion
+    $.equal-to "all of conditions\nExpected: <1> equal to value and <100> less than value and <2> greater than value\n     but: a value was <3>"
 
 [] > all-of-close-to-failed-output
-  nop > @
-    [] > suggestion
-      assert-that > @
-        42.0
-        $.all-of
-          $.equal-to
-            number 1
-            .as-float
-          $.greater-than 100.0
-          $.close-to 20.0 2.2
-        "all of conditions"
-    assert-that
-      suggestion
-      $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a numeric value within <20.0> of <2.2>\n     but: a value was <42.0>"
+  [] > suggestion
+    assert-that > @
+      42.0
+      $.all-of
+        $.equal-to
+          number 1
+          .as-float
+        $.greater-than 100.0
+        $.close-to 20.0 2.2
+      "all of conditions"
+  assert-that > @
+    suggestion
+    $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a numeric value within <20.0> of <2.2>\n     but: a value was <42.0>"

--- a/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -25,31 +25,29 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > any-of-number-test-failed-output
-  nop > @
-    [] > suggestion
-      assert-that > @
-        150.minus 50
-        $.any-of
-          $.equal-to 1
-    assert-that
-      suggestion
-      $.equal-to "\nExpected: <1> equal to value\n     but: a value was <100>"
+  [] > suggestion
+    assert-that > @
+      150.minus 50
+      $.any-of
+        $.equal-to 1
+  assert-that > @
+    suggestion
+    $.equal-to "\nExpected: <1> equal to value\n     but: a value was <100>"
 
 [] > any-of-several-failed-output
-  nop > @
-    [] > suggestion
-      assert-that > @
-        3.times 1
-        $.any-of
-          $.equal-to 1
-          $.greater-than 100
-          $.less-than -6
-    assert-that
-      suggestion
-      $.equal-to "\nExpected: <1> equal to value or <100> less than value or <-6> greater than value\n     but: a value was <3>"
+  [] > suggestion
+    assert-that > @
+      3.times 1
+      $.any-of
+        $.equal-to 1
+        $.greater-than 100
+        $.less-than -6
+  assert-that > @
+    suggestion
+    $.equal-to "\nExpected: <1> equal to value or <100> less than value or <-6> greater than value\n     but: a value was <3>"
 
 [] > any-of-close-to-failed-output
   nop > @

--- a/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > anything-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -20,10 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > arrays-failed-output
-  nop > @
+  [] > suggestion
+    assert-that > @
+      * 1 2
+      $.array-each
+        $.equal-to 1
+        $.equal-to 3
+  assert-that > @
+    suggestion
+    $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"

--- a/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -1,0 +1,49 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-blank-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.blank-string
+      "simple-blank-string"
+  assert-that > @
+    suggestion
+    $.equal-to "simple-blank-string\nExpected: blank string\n     but: was <Привет, 世界>"
+
+[] > is-blank-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.is
+        $.blank-string
+      "simple-blank-string"
+  assert-that > @
+    suggestion
+    $.equal-to "simple-blank-string\nExpected: is blank string\n     but: was <Привет, 世界>"
+

--- a/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > float-is-close-to-float-with-delta-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-contains-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.contains-string "111"
+      "constains-string"
+  assert-that > @
+    suggestion
+    $.equal-to "constains-string\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+
+[] > contains-any-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "Hello"
+      $.any-of
+        $.contains-string "2"
+      "constains-string"
+  assert-that > @
+    suggestion
+    $.equal-to "constains-string\nExpected: string contains: <2>\n     but: a value was <Hello>"
+
+[] > contains-all-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "so sad"
+      $.all-of
+        $.contains-string "2"
+        $.contains-string "happy"
+      "constains-string"
+  assert-that > @
+    suggestion
+    $.equal-to "constains-string\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+
+
+
+

--- a/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > two-sum-described-as-equal-to-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -1,0 +1,37 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-empty-string-failed
+  [] > suggestion
+    assert-that > @
+      "幸福"
+      $.empty-string
+      "simple-empty-string"
+  assert-that > @
+    suggestion
+    $.equal-to "simple-empty-string\nExpected: empty string\n     but: was <幸福>"

--- a/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 +alias org.eolang.hamcrest.assert-that
++alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > delayed-calculation
   memory 0 > m
@@ -71,3 +72,16 @@
     suggestion
     "\nExpected: <11.0> equal to value\n     but: was <44.0>"
 
+[] > equal-to-assert-twice-that-failed-output
+  nop > @
+    [] > suggestion
+      memory 0 > count
+      [] > foo
+        count.write (count.plus 1) > @
+      assert-twice-that > @
+        foo
+        $.equal-to 3
+    assert-that
+      suggestion
+      $.equal-to
+        "\nExpected: <3> equal to value\n     but: was <2>"

--- a/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > greater-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > is-failed-output-with-two-bools
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-contains-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.is-substring "111"
+      "is-substring"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+
+[] > contains-any-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "Hello"
+      $.any-of
+        $.is-substring "2"
+      "is-substring"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
+
+[] > contains-all-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "so sad"
+      $.all-of
+        $.is-substring "2"
+        $.is-substring "happy"
+      "is-substring"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+
+
+
+

--- a/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > less-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -1,0 +1,37 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > matches-regex-failed-output
+  [] > suggestion
+    assert-that > @
+      "abc"
+      $.matches-regex
+        "/($[0-9])/"
+  assert-that > @
+    suggestion
+    $.equal-to "\nExpected: a string matching the pattern </($[0-9])/>\n     but: the string was <abc>"

--- a/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.2.12
++version 0.3.0
 
 [] > not-failed-output-two-strings
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -1,0 +1,67 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-ends-with-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.string-ends-with "Привет"
+      "string-ends-with Привет"
+  assert-that > @
+    suggestion
+    $.equal-to "string-ends-with Привет\nExpected: string ends with: <Привет>\n     but: was <Привет, 世界>"
+
+[] > ends-with-any-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.all-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.string-ends-with "ет"
+      "ends-with"
+  assert-that > @
+    suggestion
+    $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
+
+[] > ends-with-all-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "ffffffffffff"
+      $.any-of
+        $.contains-string "Привет"
+        $.string-ends-with "dddd"
+        $.contains-string "界"
+      "ends-with"
+  assert-that > @
+    suggestion
+    $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+
+
+
+

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -1,0 +1,67 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest.failed-output
++version 0.3.0
+
+[] > simple-starts-with-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.string-starts-with "界"
+      "string-starts-with 界"
+  assert-that > @
+    suggestion
+    $.equal-to "string-starts-with 界\nExpected: string starts with: <界>\n     but: was <Привет, 世界>"
+
+[] > starts-with-any-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "Привет, 世界"
+      $.all-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.string-starts-with "ет"
+      "starts-with"
+  assert-that > @
+    suggestion
+    $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
+
+[] > starts-with-all-of-string-failed
+  [] > suggestion
+    assert-that > @
+      "ffffffffffff"
+      $.any-of
+        $.contains-string "Привет"
+        $.string-starts-with "dddd"
+        $.contains-string "界"
+      "starts-with"
+  assert-that > @
+    suggestion
+    $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+
+
+
+

--- a/tests/org/eolang/hamcrest/greater-than-tests.eo
+++ b/tests/org/eolang/hamcrest/greater-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > two-sum-greater-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-is-substring
+  assert-that > @
+    "Привет, 世界"
+    $.is-substring "世"
+    "is-substring"
+
+[] > check-all-is-substring
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.is-substring "Привет"
+      $.is-substring "世"
+      $.is-substring "界"
+    "is-substring-of-string"
+
+[] > check-any-is-substring
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.is-substring "Привет"
+      $.is-substring "世"
+      $.is-substring "f"
+    "is-substring-of-string"
+

--- a/tests/org/eolang/hamcrest/is-tests.eo
+++ b/tests/org/eolang/hamcrest/is-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > is-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/less-than-tests.eo
+++ b/tests/org/eolang/hamcrest/less-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > two-sum-less-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/tests/org/eolang/hamcrest/matches-regex-tests.eo
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > matches-regex-alphabetical-test
+  assert-that > @
+    "abc"
+    $.matches-regex
+      "/([a-z])/"
+
+[] > matches-regex-dollar-test
+  assert-that > @
+    "$12"
+    $.matches-regex
+      "/($[0-9]*)/"
+
+[] > matches-regex-multiline-test
+  assert-that > @
+    "1 bottle of water on the wall. \\n1 bottle of water."
+    $.matches-regex
+      "/(^([0-9]+).*)/m"
+
+[] > matches-regex-dotall-test
+  assert-that > @
+    "too \\n many \\n line \\n Feed\\n"
+    $.matches-regex
+      "/(.*)/s"
+
+[] > matches-regex-comments-test
+  assert-that > @
+    "4"
+    $.matches-regex
+      "/(\\d) #ignore this comment/x"
+
+[] > matches-regex-unicode-test
+  assert-that > @
+    "Yıldırım"
+    $.matches-regex
+      "/(yildirim)/ui"

--- a/tests/org/eolang/hamcrest/not-tests.eo
+++ b/tests/org/eolang/hamcrest/not-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.2.12
++version 0.3.0
 
 [] > not-equal-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-ends-with-string
+  assert-that > @
+    "Привет, 世界"
+    $.string-ends-with "界"
+    "string-ends-with 界"
+
+[] > check-all-contains-and-ends-with-string
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.string-ends-with "界"
+    "ends-with"
+
+[] > check-any-contains-and-ends-with-string
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.string-ends-with "fffff"
+      $.contains-string "界"
+    "ends-with"
+

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Graur Andrew
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-hamcrest
++junit
++package org.eolang.hamcrest
++version 0.3.0
+
+[] > simple-starts-with-string
+  assert-that > @
+    "Привет, 世界"
+    $.string-starts-with "Привет"
+    "string-starts-with Привет"
+
+[] > check-all-contains-and-starts-with-string
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.string-starts-with "Пр"
+    "starts-with"
+
+[] > check-any-contains-and-starts-with-string
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.string-starts-with "fffff"
+      $.contains-string "界"
+    "starts-with"
+

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -1,0 +1,66 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2022 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EcounterPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.hamcrest.assert-that
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++junit
++package org.eolang
++version 0.28.14
+
+[] > seq-single-dataization-float-less-than-test
+  memory 0.0 > counter
+  assert-that > @
+    seq
+      counter.write
+        counter.plus 1.0
+      counter
+    $.less-than 2.0
+
+[] > seq-single-dataization-float-greater-than-test
+  memory 0.0 > counter
+  assert-that > @
+    seq
+      counter.write
+        counter.plus 1.0
+      counter
+    $.not
+      $.greater-than 1.1
+
+[] > seq-single-dataization-int-less-than-test
+  memory 0 > counter
+  assert-that > @
+    seq
+      counter.write
+        counter.plus 1
+      counter
+    $.less-than 2
+
+[] > seq-single-dataization-int-greater-than-test
+  memory 0 > counter
+  assert-that > @
+    seq
+      counter.write
+        counter.plus 1
+      counter
+    $.not
+      $.greater-than 1


### PR DESCRIPTION
What is done:

- updated EO version
- fixed assert-twice-that object and added new pdd puzzle. Now it uses recursion instead of while object
- fixed all-of and any-of matchers. Now they use reduced object instead of while
- fixed has-items object. Now it uses reduced object instead of while