### PR TITLE
hot fix with 'meta of out order' in eo-hamcrest

### DIFF
--- a/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objects/org/eolang/hamcrest/assert-that.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -40,7 +41,6 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
-+alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -39,7 +40,6 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
-+alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest


### PR DESCRIPTION
Related to: https://github.com/objectionary/eo/issues/1620 and https://github.com/objectionary/eo-hamcrest/issues/184

We have some build problem in EO, since eo-hamcrest was released.

What's done:

- hot fix with reordering meta in eo-hamcrest