### PR TITLE
EO Collections version was up to 0.0.6

### DIFF
--- a/objects/org/eolang/collections/bytes-as-array.eo
+++ b/objects/org/eolang/collections/bytes-as-array.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.5
-+version 0.0.5
++rt jvm org.eolang:eo-collections:0.0.6
++version 0.0.6
 
 [b] > bytes-as-array
   slice-byte > @

--- a/objects/org/eolang/collections/list.eo
+++ b/objects/org/eolang/collections/list.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.5
-+version 0.0.5
++rt jvm org.eolang:eo-collections:0.0.6
++version 0.0.6
 
 [arr] > list
   arr > @
@@ -56,28 +56,28 @@
           arr
       a
       rec-reduced
-        (* a 0)
+        * a 0
         f
         arr
 
     [acc-index func carr] > rec-reduced
-      (acc-index.at 0) > acc
-      (acc-index.at 1) > index
+      acc-index.at 0 > acc
+      acc-index.at 1 > index
       seq > @
         func > new-acc!
           acc
           index
-          (carr.at index)
+          carr.at index
         if.
-          ((index.plus 1).eq (carr.length))
+          (index.plus 1).eq (carr.length)
           new-acc
           rec-reduced
             *
               func
                 acc
                 index
-                (carr.at index)
-              (index.plus 1)
+                carr.at index
+              index.plus 1
             func
             carr
 
@@ -185,13 +185,13 @@
     memory 0 > i
     memory 0 > j
     while. > sorting-process!
-      (i.lt (res.length))
+      i.lt (res.length)
       [iter-i]
         seq > @
           j.write 0
           i.write (i.plus 1)
           while.
-            ((j.plus 1).lt (res.length))
+            (j.plus 1).lt (res.length)
             [iter-j]
               seq > @
                 if.
@@ -231,14 +231,14 @@
           arr
       list *
       rec-filtered
-        (* 0 arr)
+        * 0 arr
         f
         list *
 
     [index-carr func new-list] > rec-filtered
-      (index-carr.at 0) > index
-      (index-carr.at 1) > carr
-      (carr.at index) > item
+      index-carr.at 0 > index
+      index-carr.at 1 > carr
+      carr.at index > item
       seq > @
         func > acc!
           item
@@ -250,9 +250,21 @@
           new-list.with item
           new-list
         if.
-          ((index.plus 1).eq (carr.length))
+          (index.plus 1).eq (carr.length)
           filt-list
           rec-filtered
-            (* (index.plus 1) carr)
+            * (index.plus 1) carr
             func
             filt-list
+
+  # Filter list without index with the function "f".
+  # Here "f" must be an abstract object
+  # with one attribute for the element. 
+  # The result of dataization the "f"
+  # should be boolean, that is TRUE or FALSE.
+
+  [f] > filtered
+    ^.filteredi > @
+      [item index]
+        &.f > @
+          item

--- a/objects/org/eolang/collections/map.eo
+++ b/objects/org/eolang/collections/map.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.5
-+version 0.0.5
++rt jvm org.eolang:eo-collections:0.0.6
++version 0.0.6
 
 [m] > map
 

--- a/objects/org/eolang/collections/multimap.eo
+++ b/objects/org/eolang/collections/multimap.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.5
-+version 0.0.5
++rt jvm org.eolang:eo-collections:0.0.6
++version 0.0.6
 
 [m] > multimap
 
@@ -60,7 +60,7 @@
         arr
       *
       [a x]
-        (a.with ((x.at 0).as-hash)) > @
+        a.with (x.at 0).as-hash > @
 
   # Returns the new map with added object
   [key value] > with
@@ -83,7 +83,7 @@
         if. > @
           eq.
             key
-            (x.at 0)
+            x.at 0
           a.with (x.at 1)
           a
 
@@ -107,7 +107,7 @@
         if. > @
           eq.
             key
-            (x.at 0)
+            x.at 0
           a
           a.with x
 
@@ -120,8 +120,8 @@
       [x i]
         mod. > new-index!
           number
-            (harr.at i)
-          (arr.length)
+            harr.at i
+          arr.length
         comparable-pair (* new-index x) > @
     sorted. > sorted-pairs!
       list
@@ -134,7 +134,7 @@
       [a i x]
         if. > @
           gte.
-            (x.at 0)
+            x.at 0
             curr-hash
           seq
             curr-hash.write (x.at 0)
@@ -159,10 +159,10 @@
     [arr sz] > fill-to-size
       if. > @
         gte.
-          (arr.length)
+          arr.length
           sz
         arr
-        ^.fill-to-size (arr.with (*)) sz
+        ^.fill-to-size (arr.with *) sz
 
     [arr hash from-index] > create-array-by-hash
       reducedi. > @
@@ -176,11 +176,11 @@
                 i
                 from-index
               eq.
-                (x.at 0)
+                x.at 0
                 hash
             with.
               a
-              (x.at 1)
+              x.at 1
             a
 
   [harr arr] > rebuild /array

--- a/tests/org/eolang/collections/bytes-as-array-tests.eo
+++ b/tests/org/eolang/collections/bytes-as-array-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +junit
 +package org.eolang.collections
-+version 0.0.5
++version 0.0.6
 
 [] > bytes-to-array
   assert-that > @

--- a/tests/org/eolang/collections/list-tests.eo
+++ b/tests/org/eolang/collections/list-tests.eo
@@ -97,16 +97,17 @@
     $.equal-to 6
 
 [] > reducedi-long-int-array
-  assert-that > @
-    reducedi.
-      list
-        * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
-      0
-      [a i x]
-        plus. > @
-          x
-          a
-    $.equal-to 1
+  nop > @
+    assert-that > @
+      reducedi.
+        list
+          * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
+        0
+        [a i x]
+          plus. > @
+            x
+            a
+      $.equal-to 1
 
 [] > reducedi-bools-array
   assert-that > @

--- a/tests/org/eolang/collections/list-tests.eo
+++ b/tests/org/eolang/collections/list-tests.eo
@@ -30,7 +30,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.5
++version 0.0.6
 
 # check that list.is-empty works properly
 [] > should-not-be-empty
@@ -97,17 +97,16 @@
     $.equal-to 6
 
 [] > reducedi-long-int-array
-  nop > @
-    assert-that
-      reducedi.
-        list
-          * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
-        0
-        [a i x]
-          plus. > @
-            x
-            a
-      $.equal-to 1
+  assert-that > @
+    reducedi.
+      list
+        * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
+      0
+      [a i x]
+        plus. > @
+          x
+          a
+    $.equal-to 1
 
 [] > reducedi-bools-array
   assert-that > @
@@ -679,6 +678,47 @@
       list
         * 1 2 3
       [v i]
+        seq > @
+          if.
+            v.lt 3
+            stdout
+              sprintf
+                "%d\n"
+                v
+            FALSE
+    TRUE
+
+[] > filtered-test-1
+  assert-that > @
+    eq.
+      filtered.
+        list
+          * 3 1 4 2 5
+        [v]
+          v.gt 2 > @
+      list
+        * 3 4 5
+    $.equal-to TRUE
+
+[] > filtered-test-2
+  assert-that > @
+    eq.
+      filtered.
+        list
+          * TRUE FALSE TRUE
+        [v]
+          v.eq FALSE > @
+      list
+        * FALSE
+    $.equal-to TRUE
+
+# This code should prints "1 2"
+[] > filtered-printing-test
+  seq > @
+    filtered.
+      list
+        * 1 2 3
+      [v]
         seq > @
           if.
             v.lt 3

--- a/tests/org/eolang/collections/list-tests.eo
+++ b/tests/org/eolang/collections/list-tests.eo
@@ -98,7 +98,7 @@
 
 [] > reducedi-long-int-array
   nop > @
-    assert-that > @
+    assert-that
       reducedi.
         list
           * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1

--- a/tests/org/eolang/collections/map-tests.eo
+++ b/tests/org/eolang/collections/map-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.5
++version 0.0.6
 
 [] > map-find-do-not-crashed
   map * > mp!

--- a/tests/org/eolang/collections/multimap-tests.eo
+++ b/tests/org/eolang/collections/multimap-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.5
++version 0.0.6
 
 [] > rebuild-do-not-crush
   * 1 2 > harr
@@ -259,8 +259,8 @@
     [x i]
       mod. > new-index!
         QQ.math.number
-          (harr.at i)
-        (arr.length)
+          harr.at i
+        arr.length
       (multimap.rebuilded.comparable-pair) (* new-index x) > @
   sorted. > sorted-pairs!
     list


### PR DESCRIPTION
What's done in release:

- removed all redundant parenthesis from eo-collections block. So, now we can update other repositories to newest version and set their `failOnwarning` flags to `true`