### PR TITLE
#96 adding objects index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,9 @@ jobs:
       - run: git ls-remote --tags --heads origin > data/tags.txt
       - run: sed -i '' 's+refs/tags/++g' data/tags.txt
       - run: sed -i '' 's+refs/heads/++g' data/tags.txt
+      - run: touch data/objectionary.lst
+      - run: find objects -name '*.eo' > data/objectionary.lst
+      - run: find tests -name '*.eo' >> data/objectionary.lst
       - uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages


### PR DESCRIPTION
closes #96

Creating `objectionary.lst` file with all object names within Objectionary on pages build.
Format of names:
```
objects/org/eolang/heap.eo
tests/org/eolang/hamcrest/matches-regex-tests.eo
```

