### PR TITLE
Rename array -> tuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 target/
+.idea

--- a/objects/org/eolang/collections/multimap.eo
+++ b/objects/org/eolang/collections/multimap.eo
@@ -183,7 +183,7 @@
               x.at 1
             a
 
-  [harr arr] > rebuild /array
+  [harr arr] > rebuild /tuple
 
   # Returns a new map, without elements with the given key
   # Returns the map itself, if there was no item with this key

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -37,7 +37,7 @@
 
   # Go though all files in the directory, recursively
   # finding them with the "glob" provided.
-  [glob] > walk /array
+  [glob] > walk /tuple
 
   # Delete directory and all files in it, recursively.
   # Always returns TRUE.

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -26,19 +26,19 @@
 +rt jvm org.eolang:eo-runtime:0.29.0
 +version 0.29.0
 
-[] > array
-  # Create empty array
+[] > tuple
+  # Create empty tuple
   [] > empty
     * > @
 
-  # Obtain the length of the array.
+  # Obtain the length of the tuple.
   [] > length /int
 
-  # Take one element from the array, at the
+  # Take one element from the tuple, at the
   # given position.
   [i] > at /?
 
-  # Create a new array with this element added to
+  # Create a new tuple with this element added to
   # the end of it.
-  [x] > with /array
+  [x] > with /tuple
 

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -50,7 +50,7 @@
   #  - start position in which match was found
   #  - matched string
   #  - array of identified matched groups
-  [txt] > match /array
+  [txt] > match /tuple
 
   # Matches
   [txt] > matches

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -31,4 +31,4 @@
 # 1. format - is a formatter string (e.g. "Hello, %s!")
 # 2. read - is a string where data exists (e.g. "Hello, John!")
 # returns an array of formatted values (e.g. * "John").
-[format read] > sscanf /array
+[format read] > sscanf /tuple

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -102,7 +102,7 @@
   [other] > compare /int
 
   # Returns an array of strings, separated by a given string
-  [delimiter] > split /array
+  [delimiter] > split /tuple
 
   # Check that all signs in string are letters
   [] > is-alphabetic /bool

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -28,54 +28,54 @@
 +package org.eolang
 +version 0.29.0
 
-[] > makes-array-through-special-syntax
+[] > makes-tuple-through-special-syntax
   assert-that > @
     (* 1 2).length
     $.equal-to 2
 
-[] > gets-lengths-of-empty-array-through-special-syntax
+[] > gets-lengths-of-empty-tuple-through-special-syntax
   assert-that > @
     *.length
     $.equal-to 0
 
-# check that an empty array's .length equals to zero
-[] > empty-array-length
+# check that an empty tuple's .length equals to zero
+[] > empty-tuple-length
   [elements...] > arr
   assert-that > @
     arr.elements.length
     $.equal-to 0
 
-# check that array.length works properly for non-empty arrays
-[] > non-empty-array-length-test
+# check that tuple.length works properly for non-empty tuples
+[] > non-empty-tuple-length-test
   [elements...] > arr
   assert-that > @
     (arr "a" "b" "c" "d" "e").elements.length
     $.equal-to 5
 
-[] > array-as-a-bound-attribute-size-0
-  * > anArray
+[] > tuple-as-a-bound-attribute-size-0
+  * > anTuple
   assert-that > @
-    anArray.length
+    anTuple.length
     $.equal-to 0
 
-[] > array-as-a-bound-attribute-size-1
-  * > anArray
+[] > tuple-as-a-bound-attribute-size-1
+  * > anTuple
     100
   assert-that > @
-    anArray.at 0
+    anTuple.at 0
     $.equal-to 100
 
-[] > array-as-a-bound-attribute-size-2
-  * > anArray
+[] > tuple-as-a-bound-attribute-size-2
+  * > anTuple
     1
     2
   assert-that > @
-    anArray
+    anTuple
     $.array-each
       $.equal-to 1
       $.equal-to 2
 
-[] > array-with-in-seq
+[] > tuple-with-in-seq
   [a] > foo
     seq > @
       a.with "hi" > t
@@ -85,7 +85,7 @@
       * 1 2 3
     TRUE
 
-[] > array-with
+[] > tuple-with
   assert-that > @
     with.
       * 1 2 3
@@ -94,7 +94,7 @@
       list
         * 1 2 3 "with"
 
-[] > array-at-with-error
+[] > tuple-at-with-error
   assert-that > @
     try
       []
@@ -106,9 +106,9 @@
       nop
     $.is
       $.equal-to
-        "Can't #at(20) the 21th element of the array, there are just 4 of them"
+        "Can't #at(20) the 21th element of the tuple, there are just 4 of them"
 
-[] > concat-array-with-empty-array-1
+[] > concat-tuple-with-empty-array-1
   * 1 2 3 > a
   * > b
   concat. > res
@@ -118,7 +118,7 @@
     res.length
     $.equal-to 3
 
-[] > concat-array-with-empty-array-2
+[] > concat-tuple-with-empty-tuple-2
   * > a
   * 1 2 3 > b
   concat. > res
@@ -128,7 +128,7 @@
     res.length
     $.equal-to 3
 
-[] > concat-array-with-empty-array-3
+[] > concat-tuple-with-empty-array-3
   * > a
   * > b
   concat. > res
@@ -138,7 +138,7 @@
     res.length
     $.equal-to 0
 
-[] > concat-arrays
+[] > concat-tuples
   * 1 2 3 > a
   * 100 200 > b
   concat. > res
@@ -150,7 +150,7 @@
       res.at 4
     $.equal-to 203
 
-[] > concat-three-arrays
+[] > concat-three-tuples
   * 0 1 2 > a
   * 3 4 > b
   * (* "five" "six") (* "siven") > c
@@ -165,14 +165,14 @@
       list
         * 7 "six"
 
-[] > array-fluent-with
+[] > tuple-fluent-with
   assert-that > @
     ((*.with 1).with 2).with 3
     $.equal-to
       list
         * 1 2 3
 
-[] > array-fluent-with-indented
+[] > tuple-fluent-with-indented
   *
   .with 1
   .with 2
@@ -183,13 +183,13 @@
       list
         * 1 2 3
 
-[] > gets-lengths-of-empty-array-keyword
+[] > gets-lengths-of-empty-tuple-keyword
   assert-that > @
-    array.empty.length
+    tuple.empty.length
     $.equal-to 0
 
-[] > array-fluent-with-indented-keyword
-  array.empty
+[] > tuple-fluent-with-indented-keyword
+  tuple.empty
   .with 1
   .with 2
   .with 3 > a
@@ -198,19 +198,19 @@
     $.equal-to
       list (* 1 2 3)
 
-[] > array-with-negative-index-gets-last
+[] > tuple-with-negative-index-gets-last
   * 0 1 2 3 4 > arr
   assert-that > @
     arr.at -1
     $.equal-to 4
 
-[] > array-with-negative-index-gets-first
+[] > tuple-with-negative-index-gets-first
   * 0 1 2 3 4 > arr
   assert-that > @
     arr.at -5
     $.equal-to 0
 
-[] > array-with-negative-index-out-of-bounds
+[] > tuple-with-negative-index-out-of-bounds
   * 0 1 2 3 4 > arr
   assert-that > @
     try


### PR DESCRIPTION
I've renamed  `array` to `tuple` files and didn't touch subfolders that use `array`, probably they have to be updated themselves from their repositories.