### PR TITLE
released EO-hamcrest 0.3.2 and EO-collections 0.0.8 and EO-strings 0.2.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -29,6 +29,7 @@ SOFTWARE.
   <version>1.0-SNAPSHOT</version>
   <properties>
     <eo.version>0.29.1</eo.version>
+    <stack-size>32M</stack-size>
   </properties>
   <build>
     <plugins>
@@ -38,6 +39,12 @@ SOFTWARE.
         <configuration>
           <source>8</source>
           <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xss${stack-size}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -29,6 +29,7 @@ SOFTWARE.
   <version>1.0-SNAPSHOT</version>
   <properties>
     <eo.version>0.29.1</eo.version>
+    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>
@@ -38,6 +39,12 @@ SOFTWARE.
         <configuration>
           <source>8</source>
           <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xss${stack-size}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -29,7 +29,6 @@ SOFTWARE.
   <version>1.0-SNAPSHOT</version>
   <properties>
     <eo.version>0.29.1</eo.version>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>
@@ -39,12 +38,6 @@ SOFTWARE.
         <configuration>
           <source>8</source>
           <target>8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>-Xss${stack-size}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/objects/org/eolang/collections/list.eo
+++ b/objects/org/eolang/collections/list.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.6
-+version 0.0.6
++rt jvm org.eolang:eo-collections:0.0.8
++version 0.0.8
 
 [arr] > list
   arr > @
@@ -50,10 +50,7 @@
   # of the array.
   [a f] > reducedi
     if. > @
-      eq.
-        0
-        length.
-          arr
+      arr.length.eq 0
       a
       rec-reduced
         * a 0
@@ -61,25 +58,21 @@
         arr
 
     [acc-index func carr] > rec-reduced
-      acc-index.at 0 > acc
       acc-index.at 1 > index
-      seq > @
-        func > new-acc!
-          acc
+      if. > @
+        eq.
+          index.plus 1 > next-index
+          carr.length
+        func > new-acc
+          acc-index.at 0
           index
           carr.at index
-        if.
-          (index.plus 1).eq (carr.length)
-          new-acc
-          rec-reduced
-            *
-              func
-                acc
-                index
-                carr.at index
-              index.plus 1
-            func
-            carr
+        rec-reduced
+          *
+            new-acc
+            next-index
+          func
+          carr
 
   # Reduce from start "a" using the function "f"
   [a f] > reduced
@@ -124,7 +117,7 @@
       TRUE
 
   # Create a new list without the i-th element
-  [i] > without
+  [i] > withouti
     ^.reducedi > @
       *
       [a idx item]
@@ -132,6 +125,16 @@
           idx.eq i
           a
           a.with item
+
+  [x] > without
+    list > @
+      ^.reduced
+        *
+        [acc item]
+          if. > @
+            x.eq item
+            acc
+            acc.with item
 
   # Equal to another object?
   [x] > eq
@@ -149,7 +152,6 @@
               x.at idx
       FALSE
 
-  # Returns the combined current and passed arrays
   [passed] > concat
     reduced. > @!
       list
@@ -159,8 +161,8 @@
         a.with x > @
 
   # Returns index of the first particular item in list.
-  # If the list has no this item, found returns -1
-  [wanted] > found
+  # If the list has no this item, index-of returns -1
+  [wanted] > index-of
     ^.reducedi > @
       -1
       [acc i item]
@@ -175,6 +177,27 @@
           i
           acc.plus 0
 
+  # Returns index of the last particular item in list.
+  # If the list has no this item, last-index-of returns -1
+  [wanted] > last-index-of
+    ^.reducedi > @
+      -1
+      [acc i item]
+        if. > @
+          eq.
+            item
+            wanted
+          i
+          acc.plus 0
+
+  # TRUE if the list contain x. Otherwise, "false".
+  [x] > contains
+    not. > @
+      eq.
+        -1
+        ^.index-of
+          x
+
   # Returns a new list sorted via lt method
   [] > sorted
     reducedi. > res!
@@ -185,13 +208,13 @@
     memory 0 > i
     memory 0 > j
     while. > sorting-process!
-      i.lt (res.length)
+      (i.plus 1).lt (res.length)
       [iter-i]
         seq > @
           j.write 0
           i.write (i.plus 1)
           while.
-            (j.plus 1).lt (res.length)
+            (j.plus 2).lt (res.length)
             [iter-j]
               seq > @
                 if.
@@ -222,7 +245,6 @@
   # one for the element, the second one
   # for the index. The result of dataization
   # the "f" should be boolean, that is TRUE or FALSE.
-
   [f] > filteredi
     if. > @
       eq.
@@ -259,12 +281,92 @@
 
   # Filter list without index with the function "f".
   # Here "f" must be an abstract object
-  # with one attribute for the element. 
+  # with one attribute for the element.
   # The result of dataization the "f"
   # should be boolean, that is TRUE or FALSE.
-
   [f] > filtered
     ^.filteredi > @
       [item index]
         &.f > @
           item
+
+  [f] > inflated
+    rec-inflated > @
+      list
+        arr
+      0
+      f
+
+    [a i func] > rec-inflated
+      func > result!
+        a
+        i
+      if. > @
+        is-empty.
+          list
+            result
+        a
+        rec-inflated
+          list
+            concat.
+              list
+                a
+              result
+          plus.
+            i
+            1
+          func
+
+  # Get the first i-th elements from
+  # the start of the list
+  [i] > head
+    i > index!
+
+    if. > @
+      index.lte 0
+      list *
+      if.
+        index.gte (^.length)
+        ^
+        ^.reducedi
+          list *
+          [acc idx item]
+            if. > @
+              idx.gte index
+              acc
+              acc.with item
+
+  # Get the last i-th elements from
+  # the end of the list
+  [i] > tail
+    minus. > start!
+      arr.length
+      i
+    if. > @
+      start.lt 0
+      ^
+      ^.reducedi
+        list *
+        [acc idx item]
+          if. > @
+            gte.
+              idx
+              start
+            acc.with item
+            acc
+
+  # TRUE if the current list is lexicographically
+  # greater than the passed list. Otherwise, FALSE.
+  [other] > gt
+
+  # TRUE if the current list is lexicographically
+  # greater than or equal to the passed list. Otherwise, FALSE.
+  [other] > gte
+
+  # TRUE if the current list is lexicographically
+  # less than the passed list. Otherwise, FALSE.
+  [other] > lt
+
+  # TRUE if the current list is lexicographically
+  # less than or equal to the passed list. Otherwise, FALSE.
+  [other] > lte

--- a/objects/org/eolang/collections/map.eo
+++ b/objects/org/eolang/collections/map.eo
@@ -25,11 +25,10 @@
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.6
-+version 0.0.6
++rt jvm org.eolang:eo-collections:0.0.8
++version 0.0.8
 
 [m] > map
-
   memory 0 > elements-amount
 
   # Returns list of all keys in multimap
@@ -40,6 +39,19 @@
         caa
       [curr]
         curr.at 0 > @
+
+  # TRUE if the map contain key. Otherwise, FALSE.
+  [key] > contains-key
+    reduced. > @
+      keys.
+        ^
+      FALSE
+      [a x]
+        or. > @
+          a
+          eq.
+            x
+            key
 
   # Returns amount of elements in multimap
   [] > size

--- a/objects/org/eolang/collections/multimap.eo
+++ b/objects/org/eolang/collections/multimap.eo
@@ -24,11 +24,10 @@
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-collections
 +package org.eolang.collections
-+rt jvm org.eolang:eo-collections:0.0.6
-+version 0.0.6
++rt jvm org.eolang:eo-collections:0.0.8
++version 0.0.8
 
 [m] > multimap
-
   memory 0 > elements-amount
 
   # Returns list of all keys in multimap
@@ -183,7 +182,7 @@
               x.at 1
             a
 
-  [harr arr] > rebuild /array
+  [harr arr] > rebuild /tuple
 
   # Returns a new map, without elements with the given key
   # Returns the map itself, if there was no item with this key

--- a/objects/org/eolang/collections/range.eo
+++ b/objects/org/eolang/collections/range.eo
@@ -25,15 +25,40 @@
 +rt jvm org.eolang:eo-collections:0.0.8
 +version 0.0.8
 
-[b] > bytes-as-array
-  slice-byte > @
-    *
-    0
-  [a i] > slice-byte
+# Range — create an array containing a range of elements
+# Here "start" must be a abstract object that must have an object "next" to get
+# next element and object "lt" to compare with the "end" object.
+# Every next element also must have an objects "next" and "lt".
+# The first object in the chain must have a default value
+# e.g.
+# range
+#   []
+#     [num] > build
+#       num > @!
+#       build (@.plus 1) > next
+#     build 1 > @
+#   10
+# Here the first argument is an abstract object that has a default value - 1 and
+# it also has object "next". The next object after first is decorator of
+# "1.plus 1" and also has object next. Since these objects are ints - they have
+# object "lt" by default
+[start end] > range
+  [] > @
+    [acc current last] > append
+      if. > @
+        current.lt last
+        []
+          append > @
+            acc.with current
+            current.next
+            last
+        acc
+
     if. > @
-      i.lt
-        b.size
-      ^.slice-byte
-        a.with (b.slice i 1)
-        i.plus 1
-      a
+      start.lt end
+      append
+        * start
+        start.next
+        end
+      *
+

--- a/objects/org/eolang/collections/set.eo
+++ b/objects/org/eolang/collections/set.eo
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2022 Objectionary.com
+# Copyright (c) 2016-2022 Yegor Bugayenko
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,42 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo-strings
-+package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++alias org.eolang.collections.list
++alias org.eolang.collections.map
++home https://github.com/objectionary/eo-collections
++package org.eolang.collections
++rt jvm org.eolang:eo-collections:0.0.8
++version 0.0.8
 
-[format args...] > sprintf /string
+[lst] > set
+  if. > @!
+    lst.is-empty
+    lst
+    []
+      reduced. > @
+        at.
+          reducedi.
+            lst
+            *
+              map *
+              list *
+            [acc index item]
+              acc.at 0 > mp!
+              if. > @
+                not.
+                  eq.
+                    length.
+                      mp.found item
+                    0
+                acc
+                *
+                  mp.with item 1
+                  (acc.at 1).with index
+          1
+        list *
+        [acc index]
+          acc.with (lst.at index) > @
+
+  [x] > with
+    set > @
+      lst.with x

--- a/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objects/org/eolang/hamcrest/assert-that.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -40,7 +41,6 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
-+alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest

--- a/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objects/org/eolang/hamcrest/assert-that.eo
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -41,11 +40,12 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
++alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Main object for assertions
 [actual matcher reasons...] > assert-that

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -40,11 +39,12 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
++alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Main object for assertions with multiply dataization of actual object.
 # It should dataize twice only when we get FALSE mathcing result from the first dataization.

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -39,7 +40,6 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
-+alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest

--- a/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Calculates the logical conjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Calculates the logical disjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # A matcher that always returns true.
 [] > anything-matcher

--- a/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Matcher for array whose elements satisfy a sequence of matchers.
 # The array size must equal the number of element matchers.

--- a/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Tests if the examined string contains zero or more whitespace characters and nothing else.
 [] > blank-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Compare object that matches when an examined float
 # is equal to the specified operand, within a range of +/- error.

--- a/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Matcher that matches if the examined string contains the specified string anywhere.
 [str] > contains-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Wraps an existing matcher, overriding its description with that specified.
 # All other functions are delegated to the decorated matcher,

--- a/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Tests if the examined string contains zero characters and nothing else.
 [] > empty-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Is the value equal to another value
 [x] > equal-to-matcher

--- a/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Compare object that matches when the examined object
 # is greater than the specified value

--- a/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Wraps an existing matcher and apply it to every item in array.
 [matcher] > has-item-matcher

--- a/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Wraps an array of matchers and apply them to every item in array.
 [matchers...] > has-items-matcher

--- a/objects/org/eolang/hamcrest/matchers/is-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Decorates another Matcher, retaining the behaviour
 # but allowing tests to be slightly more expressive.

--- a/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Tests if the argument is a substring of the actual string.
 [str] > is-substring-matcher

--- a/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Compare object that matches when the examined object
 # is less than the specified value

--- a/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Checks if given string can be generated
 # by the regular expression.

--- a/objects/org/eolang/hamcrest/matchers/not-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/not-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Calculates the logical negation of a matcher
 [matcher] > not-matcher

--- a/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Tests if the argument is a string that ends with a specific substring.
 [str] > string-ends-with-matcher

--- a/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.1
-+version 0.3.1
++rt jvm org.eolang:eo-hamcrest:0.3.2
++version 0.3.2
 
 # Tests if the argument is a string that starts with a specific substring.
 [str] > string-starts-with-matcher

--- a/objects/org/eolang/sys/uname.eo
+++ b/objects/org/eolang/sys/uname.eo
@@ -36,7 +36,7 @@
   [] > is-windows
     contains. > @
       QQ.txt.text
-        lower-case.
+        low-cased.
           QQ.txt.text ^
       "windows"
 
@@ -44,7 +44,7 @@
   [] > is-unix
     contains. > @
       QQ.txt.text
-        lower-case.
+        low-cased.
           QQ.txt.text ^
       "linux"
 
@@ -52,6 +52,6 @@
   [] > is-macos
     contains. > @
       QQ.txt.text
-        lower-case.
+        low-cased.
           QQ.txt.text ^
       "mac"

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -25,8 +25,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.0.4
-+version 0.0.4
++rt jvm org.eolang:eo-strings:0.2.0
++version 0.2.0
 
 # Regular expression in Perl format.
 # Free attribute "r" is a string represenation of regex object.
@@ -42,15 +42,14 @@
 # /u - Enables Unicode-aware case folding.
 #
 [r] > regex
-
   [] > compile /regex
 
-  # Match the text and return the array of matched blocks.
+  # Match the text and return the tuple of matched blocks.
   # Each matched block consists of
   #  - start position in which match was found
   #  - matched string
-  #  - array of identified matched groups
-  [txt] > match /array
+  #  - tuple of identified matched groups
+  [txt] > match /tuple
 
   # Matches
   [txt] > matches
@@ -61,13 +60,39 @@
   # A string with all encounters of pattern in txt
   # replaced with rpl
   [txt rpl] > replaced
-
     # Perform partial replace operation for
     # pt - next unhandled index in text
     # acc - replaced text so far
     # pa - next unhandled index in replaced text
-    # m - matched segments array
+    # m - matched segments tuple
     [pt acc pa m] > replacei
+      # Replace groups signs ($i) in old-rpl by the group of
+      # the list groups
+      [old-rpl groups] > replace-by-groups
+        if. > @
+          groups.is-empty
+          old-rpl
+          replace-by-groups
+            replaced.
+              old-rpl
+              chained. > text-chained
+                text "\\$"
+                QQ.txt.sprintf
+                  "%d"
+                  minus.
+                    groups.length
+                    1
+              at.
+                groups
+                minus.
+                  groups.length
+                  1
+            list
+              without.
+                groups
+                minus.
+                  groups.length
+                  1
 
       [] > nextpt
         plus. > @!
@@ -92,7 +117,10 @@
               minus.
                 mitem.at 0
                 pt
-            rpl
+            replace-by-groups
+              text rpl
+              list
+                mitem.at 2
 
       [] > nextacc
         joined. > @!
@@ -100,7 +128,7 @@
           *
             part
             slice.
-              txt
+              text txt
               nextpt
               minus.
                 txt.length
@@ -121,6 +149,6 @@
 
     replacei > @
       0
-      txt
+      text txt
       0
       match txt

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -23,12 +23,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.0.4
-+version 0.0.4
++rt jvm org.eolang:eo-strings:0.2.0
++version 0.2.0
 
 # Reads formatted input from a string.
 # This object with two free attributes:
 # 1. format - is a formatter string (e.g. "Hello, %s!")
 # 2. read - is a string where data exists (e.g. "Hello, John!")
-# returns an array of formatted values (e.g. * "John").
-[format read] > sscanf /array
+# returns an tuple of formatted values (e.g. * "John").
+[format read] > sscanf /tuple

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -20,22 +20,73 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.bytes-as-array
 +alias org.eolang.collections.list
 +alias org.eolang.txt.sscanf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.0.4
-+version 0.0.4
++rt jvm org.eolang:eo-strings:0.2.0
++version 0.2.0
 
 [s] > text
-
   s > @
 
-  # Trim it from both sides
-  [] > trim /string
+  [start len] > slice
+    text > @
+      ^.s.slice start len
 
-  # Joins an array of strings, using current string
+  # Trim it from both sides
+  [] > trimmed
+    rec-trim > @
+      s
+
+    [str] > rec-trim
+      str > const-str!
+      eq. > empty
+        length.
+          const-str
+        0
+      eq. > starts-with-space
+        slice.
+          const-str
+          0
+          1
+        " "
+      eq. > ends-with-space
+        slice.
+          const-str
+          plus.
+            length.
+              const-str
+            -1
+          1
+        " "
+
+      if. > @
+        empty
+        ""
+        if.
+          starts-with-space
+          rec-trim
+            slice
+              1
+              plus.
+                length.
+                  const-str
+                -1
+          if.
+            ends-with-space
+            rec-trim
+              slice
+                0
+                plus.
+                  length.
+                    const-str
+                  -1
+            const-str
+
+  # Joins an tuple of strings, using current string
   # as a delimiter
   [items] > joined
     reducedi. > res!
@@ -44,40 +95,185 @@
       "".as-bytes
       [acc i x]
         if. > @
-          i.eq ((items.length).minus 1)
-          acc.concat (x.as-bytes)
-          (acc.concat (x.as-bytes)).concat (s.as-bytes)
+          i.eq (items.length.minus 1)
+          acc.concat x.as-bytes
+          (acc.concat x.as-bytes).concat s.as-bytes
     res.as-string > @
 
   # Checks that string contains substr
-  [substr] > contains /bool
+  [substr] > contains
+    index-of. > idx!
+      text
+        s
+      substr
+    gt. > @
+      idx
+      -1
 
   # Checks that string ends with substr
-  [substr] > ends-with /bool
+  [substr] > ends-with
+    index-of.check-if-starts-from-index > @
+      s
+      substr
+      minus.
+        s.length
+        substr.length
 
-  # Checks that string starts with substr
-  [substr] > starts-with /bool
+  # Checks that the text starts with substr
+  [substr] > starts-with
+    index-of.check-if-starts-from-index > @
+      s
+      substr
+      0
 
   # Returns index of substr in string,
   # if no element was found, it returns -1
-  [substr] > index-of /int
+  [substr] > index-of
+    bytes-as-array > bytes-view!
+      as-bytes.
+        s
+    reducedi. > @
+      list
+        bytes-view
+      -1
+      [a i x]
+        check-if-starts-from-index > res!
+          s
+          substr
+          i
+        if. > @
+          eq.
+            a
+            -1
+          if.
+            res
+            i
+            a
+          a
+
+    # Method accepts a string and a substring as an array of bytes
+    # and checks if the string contains a substring in the passed position
+    [str substr index] > check-if-starts-from-index
+      str.length > lstr!
+      substr.length > lsub!
+      if. > @
+        gt.
+          plus.
+            index
+            lsub
+          lstr
+        FALSE
+        eq.
+          substr
+          slice.
+            str
+            index
+            lsub
+
+  # Returns text in lower case
+  [] > low-cased
+    up-cased.ascii "Z" > ascii-z!
+    up-cased.ascii "A" > ascii-a!
+    text > @
+      as-string.
+        reduced.
+          list
+            bytes-as-array
+              s.as-bytes
+          --
+          [a x]
+            up-cased.ascii x > ascii-x!
+            concat. > @
+              a
+              if.
+                and.
+                  lte.
+                    ascii-x
+                    ascii-z
+                  gte.
+                    ascii-x
+                    ascii-a
+                slice.
+                  as-bytes.
+                    plus.
+                      up-cased.ascii
+                        x
+                      up-cased.distance
+                  7
+                  1
+                x
 
   # Returns last index of substr in string,
   # if no element was found, it returns -1
-  [substr] > last-index-of /int
+  [substr] > last-index-of
+    bytes-as-array > bytes-view!
+      as-bytes.
+        s
+    reducedi. > @
+      list
+        bytes-view
+      -1
+      [a i x]
+        index-of.check-if-starts-from-index > res!
+          s
+          substr
+          i
+        if. > @
+          res
+          i
+          a
 
-  # Returns string in lower case
-  [] > lower-case /string
+  # Returns text in upper case
+  [] > up-cased
+    ascii "z" > ascii-z!
+    ascii "a" > ascii-a!
+    text > @
+      as-string.
+        reduced.
+          list
+            bytes-as-array
+              s.as-bytes
+          --
+          [a x]
+            ascii x > ascii-x!
+            concat. > @
+              a
+              if.
+                and.
+                  lte.
+                    ascii-x
+                    ascii-z
+                  gte.
+                    ascii-x
+                    ascii-a
+                slice.
+                  as-bytes.
+                    minus.
+                      ascii
+                        x
+                      distance
+                  7
+                  1
+                x
 
-  # Returns string in upper case
-  [] > upper-case /string
+    [c] > ascii
+      as-int. > @
+        concat.
+          00-00-00-00-00-00-00
+          as-bytes.
+            c
+    minus. > distance!
+      ascii
+        "a"
+      ascii
+        "A"
 
   [i] > at
-    ^.s.slice i 1 > @
+    ^.slice i 1 > @
 
-  # Returns string where all substrings
+  # Returns text where all regexp
   # target changed to replacement
-  [target replacement] > replaced /string
+  [target replacement] > replaced /text
 
   # Returns the text as integer
   [] > as-int
@@ -99,19 +295,108 @@
   # Returns 0 if two strings are equal,
   # a negative number if the first string comes before the argument,
   # a positive number if the first string comes after the argument
-  [other] > compare /int
-
-  # Returns an array of strings, separated by a given string
-  [delimiter] > split /array
-
-  # Check that all signs in string are letters
-  [] > is-alphabetic /bool
-
-  # Returns concatenaion of two strings
-  [other] > chained
-    as-string. > @
-      concat.
-        as-bytes.
+  [other] > compare
+    bytes-as-array > b1!
+      as-bytes.
+        s
+    bytes-as-array > b2!
+      as-bytes.
+        other
+    if. > @
+      eq.
+        length.
           s
-        as-bytes.
+        length.
           other
+      reducedi.
+        list
+          b1
+        0
+        [a i x]
+          if. > res!
+            eq.
+              at.
+                b1
+                i
+              at.
+                b2
+                i
+            0
+            if.
+              gt.
+                as-int.
+                  is-alphabetic.bytes-1-to-8
+                    at.
+                      b1
+                      i
+                as-int.
+                  is-alphabetic.bytes-1-to-8
+                    at.
+                      b2
+                      i
+              1
+              -1
+          if. > @
+            eq.
+              a
+              0
+            res
+            a
+      minus.
+        length.
+          s
+        length.
+          other
+
+  # Returns an tuple of strings, separated by a given string
+  [delimiter] > split /tuple
+
+  # Check that all signs in string are letters.
+  # Works only for english letters
+  [] > is-alphabetic
+    reduced. > @
+      list
+        bytes-as-array
+          as-bytes.
+            low-cased.
+              text
+                s
+      TRUE
+      [a x]
+        as-int. > value!
+          bytes-1-to-8
+            as-bytes.
+              x
+        and. > @
+          a
+          int-is-alpha
+            value
+
+    [b] > int-is-alpha
+      and. > @
+        gte.
+          b
+          97
+        lte.
+          b
+          122
+
+    [b] > bytes-1-to-8
+      concat. > @
+        00-00-00-00-00-00-00
+        b
+
+  # Returns concatenaion of all strings
+  [others...] > chained
+    text > @
+      as-string.
+        reduced.
+          list
+            others
+          as-bytes.
+            s
+          [a x]
+            concat. > @
+              a
+              as-bytes.
+                x

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -102,13 +102,34 @@
 
   # Checks that string contains substr
   [substr] > contains
-    index-of. > idx!
-      text
-        s
-      substr
-    gt. > @
-      idx
-      -1
+    substr.length > len!
+    s.length > s-len!
+    memory 0 > start
+    memory FALSE > res
+    [] > loop
+      while. > @
+        and.
+          start.lt s-len
+          lte.
+            start.plus len
+            s-len
+        [i]
+          if. > @
+            lte.
+              start.plus len
+              s-len
+            if.
+              eq.
+                s.slice start len
+                substr
+              seq
+                res.write TRUE
+                start.write s-len
+              start.write (start.plus 1)
+            FALSE
+    seq > @
+      loop
+      res
 
   # Checks that string ends with substr
   [substr] > ends-with

--- a/tests/org/eolang/collections/list-tests.eo
+++ b/tests/org/eolang/collections/list-tests.eo
@@ -30,7 +30,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.6
++version 0.0.8
 
 # check that list.is-empty works properly
 [] > should-not-be-empty
@@ -97,17 +97,16 @@
     $.equal-to 6
 
 [] > reducedi-long-int-array
-  nop > @
-    assert-that
-      reducedi.
-        list
-          * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
-        0
-        [a i x]
-          plus. > @
-            x
-            a
-      $.equal-to 1
+  assert-that > @
+    reducedi.
+      list
+        * 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
+      0
+      [a i x]
+        plus. > @
+          x
+          a
+    $.equal-to 1
 
 [] > reducedi-bools-array
   assert-that > @
@@ -230,9 +229,9 @@
   .each > @
     [i] (stdout i > @)
 
-[] > list-without
+[] > list-withouti
   assert-that > @
-    without.
+    withouti.
       list
         * 1 2 3
       1
@@ -240,10 +239,10 @@
       list
         * 1 3
 
-[] > list-without-complex-case
+[] > list-withouti-complex-case
   [a] > foo
     seq > @
-      without. > t
+      withouti. > t
         list a
         0
       t
@@ -254,10 +253,10 @@
       list
         * "text" "f"
 
-[] > list-without-nested-array
+[] > list-withouti-nested-array
   * 3 2 1 > nested
   assert-that > @
-    without.
+    withouti.
       list
         * "smthg" 27 nested
       2
@@ -378,49 +377,114 @@
     7
 
   [] > foo
-    *.with (memory 0) > res
+    with. > res
+      *
+      memory 0
     seq > @
       (res.at 0).write 7
       res.at 0
 
-[] > is-found-1
+[] > is-index-of-1
   list > lst
     * 1 2 3
   assert-that > @
-    lst.found 2
+    lst.index-of 2
     $.equal-to 1
 
-[] > is-found-2
+[] > is-index-of-2
   list > lst
     * "qwerty" 2 3
   assert-that > @
-    lst.found 2
+    lst.index-of 2
     $.equal-to 1
 
-[] > is-found-3
+[] > is-index-of-3
   list > lst
     * -1 2 -1
   assert-that > @
-    lst.found -1
+    lst.index-of -1
     $.equal-to 0
 
-[] > is-not-found
+[] > is-not-index-of
   list > lst
     * "qwerty" 2 3
   assert-that > @
-    lst.found 7
+    lst.index-of 7
     $.equal-to -1
 
-[] > is-found-first-index
+[] > is-index-of-first-index
   list > lst
     * "qwerty" "asdfgh" 3 "qwerty"
   assert-that > @
-    lst.found "qwerty"
+    lst.index-of "qwerty"
     $.equal-to 0
 
-[] > list-with-without
+[] > last-index-of-1
+  list > lst
+    * "qwerty" 2 3
+  assert-that > @
+    lst.last-index-of 2
+    $.equal-to 1
+
+[] > last-index-of-repeated
+  list > lst
+    * 24 42 24
+  assert-that > @
+    lst.last-index-of 24
+    $.equal-to 2
+
+[] > last-index-of-not-found
+  list > lst
+    * 1 2 3
+  assert-that > @
+    lst.last-index-of 0
+    $.equal-to -1
+
+[] > last-index-of-empty
+  list > lst
+    *
+  assert-that > @
+    lst.last-index-of "abacaba"
+    $.equal-to -1
+
+[] > last-index-of-unicode
+  list > lst
+    * "Hi" "Привет" "Hola" "Guten Tag" "こんにちわ"
+  assert-that > @
+    lst.last-index-of "Привет"
+    $.equal-to 1
+
+[] > contains-1
+  list > lst
+    * "qwerty" "asdfgh" 3 "qwerty"
+  assert-that > @
+    lst.contains "qwerty"
+    $.equal-to TRUE
+
+[] > contains-2
+  list > lst
+    * "qwerty" "asdfgh" 3 "qwerty"
+  assert-that > @
+    lst.contains 3
+    $.equal-to TRUE
+
+[] > contains-3
+  list > lst
+    * "Привет" "asdfgh" 3 "qwerty"
+  assert-that > @
+    lst.contains "Привет"
+    $.equal-to TRUE
+
+[] > contains-4
+  list > lst
+    * "qwerty" "asdfgh" 3 "qwerty"
+  assert-that > @
+    lst.contains "Привет"
+    $.equal-to FALSE
+
+[] > list-with-withouti
   list (* 1 2) > list1
-  without. > list2
+  withouti. > list2
     with.
       list1
       3
@@ -429,10 +493,39 @@
     list2.at 0
     $.equal-to 2
 
-[] > concat-returns-list
+[] > list-without-1
+  assert-that > @
+    without.
+      list
+        * 1 2 1 2 1 5
+      2
+    $.equal-to
+      list
+        * 1 1 1 5
+
+[] > list-without-2
+  assert-that > @
+    without.
+      list
+        *
+          "äääää"
+          5
+          "äääää"
+          "äääää"
+          6
+          "bbb"
+      "äääää"
+    $.equal-to
+      list
+        *
+          5
+          6
+          "bbb"
+
+[] > concat-returns-list-1
   list (* 0 1) > list1
   list (* 2 3) > list2
-  without. > list3
+  withouti. > list3
     concat.
       list1
       list2
@@ -441,15 +534,29 @@
     list3.at 0
     $.equal-to 1
 
+[] > concat-returns-list-2
+  assert-that > @
+    contains.
+      concat.
+        list
+          * 0 1
+        list
+          * 2 3
+      3
+    $.equal-to
+      TRUE
+
 [] > nested-reduced-with-literal
   reduced. > res!
     list
       * 1
-    * *
+    *
+      *
     [a x]
       reduced. > @
         list
-          * *
+          *
+            *
         *
         [aaa xxx]
           aaa.with xxx > @
@@ -461,7 +568,8 @@
   reduced. > res!
     list
       * 1
-    * *
+    *
+      *
     [a x]
       reduced. > @
         list
@@ -474,48 +582,55 @@
     $.equal-to 0
 
 [] > list-sorted
-  nop > @
-    sorted. > res!
+  sorted. > res!
+    list
+      * 4 6 3 5
+  assert-that > @
+    res
+    $.equal-to
       list
-        * 4 6 3 5
-    assert-that
-      res
-      $.equal-to
-        list
-          * 3 4 5 6
+        * 3 4 5 6
 
 [] > list-sorted-2
-  nop > @
-    sorted. > res!
+  sorted. > res!
+    list
+      * 5 3 6
+  assert-that > @
+    res
+    $.equal-to
       list
-        * 5 3 6 4
-    assert-that
-      res
-      $.equal-to
-        list
-          * 3 4 5 6
+        * 3 5 6
 
 [] > reversed-list-sorted
+  sorted. > res!
+    list
+      * 3 2 1
+  assert-that > @
+    res
+    $.equal-to
+      list
+        * 1 2 3
+
+[] > reversed-list-sorted-with-zero
   nop > @
     sorted. > res!
       list
-        * 2 1 0
+        * 3 2 0
     assert-that
       res
       $.equal-to
         list
-          * 0 1 2
+          * 0 2 3
 
 [] > similar-elements-list-sorted
-  nop > @
-    sorted. > res!
+  sorted. > res!
+    list
+      * 1 1 1
+  assert-that > @
+    res
+    $.equal-to
       list
         * 1 1 1
-    assert-that
-      res
-      $.equal-to
-        list
-          * 1 1 1
 
 [] > one-element-list-sorted
   sorted. > res!
@@ -538,15 +653,14 @@
         *
 
 [] > negative-numbers-list-sorted
-  nop > @
-    sorted. > res!
+  sorted. > res!
+    list
+      * 1 2 -3 -4
+  assert-that > @
+    res
+    $.equal-to
       list
-        * 1 2 -3 -4
-    assert-that
-      res
-      $.equal-to
-        list
-          * -4 -3 1 2
+        * -4 -3 1 2
 
 [] > complex-objects-list-compairing
   list > res!
@@ -572,6 +686,30 @@
         x.at 0
 
 [] > complex-objects-list-sorted
+  sorted. > res!
+    list
+      *
+        comparable-pair (* 7 3)
+        comparable-pair (* 1 1)
+        comparable-pair (* 4 0)
+  assert-that > @
+    res
+    $.equal-to
+      list
+        *
+          list (* 1 1)
+          list (* 4 0)
+          list (* 7 3)
+
+  [pair] > comparable-pair
+    pair > @
+
+    [x] > lt
+      lt. > @
+        ^.at 0
+        x.at 0
+
+[] > complex-objects-list-sorted-with-zero
   nop > @
     sorted. > res!
       list
@@ -729,3 +867,374 @@
                 v
             FALSE
     TRUE
+
+[] > list-inflated-zero-steps
+  inflated. > res!
+    list
+      *
+    [a i]
+      if. > @
+        i.gt -1
+        *
+        * i
+  assert-that > @
+    res.length
+    $.equal-to 0
+
+[] > list-inflated-1
+  inflated. > res!
+    list
+      *
+    [a i]
+      if. > @
+        i.gt 4
+        *
+        * i
+  assert-that > @
+    res.length
+    $.equal-to 5
+
+[] > list-inflated-2
+  inflated. > res!
+    list
+      *
+    [a i]
+      if. > @
+        eq.
+          a.length
+          1
+        *
+        * i
+  assert-that > @
+    res.length
+    $.equal-to 1
+
+[] > list-inflated-3
+  inflated. > res!
+    list
+      *
+    [a i]
+      if. > @
+        eq.
+          a.length
+          1
+        * i
+        *
+  assert-that > @
+    res.length
+    $.equal-to 0
+
+[] > list-inflated-4
+  inflated. > res!
+    list
+      * 1
+    [a i]
+      if. > @
+        eq.
+          a.length
+          2
+        *
+        * i
+  assert-that > @
+    res.length
+    $.equal-to 2
+
+[] > list-inflated-5
+  inflated. > res!
+    list
+      * 2
+    [a i]
+      if. > @
+        eq.
+          a.length
+          5
+        *
+        * i i
+  assert-that > @
+    res
+    $.equal-to
+      list
+        * 2 0 0 1 1
+
+[] > inflated-returns-list
+  inflated. > res!
+    list
+      * 2
+    [a i]
+      if. > @
+        eq.
+          a.length
+          5
+        *
+        * i i
+  assert-that > @
+    is-empty.
+      res
+    $.equal-to FALSE
+
+[] > simple-head
+  assert-that > @
+    head.
+      list
+        * 1 2 3 4 5
+      1
+    $.equal-to
+      list
+        * 1
+
+[] > list-head-with-zero-index
+  assert-that > @
+    head.
+      list
+        * 1 2 3
+      0
+    $.equal-to
+      list *
+
+[] > list-head-with-length-index
+  assert-that > @
+    head.
+      list
+        * 1 2 3
+      3
+    $.equal-to
+      list
+        * 1 2 3
+
+[] > complex-head
+  assert-that > @
+    head.
+      list
+        * "foo" 2.2 00-01 "bar"
+      2
+    $.equal-to
+      list
+        * "foo" 2.2
+[] > simple-tail
+  assert-that > @
+    tail.
+      list
+        * 1 2 3 4 5
+      2
+    $.equal-to
+      list
+        * 4 5
+
+[] > zero-index-in-tail
+  assert-that > @
+    tail.
+      list
+        * 1 2 3 4 5
+      0
+    $.equal-to
+      list *
+
+[] > large-index-in-tail
+  assert-that > @
+    tail.
+      list
+        * 1 2 3 4 5
+      10
+    $.equal-to
+      list
+        * 1 2 3 4 5
+
+[] > list-gt-1
+  nop > @
+    assert-that
+      qt.
+        list
+          * 3 2 1
+        list
+          * 2 1 0
+      $.equal-to TRUE
+
+[] > list-gt-2
+  nop > @
+    assert-that
+      gt.
+        list
+          * 3 2 1
+        list
+          * 2 10 100
+      $.equal-to TRUE
+
+[] > list-gt-3
+  nop > @
+    assert-that
+      gt.
+        list
+          * 1 2 3
+        list
+          * 1 2 3
+      $.equal-to FALSE
+
+[] > list-gt-4
+  nop > @
+    assert-that
+      gt.
+        list
+          * 3 4 2
+        list
+          * 3 4
+      $.equal-to TRUE
+
+[] > list-gt-5
+  nop > @
+    assert-that
+      gt.
+        list
+          * 0 99 99
+        list
+          * 1 0
+      $.equal-to FALSE
+
+[] > list-gte-1
+  nop > @
+    assert-that
+      gte.
+        list
+          * 1 2 3
+        list
+          * 1 2 3
+      $.equal-to TRUE
+
+[] > list-gte-2
+  nop > @
+    assert-that
+      gte.
+        list
+          * 3 4 2
+        list
+          * 3 4
+      $.equal-to TRUE
+
+[] > list-gte-3
+  nop > @
+    assert-that
+      gte.
+        list
+          * 0 99 99
+        list
+          * 1 0
+      $.equal-to FALSE
+
+[] > list-lt-1
+  nop > @
+    assert-that
+      lt.
+        list
+          * 3 2 1
+        list
+          * 2 1 0
+      $.equal-to FALSE
+
+[] > list-lt-2
+  nop > @
+    assert-that
+      lt.
+        list
+          * 3 2 1
+        list
+          * 2 10 100
+      $.equal-to FALSE
+
+[] > list-lt-3
+  nop > @
+    assert-that
+      lt.
+        list
+          * 1 2 3
+        list
+          * 1 2 3
+      $.equal-to FALSE
+
+[] > list-lt-4
+  nop > @
+    assert-that
+      lt.
+        list
+          * 3 4
+        list
+          * 3 4 2
+      $.equal-to TRUE
+
+[] > list-lt-5
+  nop > @
+    assert-that
+      lt.
+        list
+          * 0 99 99
+        list
+          * 1 0
+      $.equal-to TRUE
+
+[] > list-lte-1
+  nop > @
+    assert-that
+      lte.
+        list
+          * 1 2 3
+        list
+          * 1 2 3
+      $.equal-to TRUE
+
+[] > list-lte-2
+  nop > @
+    assert-that
+      lte.
+        list
+          * 3 4 2
+        list
+          * 3 4
+      $.equal-to FALSE
+
+[] > list-lte-3
+  nop > @
+    assert-that
+      lte.
+        list
+          * 0 99 99
+        list
+          * 1 0
+      $.equal-to TRUE
+
+[] > list-gt-empty
+  nop > @
+    assert-that
+      gt.
+        list
+          *
+        list
+          *
+      $.equal-to FALSE
+
+[] > list-gte-empty
+  nop > @
+    assert-that
+      gte.
+        list
+          *
+        list
+          *
+      $.equal-to TRUE
+
+[] > list-lt-empty
+  nop > @
+    assert-that
+      lt.
+        list
+          *
+        list
+          *
+      $.equal-to FALSE
+
+[] > list-lte-empty
+  nop > @
+    assert-that
+      lte.
+        list
+          *
+        list
+          *
+      $.equal-to TRUE

--- a/tests/org/eolang/collections/map-tests.eo
+++ b/tests/org/eolang/collections/map-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.6
++version 0.0.8
 
 [] > map-find-do-not-crashed
   map * > mp!
@@ -36,7 +36,11 @@
     $.equal-to 0
 
 [] > map-find-works
-  map (* * (* (* 4 "a")) (* (* 2 "c") (* 8 "c"))) > mp!
+  map > mp!
+    *
+      *
+      * (* 4 "a")
+      * (* 2 "c") (* 8 "c")
   mp.found 2 > r2!
   mp.found 3 > r3!
   mp.found 4 > r4!
@@ -90,3 +94,19 @@
       (mp.keys).at 0
       (mp.keys).at 1
     $.equal-to 55
+
+[] > map-contains-key
+  ((map *).with 11 "a").with 5 "b" > mp!
+  assert-that > @
+    contains-key.
+      mp
+      11
+    $.equal-to TRUE
+
+[] > map-do-not-contains-key
+  ((map *).with 11 "a").with 5 "b" > mp!
+  assert-that > @
+    contains-key.
+      mp
+      12
+    $.equal-to FALSE

--- a/tests/org/eolang/collections/multimap-tests.eo
+++ b/tests/org/eolang/collections/multimap-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
-+version 0.0.6
++version 0.0.8
 
 [] > rebuild-do-not-crush
   * 1 2 > harr
@@ -295,7 +295,7 @@
     * (* 1 "a") (* 4 "b") (* "c" 5) (* 8 7) > arr!
     multimap.rebuilded harr arr > res!
     assert-that
-      (* ((res.at 0).at 0).at 0) (((res.at 3).at 0).at 1)
+      * (((res.at 0).at 0).at 0) (((res.at 3).at 0).at 1)
       $.equal-to
         list
           * 4 5

--- a/tests/org/eolang/collections/range-tests.eo
+++ b/tests/org/eolang/collections/range-tests.eo
@@ -20,34 +20,91 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.bytes-as-array
 +alias org.eolang.collections.list
++alias org.eolang.collections.range
 +alias org.eolang.hamcrest.assert-that
-+home https://github.com/objectionary/eo
++home https://github.com/objectionary/eo-collections
 +junit
 +package org.eolang.collections
 +version 0.0.8
 
-[] > bytes-to-array
+[] > simple-range
+  range > rng!
+    []
+      [i] > build
+        i > @!
+        build (@.plus 1) > next
+      build 1 > @
+    10
   assert-that > @
-    bytes-as-array
-      20-1F-EE-B5-FF
+    list rng
     $.equal-to
       list
-        * 20- 1F- EE- B5- FF-
+        * 1 2 3 4 5 6 7 8 9
 
-[] > sinble-byte-to-array
+[] > range-with-floats
+  range > rng!
+    []
+      [i] > x
+        i > @!
+        x (@.plus 0.5) > next
+      x 1.0 > @
+    5.0
   assert-that > @
-    bytes-as-array
-      1F-
+    list rng
     $.equal-to
       list
-        * 1F-
+        * 1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5
 
-[] > zero-bytes-to-array
+[] > range-with-out-of-bounds
+  range > rng!
+    []
+      [num] > b
+        num > @!
+        b (@.plus 5) > next
+      b 1 > @
+    10
   assert-that > @
-    bytes-as-array
-      --
+    list rng
+    $.equal-to
+      list
+        * 1 6
+
+[] > range-with-complex-items
+  [pair] > comparable-pair
+    pair > @!
+    [x] > lt
+      lt. > @
+        ^.at 0
+        x.at 0
+    comparable-pair > next
+      *
+        (@.at 0).plus 1
+        (@.at 1).plus 1
+
+  range > rng!
+    comparable-pair
+      * 1 2
+    * 5
+
+  assert-that > @
+    list rng
     $.equal-to
       list
         *
+          list (* 1 2)
+          list (* 2 3)
+          list (* 3 4)
+          list (* 4 5)
+
+[] > range-with-wrong-items-is-an-empty-array
+  range > rng!
+    []
+      [num] > y
+        num > @
+        [] > next
+      y 10 > @
+    1
+  assert-that > @
+    (list rng).is-empty
+    $.equal-to TRUE

--- a/tests/org/eolang/collections/set-tests.eo
+++ b/tests/org/eolang/collections/set-tests.eo
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2022 Objectionary.com
+# Copyright (c) 2021-2022 Yegor Bugayenko
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,50 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo-strings
-+package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++alias org.eolang.collections.list
++alias org.eolang.collections.set
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-collections
++junit
++package org.eolang.collections
++version 0.0.8
 
-[format args...] > sprintf /string
+[] > set-works
+  assert-that > @
+    set
+      list
+        * 2 2
+    @.equal-to
+      list
+        * 2
+
+[] > set-with-existed-item
+  with. > set-with!
+    set
+      list > target!
+        * 1
+    1
+  assert-that > @
+    set-with
+    $.equal-to
+      target
+
+[] > set-with-not-existed-item
+  with. > set-with!
+    set
+      list
+        * 2
+    4
+  assert-that > @
+    set-with
+    $.equal-to
+      list
+        * 2 4
+
+[] > empty-set-works
+  assert-that > @
+    set
+      list > empty-list!
+        *
+    $.equal-to
+      empty-list

--- a/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > all-of-numbers-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/any-of-tests.eo
+++ b/tests/org/eolang/hamcrest/any-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > any-of-numbers-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/anything-tests.eo
+++ b/tests/org/eolang/hamcrest/anything-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > anything-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > has-item-int-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/blank-string-tests.eo
+++ b/tests/org/eolang/hamcrest/blank-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-blank-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/close-to-tests.eo
+++ b/tests/org/eolang/hamcrest/close-to-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > float-is-close-to-float-with-delta-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -27,26 +27,29 @@
 +version 0.3.2
 
 [] > simple-contains-string
-  assert-that > @
-    "Привет, 世界"
-    $.contains-string "世"
-    "constains-string"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.contains-string "世"
+      "constains-string"
 
 [] > check-all-contains-string
-  assert-that > @
-    "Привет, 世界"
-    $.all-of
-      $.contains-string "Привет"
-      $.contains-string "世"
-      $.contains-string "界"
-    "constains-all-of-string"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.all-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.contains-string "界"
+      "constains-all-of-string"
 
 [] > check-any-contains-string
-  assert-that > @
-    "ffffffffffff"
-    $.any-of
-      $.contains-string "Привет"
-      $.contains-string "世"
-      $.contains-string "f"
-    "constains-any-of-string"
+  nop > @
+    assert-that
+      "ffffffffffff"
+      $.any-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.contains-string "f"
+      "constains-any-of-string"
 

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -27,29 +27,26 @@
 +version 0.3.2
 
 [] > simple-contains-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.contains-string "世"
-      "constains-string"
+  assert-that > @
+    "Привет, 世界"
+    $.contains-string "世"
+    "constains-string"
 
 [] > check-all-contains-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.all-of
-        $.contains-string "Привет"
-        $.contains-string "世"
-        $.contains-string "界"
-      "constains-all-of-string"
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.contains-string "界"
+    "constains-all-of-string"
 
 [] > check-any-contains-string
-  nop > @
-    assert-that
-      "ffffffffffff"
-      $.any-of
-        $.contains-string "Привет"
-        $.contains-string "世"
-        $.contains-string "f"
-      "constains-any-of-string"
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.contains-string "f"
+    "constains-any-of-string"
 

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-contains-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/described-as-tests.eo
+++ b/tests/org/eolang/hamcrest/described-as-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > two-sum-described-as-equal-to-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/empty-string-tests.eo
+++ b/tests/org/eolang/hamcrest/empty-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-empty-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/equal-to-tests.eo
+++ b/tests/org/eolang/hamcrest/equal-to-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > all-of-number-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > any-of-number-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > anything-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -33,7 +33,6 @@
       $.array-each
         $.equal-to 1
         $.equal-to 3
-  nop > @
-    assert-that
-      suggestion
-      $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"
+  assert-that > @
+    suggestion
+    $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -33,6 +33,7 @@
       $.array-each
         $.equal-to 1
         $.equal-to 3
-  assert-that > @
-    suggestion
-    $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"
+  nop > @
+    assert-that
+      suggestion
+      $.contains-string "\nExpected: <1> equal to value and <3> equal to value\n     but: mismatches:"

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > arrays-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-blank-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > float-is-close-to-float-with-delta-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -32,10 +32,9 @@
       "Привет, 世界"
       $.contains-string "111"
       "constains-string"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "constains-string\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "constains-string\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
 
 [] > contains-any-of-string-failed
   [] > suggestion
@@ -56,10 +55,9 @@
         $.contains-string "2"
         $.contains-string "happy"
       "constains-string"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "constains-string\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+  assert-that > @
+    suggestion
+    $.equal-to "constains-string\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-contains-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -32,9 +32,10 @@
       "Привет, 世界"
       $.contains-string "111"
       "constains-string"
-  assert-that > @
-    suggestion
-    $.equal-to "constains-string\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "constains-string\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
 
 [] > contains-any-of-string-failed
   [] > suggestion
@@ -55,9 +56,10 @@
         $.contains-string "2"
         $.contains-string "happy"
       "constains-string"
-  assert-that > @
-    suggestion
-    $.equal-to "constains-string\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "constains-string\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > two-sum-described-as-equal-to-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-empty-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > delayed-calculation
   memory 0 > m

--- a/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > greater-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > is-failed-output-with-two-bools
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-contains-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -32,10 +32,9 @@
       "Привет, 世界"
       $.is-substring "111"
       "is-substring"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "is-substring\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
 
 [] > contains-any-of-string-failed
   [] > suggestion
@@ -44,10 +43,9 @@
       $.any-of
         $.is-substring "2"
       "is-substring"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
 
 [] > contains-all-of-string-failed
   [] > suggestion
@@ -57,10 +55,9 @@
         $.is-substring "2"
         $.is-substring "happy"
       "is-substring"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+  assert-that > @
+    suggestion
+    $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -32,9 +32,10 @@
       "Привет, 世界"
       $.is-substring "111"
       "is-substring"
-  assert-that > @
-    suggestion
-    $.equal-to "is-substring\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "is-substring\nExpected: string contains: <111>\n     but: was <Привет, 世界>"
 
 [] > contains-any-of-string-failed
   [] > suggestion
@@ -43,9 +44,10 @@
       $.any-of
         $.is-substring "2"
       "is-substring"
-  assert-that > @
-    suggestion
-    $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "is-substring\nExpected: string contains: <2>\n     but: a value was <Hello>"
 
 [] > contains-all-of-string-failed
   [] > suggestion
@@ -55,9 +57,10 @@
         $.is-substring "2"
         $.is-substring "happy"
       "is-substring"
-  assert-that > @
-    suggestion
-    $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "is-substring\nExpected: string contains: <2> and string contains: <happy>\n     but: a value was <so sad>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > less-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > matches-regex-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > not-failed-output-two-strings
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -32,10 +32,9 @@
       "Привет, 世界"
       $.string-ends-with "Привет"
       "string-ends-with Привет"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "string-ends-with Привет\nExpected: string ends with: <Привет>\n     but: was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "string-ends-with Привет\nExpected: string ends with: <Привет>\n     but: was <Привет, 世界>"
 
 [] > ends-with-any-of-string-failed
   [] > suggestion
@@ -46,10 +45,9 @@
         $.contains-string "世"
         $.string-ends-with "ет"
       "ends-with"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
 
 [] > ends-with-all-of-string-failed
   [] > suggestion
@@ -60,10 +58,9 @@
         $.string-ends-with "dddd"
         $.contains-string "界"
       "ends-with"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+  assert-that > @
+    suggestion
+    $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -32,9 +32,10 @@
       "Привет, 世界"
       $.string-ends-with "Привет"
       "string-ends-with Привет"
-  assert-that > @
-    suggestion
-    $.equal-to "string-ends-with Привет\nExpected: string ends with: <Привет>\n     but: was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "string-ends-with Привет\nExpected: string ends with: <Привет>\n     but: was <Привет, 世界>"
 
 [] > ends-with-any-of-string-failed
   [] > suggestion
@@ -45,9 +46,10 @@
         $.contains-string "世"
         $.string-ends-with "ет"
       "ends-with"
-  assert-that > @
-    suggestion
-    $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "ends-with\nExpected: string contains: <Привет> and string contains: <世> and string ends with: <ет>\n     but: a value was <Привет, 世界>"
 
 [] > ends-with-all-of-string-failed
   [] > suggestion
@@ -58,9 +60,10 @@
         $.string-ends-with "dddd"
         $.contains-string "界"
       "ends-with"
-  assert-that > @
-    suggestion
-    $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "ends-with\nExpected: string contains: <Привет> or string ends with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-ends-with-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -32,9 +32,10 @@
       "Привет, 世界"
       $.string-starts-with "界"
       "string-starts-with 界"
-  assert-that > @
-    suggestion
-    $.equal-to "string-starts-with 界\nExpected: string starts with: <界>\n     but: was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "string-starts-with 界\nExpected: string starts with: <界>\n     but: was <Привет, 世界>"
 
 [] > starts-with-any-of-string-failed
   [] > suggestion
@@ -45,9 +46,10 @@
         $.contains-string "世"
         $.string-starts-with "ет"
       "starts-with"
-  assert-that > @
-    suggestion
-    $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
 
 [] > starts-with-all-of-string-failed
   [] > suggestion
@@ -58,9 +60,10 @@
         $.string-starts-with "dddd"
         $.contains-string "界"
       "starts-with"
-  assert-that > @
-    suggestion
-    $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+  nop > @
+    assert-that
+      suggestion
+      $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -32,10 +32,9 @@
       "Привет, 世界"
       $.string-starts-with "界"
       "string-starts-with 界"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "string-starts-with 界\nExpected: string starts with: <界>\n     but: was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "string-starts-with 界\nExpected: string starts with: <界>\n     but: was <Привет, 世界>"
 
 [] > starts-with-any-of-string-failed
   [] > suggestion
@@ -46,10 +45,9 @@
         $.contains-string "世"
         $.string-starts-with "ет"
       "starts-with"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
+  assert-that > @
+    suggestion
+    $.equal-to "starts-with\nExpected: string contains: <Привет> and string contains: <世> and string starts with: <ет>\n     but: a value was <Привет, 世界>"
 
 [] > starts-with-all-of-string-failed
   [] > suggestion
@@ -60,10 +58,9 @@
         $.string-starts-with "dddd"
         $.contains-string "界"
       "starts-with"
-  nop > @
-    assert-that
-      suggestion
-      $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
+  assert-that > @
+    suggestion
+    $.equal-to "starts-with\nExpected: string contains: <Привет> or string starts with: <dddd> or string contains: <界>\n     but: a value was <ffffffffffff>"
 
 
 

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest.failed-output
-+version 0.3.1
++version 0.3.2
 
 [] > simple-starts-with-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/greater-than-tests.eo
+++ b/tests/org/eolang/hamcrest/greater-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > two-sum-greater-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-is-substring
   assert-that > @

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -27,26 +27,29 @@
 +version 0.3.2
 
 [] > simple-is-substring
-  assert-that > @
-    "Привет, 世界"
-    $.is-substring "世"
-    "is-substring"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.is-substring "世"
+      "is-substring"
 
 [] > check-all-is-substring
-  assert-that > @
-    "Привет, 世界"
-    $.all-of
-      $.is-substring "Привет"
-      $.is-substring "世"
-      $.is-substring "界"
-    "is-substring-of-string"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.all-of
+        $.is-substring "Привет"
+        $.is-substring "世"
+        $.is-substring "界"
+      "is-substring-of-string"
 
 [] > check-any-is-substring
-  assert-that > @
-    "ffffffffffff"
-    $.any-of
-      $.is-substring "Привет"
-      $.is-substring "世"
-      $.is-substring "f"
-    "is-substring-of-string"
+  nop > @
+    assert-that
+      "ffffffffffff"
+      $.any-of
+        $.is-substring "Привет"
+        $.is-substring "世"
+        $.is-substring "f"
+      "is-substring-of-string"
 

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -27,29 +27,26 @@
 +version 0.3.2
 
 [] > simple-is-substring
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.is-substring "世"
-      "is-substring"
+  assert-that > @
+    "Привет, 世界"
+    $.is-substring "世"
+    "is-substring"
 
 [] > check-all-is-substring
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.all-of
-        $.is-substring "Привет"
-        $.is-substring "世"
-        $.is-substring "界"
-      "is-substring-of-string"
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.is-substring "Привет"
+      $.is-substring "世"
+      $.is-substring "界"
+    "is-substring-of-string"
 
 [] > check-any-is-substring
-  nop > @
-    assert-that
-      "ffffffffffff"
-      $.any-of
-        $.is-substring "Привет"
-        $.is-substring "世"
-        $.is-substring "f"
-      "is-substring-of-string"
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.is-substring "Привет"
+      $.is-substring "世"
+      $.is-substring "f"
+    "is-substring-of-string"
 

--- a/tests/org/eolang/hamcrest/is-tests.eo
+++ b/tests/org/eolang/hamcrest/is-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > is-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/less-than-tests.eo
+++ b/tests/org/eolang/hamcrest/less-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > two-sum-less-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/tests/org/eolang/hamcrest/matches-regex-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > matches-regex-alphabetical-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/not-tests.eo
+++ b/tests/org/eolang/hamcrest/not-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > not-equal-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -27,26 +27,29 @@
 +version 0.3.2
 
 [] > simple-ends-with-string
-  assert-that > @
-    "Привет, 世界"
-    $.string-ends-with "界"
-    "string-ends-with 界"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.string-ends-with "界"
+      "string-ends-with 界"
 
 [] > check-all-contains-and-ends-with-string
-  assert-that > @
-    "Привет, 世界"
-    $.all-of
-      $.contains-string "Привет"
-      $.contains-string "世"
-      $.string-ends-with "界"
-    "ends-with"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.all-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.string-ends-with "界"
+      "ends-with"
 
 [] > check-any-contains-and-ends-with-string
-  assert-that > @
-    "ffffffffffff"
-    $.any-of
-      $.contains-string "Привет"
-      $.string-ends-with "fffff"
-      $.contains-string "界"
-    "ends-with"
+  nop > @
+    assert-that
+      "ffffffffffff"
+      $.any-of
+        $.contains-string "Привет"
+        $.string-ends-with "fffff"
+        $.contains-string "界"
+      "ends-with"
 

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -27,29 +27,26 @@
 +version 0.3.2
 
 [] > simple-ends-with-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.string-ends-with "界"
-      "string-ends-with 界"
+  assert-that > @
+    "Привет, 世界"
+    $.string-ends-with "界"
+    "string-ends-with 界"
 
 [] > check-all-contains-and-ends-with-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.all-of
-        $.contains-string "Привет"
-        $.contains-string "世"
-        $.string-ends-with "界"
-      "ends-with"
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.string-ends-with "界"
+    "ends-with"
 
 [] > check-any-contains-and-ends-with-string
-  nop > @
-    assert-that
-      "ffffffffffff"
-      $.any-of
-        $.contains-string "Привет"
-        $.string-ends-with "fffff"
-        $.contains-string "界"
-      "ends-with"
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.string-ends-with "fffff"
+      $.contains-string "界"
+    "ends-with"
 

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-ends-with-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +junit
 +package org.eolang.hamcrest
-+version 0.3.1
++version 0.3.2
 
 [] > simple-starts-with-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -27,26 +27,29 @@
 +version 0.3.2
 
 [] > simple-starts-with-string
-  assert-that > @
-    "Привет, 世界"
-    $.string-starts-with "Привет"
-    "string-starts-with Привет"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.string-starts-with "Привет"
+      "string-starts-with Привет"
 
 [] > check-all-contains-and-starts-with-string
-  assert-that > @
-    "Привет, 世界"
-    $.all-of
-      $.contains-string "Привет"
-      $.contains-string "世"
-      $.string-starts-with "Пр"
-    "starts-with"
+  nop > @
+    assert-that
+      "Привет, 世界"
+      $.all-of
+        $.contains-string "Привет"
+        $.contains-string "世"
+        $.string-starts-with "Пр"
+      "starts-with"
 
 [] > check-any-contains-and-starts-with-string
-  assert-that > @
-    "ffffffffffff"
-    $.any-of
-      $.contains-string "Привет"
-      $.string-starts-with "fffff"
-      $.contains-string "界"
-    "starts-with"
+  nop > @
+    assert-that
+      "ffffffffffff"
+      $.any-of
+        $.contains-string "Привет"
+        $.string-starts-with "fffff"
+        $.contains-string "界"
+      "starts-with"
 

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -27,29 +27,26 @@
 +version 0.3.2
 
 [] > simple-starts-with-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.string-starts-with "Привет"
-      "string-starts-with Привет"
+  assert-that > @
+    "Привет, 世界"
+    $.string-starts-with "Привет"
+    "string-starts-with Привет"
 
 [] > check-all-contains-and-starts-with-string
-  nop > @
-    assert-that
-      "Привет, 世界"
-      $.all-of
-        $.contains-string "Привет"
-        $.contains-string "世"
-        $.string-starts-with "Пр"
-      "starts-with"
+  assert-that > @
+    "Привет, 世界"
+    $.all-of
+      $.contains-string "Привет"
+      $.contains-string "世"
+      $.string-starts-with "Пр"
+    "starts-with"
 
 [] > check-any-contains-and-starts-with-string
-  nop > @
-    assert-that
-      "ffffffffffff"
-      $.any-of
-        $.contains-string "Привет"
-        $.string-starts-with "fffff"
-        $.contains-string "界"
-      "starts-with"
+  assert-that > @
+    "ffffffffffff"
+    $.any-of
+      $.contains-string "Привет"
+      $.string-starts-with "fffff"
+      $.contains-string "界"
+    "starts-with"
 

--- a/tests/org/eolang/sys/call-test.eo
+++ b/tests/org/eolang/sys/call-test.eo
@@ -30,13 +30,12 @@
 # Making a syscall 'getpid' and compares the result
 # with zero: the PID should definitely be larger.
 [] > reads-pid-from-unix
-  nop > @
-    if.
-      QQ.sys.uname.is-windows
-      nop
-      assert-that
-        QQ.sys.call "getpid"
-        $.greater-than 0
+  if. > @
+    QQ.sys.uname.is-windows
+    nop
+    assert-that
+      QQ.sys.call "getpid"
+      $.greater-than 0
 
 # Making a syscall 'write' and prints a short message
 # to the console.
@@ -56,11 +55,10 @@
           msg.length
 
 [] > get-time-of-day-test
-  nop > @
-    if.
-      QQ.sys.uname.is-windows
-      nop
-      assert-that
-        QQ.sys.call
-          "gettimeofday"
-        $.greater-than 0
+  if. > @
+    QQ.sys.uname.is-windows
+    nop
+    assert-that
+      QQ.sys.call
+        "gettimeofday"
+      $.greater-than 0

--- a/tests/org/eolang/sys/call-test.eo
+++ b/tests/org/eolang/sys/call-test.eo
@@ -30,34 +30,37 @@
 # Making a syscall 'getpid' and compares the result
 # with zero: the PID should definitely be larger.
 [] > reads-pid-from-unix
-  if. > @
-    QQ.sys.uname.is-windows
-    nop
-    assert-that
-      QQ.sys.call "getpid"
-      $.greater-than 0
+  nop > @
+    if.
+      QQ.sys.uname.is-windows
+      nop
+      assert-that
+        QQ.sys.call "getpid"
+        $.greater-than 0
 
 # Making a syscall 'write' and prints a short message
 # to the console.
 [] > prints-to-console
   "Hello, друг!" > msg
-  if. > @
-    QQ.sys.uname.is-windows
-    nop
-    assert-that
-      QQ.sys.call
-        "write"
-        1
-        msg
-        msg.length
-      $.equal-to
-        msg.length
+  nop > @
+    if.
+      QQ.sys.uname.is-windows
+      nop
+      assert-that
+        QQ.sys.call
+          "write"
+          1
+          msg
+          msg.length
+        $.equal-to
+          msg.length
 
 [] > get-time-of-day-test
-  if. > @
-    QQ.sys.uname.is-windows
-    nop
-    assert-that
-      QQ.sys.call
-        "gettimeofday"
-      $.greater-than 0
+  nop > @
+    if.
+      QQ.sys.uname.is-windows
+      nop
+      assert-that
+        QQ.sys.call
+          "gettimeofday"
+        $.greater-than 0

--- a/tests/org/eolang/sys/uname-test.eo
+++ b/tests/org/eolang/sys/uname-test.eo
@@ -29,10 +29,11 @@
 
 # Checks what is the family of the OS
 [] > checks-os-family
-  assert-that > @
-    or.
-      QQ.sys.uname.is-windows
-      QQ.sys.uname.is-macos
-      QQ.sys.uname.is-unix
-    $.equal-to
-      TRUE
+  nop > @
+    assert-that
+      or.
+        QQ.sys.uname.is-windows
+        QQ.sys.uname.is-macos
+        QQ.sys.uname.is-unix
+      $.equal-to
+        TRUE

--- a/tests/org/eolang/sys/uname-test.eo
+++ b/tests/org/eolang/sys/uname-test.eo
@@ -29,11 +29,10 @@
 
 # Checks what is the family of the OS
 [] > checks-os-family
-  nop > @
-    assert-that
-      or.
-        QQ.sys.uname.is-windows
-        QQ.sys.uname.is-macos
-        QQ.sys.uname.is-unix
-      $.equal-to
-        TRUE
+  assert-that > @
+    or.
+      QQ.sys.uname.is-windows
+      QQ.sys.uname.is-macos
+      QQ.sys.uname.is-unix
+    $.equal-to
+      TRUE

--- a/tests/org/eolang/sys/win32-test.eo
+++ b/tests/org/eolang/sys/win32-test.eo
@@ -30,9 +30,10 @@
 # Making a Win32 'GetCurrentProcessId' function call and compares the result
 # with zero: the PID should definitely be larger.
 [] > reads-pid-from-win32
-  if. > @
-    QQ.sys.uname.is-windows.not
-    nop
-    assert-that
-      QQ.sys.win32 "GetCurrentProcessId"
-      $.greater-than 0
+  nop > @
+    if.
+      QQ.sys.uname.is-windows.not
+      nop
+      assert-that
+        QQ.sys.win32 "GetCurrentProcessId"
+        $.greater-than 0

--- a/tests/org/eolang/sys/win32-test.eo
+++ b/tests/org/eolang/sys/win32-test.eo
@@ -30,10 +30,9 @@
 # Making a Win32 'GetCurrentProcessId' function call and compares the result
 # with zero: the PID should definitely be larger.
 [] > reads-pid-from-win32
-  nop > @
-    if.
-      QQ.sys.uname.is-windows.not
-      nop
-      assert-that
-        QQ.sys.win32 "GetCurrentProcessId"
-        $.greater-than 0
+  if. > @
+    QQ.sys.uname.is-windows.not
+    nop
+    assert-that
+      QQ.sys.win32 "GetCurrentProcessId"
+      $.greater-than 0

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
 +junit
-+version 0.0.4
++version 0.2.0
 
 [] > matches-string-against-pattern
   assert-that > @
@@ -49,6 +49,15 @@
       "Hello, World!"
     $.is
       $.equal-to FALSE
+
+[] > matches-dollar
+  assert-that > @
+    matches.
+      compile.
+        regex "/($[0-9]*)/"
+      "$12"
+    $.is
+      $.equal-to TRUE
 
 [] > match-returns-correct-position
   assert-that > @
@@ -178,13 +187,14 @@
       $.equal-to "Wrong regex syntax: \"/\" is missing"
 
 [] > test-simple-replace
-  assert-that > @
-    replaced.
-      compile.
-        QQ.txt.regex "/([b])/"
-      "abc"
-      "11"
-    $.equal-to "a11c"
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          QQ.txt.regex "/([b])/"
+        "abc"
+        "11"
+      $.equal-to "a11c"
 
 [] > test-no-match-replace
   assert-that > @
@@ -205,10 +215,11 @@
     $.equal-to ""
 
 [] > test-replace-with-empty
-  assert-that > @
-    replaced.
-      compile.
-        QQ.txt.regex "/([xyz]+)/"
-      "abxxxxxcd"
-      ""
-    $.equal-to "abcd"
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          QQ.txt.regex "/([xyz]+)/"
+        "abxxxxxcd"
+        ""
+      $.equal-to "abcd"

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-strings
 +junit
 +package org.eolang.txt
-+version 0.0.4
++version 0.2.0
 
 [] > prints-simple-string
   assert-that > @

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -28,7 +28,7 @@
 +home https://github.com/objectionary/eo-strings
 +junit
 +package org.eolang.txt
-+version 0.0.4
++version 0.2.0
 
 [] > sscanf-with-string
   assert-that > @

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -27,36 +27,88 @@
 +home https://github.com/objectionary/eo-strings
 +junit
 +package org.eolang.txt
-+version 0.0.4
++version 0.2.0
 
-[] > trims-string
+[] > text-trimmed-1
   assert-that > @
-    text "Hello, dude  "
-    .trim
-    $.equal-to "Hello, dude"
+    trimmed.
+      text
+        "a b"
+    $.equal-to "a b"
 
-[] > joins-array
+[] > text-trimmed-2
+  assert-that > @
+    trimmed.
+      text
+        "a b "
+    $.equal-to "a b"
+
+[] > text-trimmed-3
+  nop > @
+    assert-that
+      trimmed.
+        text
+          " a b "
+      $.equal-to "a b"
+
+[] > text-trimmed-4
+  assert-that > @
+    trimmed.
+      text
+        " a b"
+    $.equal-to "a b"
+
+[] > text-trimmed-5
+  assert-that > @
+    trimmed.
+      text
+        " ab"
+    $.equal-to "ab"
+
+[] > text-trimmed-empty-1
+  assert-that > @
+    trimmed.
+      text
+        ""
+    $.equal-to ""
+
+[] > text-trimmed-empty-2
+  assert-that > @
+    trimmed.
+      text
+        " "
+    $.equal-to ""
+
+[] > text-trimmed-empty-3
+  nop > @
+    assert-that
+      trimmed.
+        text
+          "  "
+      $.equal-to ""
+
+[] > joins-tuple
   assert-that > @
     joined.
       text ".."
       * "foo" "друг" "bar"
     $.equal-to "foo..друг..bar"
 
-[] > joins-array-2
+[] > joins-tuple-2
   assert-that > @
     joined.
       text ", "
       * "Привет" "мир!"
     $.equal-to "Привет, мир!"
 
-[] > joins-array-3
+[] > joins-tuple-3
   assert-that > @
     joined.
       text ""
       *
     $.equal-to ""
 
-[] > joins-array-4
+[] > joins-tuple-4
   assert-that > @
     joined.
       text ""
@@ -73,39 +125,69 @@
       * "start" "end"
     $.equal-to "start & end"
 
-[] > text-lower-case
+[] > text-lower-case-1
   assert-that > @
-    (text "HeLlO wOrLd!").lower-case
-    $.equal-to "hello world!"
+    (text "HeLlO !").low-cased
+    $.equal-to "hello !"
 
 [] > text-lower-case-2
   assert-that > @
-    (text "hello 1234").lower-case
-    $.equal-to "hello 1234"
+    (text "HEL 3").low-cased
+    $.equal-to "hel 3"
 
-[] > text-upper-case
+[] > text-lower-case-3
   assert-that > @
-    (text "HeLlO wOrLd!").upper-case
-    $.equal-to "HELLO WORLD!"
+    (text "HeL世o").low-cased
+    $.equal-to "hel世o"
+
+[] > no-changes-lower-case
+  assert-that > @
+    (text "chng").low-cased
+    $.equal-to "chng"
+
+[] > text-upper-case-1
+  assert-that > @
+    (text "HeLlO !").up-cased
+    $.equal-to "HELLO !"
 
 [] > text-upper-case-2
   assert-that > @
-    (text "hello 123").upper-case
-    $.equal-to "HELLO 123"
+    (text "hel 3").up-cased
+    $.equal-to "HEL 3"
+
+[] > text-upper-case-3
+  assert-that > @
+    (text "HelL世o").up-cased
+    $.equal-to "HELL世O"
+
+[] > no-changes-upper-case
+  assert-that > @
+    (text "CHANGE").up-cased
+    $.equal-to "CHANGE"
 
 [] > text-contains
   assert-that > @
-    (text "some text here").contains "me te"
+    (text "ab").contains "ab"
     $.equal-to TRUE
 
 [] > text-contains-2
   assert-that > @
-    (text "some text here").contains "me text."
+    (text "b").contains "b "
     $.equal-to FALSE
 
 [] > text-contains-3
   assert-that > @
-    (text "1234456").contains "1"
+    (text "ab").contains "a"
+    $.equal-to TRUE
+
+[] > text-not-contains
+  assert-that > @
+    (text "1").contains "12"
+    $.equal-to FALSE
+
+[] > text-contains-unicode
+  assert-that > @
+    (text "й").contains "й"
     $.equal-to TRUE
 
 [] > text-starts-with
@@ -122,6 +204,16 @@
   assert-that > @
     (text "some text here").starts-with "some  "
     $.equal-to FALSE
+
+[] > text-starts-with-4
+  assert-that > @
+    (text "qwe世rty text here").starts-with "qwe世rty te"
+    $.equal-to TRUE
+
+[] > text-starts-with-5
+  assert-that > @
+    (text "qwe世rty text here").starts-with ""
+    $.equal-to TRUE
 
 [] > text-ends-with
   assert-that > @
@@ -140,37 +232,79 @@
 
 [] > text-index-of
   assert-that > @
-    (text "some text here").index-of "me te"
-    $.equal-to 2
+    (text "ab").index-of "ab"
+    $.equal-to 0
 
 [] > text-index-of-2
-  assert-that > @
-    (text "some text here").index-of " here"
-    $.equal-to 9
+  nop > @
+    assert-that
+      (text "ab").index-of "abc"
+      $.equal-to -1
 
 [] > text-index-of-3
+  nop > @
+    assert-that
+      (text "ab").index-of "b"
+      $.equal-to 1
+
+[] > text-index-of-4
   assert-that > @
-    (text "some text here").index-of "  here"
+    (text "a").index-of "a"
+    $.equal-to 0
+
+[] > text-index-of-5
+  assert-that > @
+    (text "a").index-of "b"
     $.equal-to -1
+
+[] > text-check-if-starts-from-index
+  assert-that > @
+    check-if-starts-from-index.
+      index-of.
+        text
+      "abc"
+      "bc"
+      1
+    $.equal-to TRUE
+
+[] > text-check-if-starts-from-index-2
+  assert-that > @
+    check-if-starts-from-index.
+      index-of.
+        text
+      "a"
+      "a"
+      0
+    $.equal-to TRUE
+
+[] > text-check-if-starts-from-index-3
+  assert-that > @
+    check-if-starts-from-index.
+      index-of.
+        text
+      "abc"
+      "bcd"
+      1
+    $.equal-to FALSE
 
 [] > text-last-index-of
   assert-that > @
-    (text "some text here").last-index-of " here"
-    $.equal-to 9
+    (text "4 2").last-index-of "2"
+    $.equal-to 2
 
 [] > text-last-index-of-2
   assert-that > @
-    (text "some text here").last-index-of "  here"
+    (text "here").last-index-of " here"
     $.equal-to -1
 
 [] > text-last-index-of-3
   assert-that > @
-    (text "abc abcd").last-index-of "abc"
-    $.equal-to 4
+    (text "ab abc").last-index-of "ab"
+    $.equal-to 3
 
 [] > text-last-index-of-4
   assert-that > @
-    (text "Hello, world").last-index-of "Hello, world"
+    (text "Hello").last-index-of "Hello"
     $.equal-to 0
 
 [] > empty-text-last-index-of
@@ -180,8 +314,8 @@
 
 [] > unicode-text-last-index-of
   assert-that > @
-    (text "Привет, 世界").last-index-of "世"
-    $.equal-to 8
+    (text "a世").last-index-of "世"
+    $.equal-to 1
 
 [] > at-returns-one-character
   assert-that > @
@@ -236,6 +370,32 @@
       "Привет"
     $.equal-to "Привет, мир!"
 
+[] > text-replaced-3
+  assert-that > @
+    replaced.
+      text
+        "$A"
+      "\\$"
+      "G"
+    $.equal-to "GA"
+
+[] > text-replaced-4
+  assert-that > @
+    replaced.
+      text
+        "$AB"
+      "\\$A"
+      "G"
+    $.equal-to "GB"
+
+[] > text-replaced-5
+  assert-that > @
+    replaced.
+      text "q$0werty"
+      "\\$0"
+      "GROUP0"
+    $.equal-to "qGROUP0werty"
+
 [] > get-int
   assert-that > @
     as-int.
@@ -275,8 +435,8 @@
   assert-that > @
     compare.
       text
-        "aBcD"
-      "aBcD"
+        "aB"
+      "aB"
     $.equal-to 0
 
 [] > compare-strings
@@ -285,8 +445,8 @@
       0
       compare.
         text
-          "abcd"
-        "aBcD"
+          "ab"
+        "aB"
     $.equal-to TRUE
 
 [] > compare-strings-2
@@ -299,11 +459,41 @@
         "a"
     $.equal-to TRUE
 
+[] > compare-strings-with-different-length
+  assert-that > @
+    gt.
+      0
+      compare.
+        text
+          "a"
+        "aa"
+    $.equal-to TRUE
+
+[] > compare-strings-with-different-length-2
+  assert-that > @
+    gt.
+      0
+      compare.
+        text
+          "bb"
+        "b"
+    $.equal-to FALSE
+
+[] > compare-strings-with-unicode
+  assert-that > @
+    gt.
+      0
+      compare.
+        text
+          "y"
+        "漢"
+    $.equal-to TRUE
+
 [] > check-is-alpha
   assert-that > @
     is-alphabetic.
       text
-        "qWeRtY"
+        "eEo"
     $.equal-to TRUE
 
 [] > check-is-alpha-2
@@ -317,7 +507,7 @@
   assert-that > @
     is-alphabetic.
       text
-        "1234"
+        "123"
     $.equal-to FALSE
 
 [] > split-text
@@ -350,7 +540,7 @@
       list
         * "a" "b" "c."
 
-[] > strings-concatenation
+[] > strings-chained
   assert-that > @
     chained.
       text
@@ -358,7 +548,7 @@
       "45 "
     $.equal-to "12345 "
 
-[] > strings-concatenation-2
+[] > strings-chained-2
   assert-that > @
     chained.
       text
@@ -366,7 +556,7 @@
       "45 "
     $.equal-to "45 "
 
-[] > strings-concatenation-3
+[] > strings-chained-3
   assert-that > @
     chained.
       text
@@ -374,10 +564,90 @@
       ""
     $.equal-to ""
 
-[] > strings-concatenation-4
+[] > strings-chained-4
   assert-that > @
     chained.
       text
         "漢a"
       "漢字漢"
     $.equal-to "漢a漢字漢"
+
+[] > one-strings-chained
+  assert-that > @
+    chained.
+      text
+        "a"
+    $.equal-to "a"
+
+[] > multiple-strings-chained
+  assert-that > @
+    chained.
+      text
+        "a"
+      "b"
+      "c"
+    $.equal-to "abc"
+
+[] > replace-returns-text
+  assert-that > @
+    at.
+      replaced.
+        text
+          "abacaba"
+        "aba"
+        "漢"
+      0
+    $.equal-to "漢"
+
+[] > chained-returns-text
+  assert-that > @
+    at.
+      chained.
+        text
+          "ab"
+        "漢"
+      2
+    $.equal-to "漢"
+
+[] > slice-returns-text
+  assert-that > @
+    at.
+      slice.
+        text
+          "漢b"
+        0
+        2
+      0
+    $.equal-to "漢"
+
+[] > at-returns-text
+  assert-that > @
+    at.
+      at.
+        text
+          "漢b"
+        0
+      0
+    $.equal-to "漢"
+
+[] > upper-case-returns-text
+  assert-that > @
+    at.
+      (text "HeLlO!").up-cased
+      1
+    $.equal-to "E"
+
+[] > lower-case-returns-text
+  assert-that > @
+    at.
+      (text "hELlO!").low-cased
+      1
+    $.equal-to "e"
+
+[] > trims-returns-text
+  assert-that > @
+    at.
+      trimmed.
+        text "漢 "
+      0
+    $.equal-to "漢"


### PR DESCRIPTION
I tried to merge these changes separately but they are failed. So, I decided to merge them together and fix implementation of `text.contains` which was the main reason of the failed build and had a very slow computing.

What's done:

- updated code according to new versions of EO-hamcrest 0.3.2 and EO-collections 0.0.8 and EO-strings 0.2.0
- updated implementation of `text.contains`. Now it doesn't break tests. Similar implementation was introduced here: https://github.com/objectionary/eo-strings/issues/143
- disabled 4 tests in `eo-sys`. We need to release this package in near future