### PR TITLE
EO-Files version was up to 0.4.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,14 +28,14 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.29.4</eo.version>
+    <eo.version>0.29.3</eo.version>
     <stack-size>32M</stack-size>
   </properties>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>8</source>
           <target>8</target>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.29.1</eo.version>
+    <eo.version>0.29.4</eo.version>
     <stack-size>32M</stack-size>
   </properties>
   <build>

--- a/objects/org/eolang/fs/base-name.eo
+++ b/objects/org/eolang/fs/base-name.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Takes the base name from the full path name,
 # for example "/tmp/bar/foo.txt" will lead to "foo.txt"

--- a/objects/org/eolang/fs/dir-name.eo
+++ b/objects/org/eolang/fs/dir-name.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Takes the directory name from the full path name,
 # for example "/tmp/bar/foo.txt" will lead to "/tmp/bar"

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 [file] > dir
   file > @
@@ -37,7 +37,7 @@
 
   # Go though all files in the directory, recursively
   # finding them with the "glob" provided.
-  [glob] > walk /array
+  [glob] > walk /tuple
 
   # Delete directory and all files in it, recursively.
   # Always returns TRUE.

--- a/objects/org/eolang/fs/ext-name.eo
+++ b/objects/org/eolang/fs/ext-name.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Takes the extension part from the full path name,
 # for example "/tmp/bar/foo.txt.gz" will lead to "txt.gz"

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # A file on the filesystem.
 [path] > file

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.fs
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Temporary directory provided by the operating system. It will
 # be automatically deleted when the program exits.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -22,14 +22,13 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.io
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Makes an input from bytes. In most cases you don't
 # need to specify the last two arguments, only the first
 # one: the bytes to read.
 [b next buf] > bytes-as-input
-
   buf > @
 
   # Read the next chunk of bytes and

--- a/objects/org/eolang/io/copied.eo
+++ b/objects/org/eolang/io/copied.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.io
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # A copy of input into output, which is a total
 # number of bytes copied.

--- a/objects/org/eolang/io/memory-as-output.eo
+++ b/objects/org/eolang/io/memory-as-output.eo
@@ -22,12 +22,11 @@
 
 +home https://github.com/objectionary/eo-files
 +package org.eolang.io
-+rt jvm org.eolang:eo-files:0.3.5
-+version 0.3.5
++rt jvm org.eolang:eo-files:0.4.0
++version 0.4.0
 
 # Turns memory into an output.
 [m] > memory-as-output
-
   m > @
 
   # Write the next chunk of bytes and

--- a/tests/org/eolang/as-phi-tests.eo
+++ b/tests/org/eolang/as-phi-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > prints-itself

--- a/tests/org/eolang/bool-tests.eo
+++ b/tests/org/eolang/bool-tests.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > compares-two-bools

--- a/tests/org/eolang/bytes-tests.eo
+++ b/tests/org/eolang/bytes-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > takes-part-of-bytes

--- a/tests/org/eolang/cage-tests.eo
+++ b/tests/org/eolang/cage-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > writes-into-cage

--- a/tests/org/eolang/collections/bytes-as-array-tests.eo
+++ b/tests/org/eolang/collections/bytes-as-array-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.list
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 [] > bytes-to-array

--- a/tests/org/eolang/collections/list-tests.eo
+++ b/tests/org/eolang/collections/list-tests.eo
@@ -28,8 +28,8 @@
 +alias org.eolang.txt.sscanf
 +alias org.eolang.txt.text
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 # check that list.is-empty works properly

--- a/tests/org/eolang/collections/map-tests.eo
+++ b/tests/org/eolang/collections/map-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.map
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 [] > map-find-do-not-crashed

--- a/tests/org/eolang/collections/multimap-tests.eo
+++ b/tests/org/eolang/collections/multimap-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.multimap
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 [] > rebuild-do-not-crush

--- a/tests/org/eolang/collections/range-tests.eo
+++ b/tests/org/eolang/collections/range-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.range
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 [] > simple-range

--- a/tests/org/eolang/collections/set-tests.eo
+++ b/tests/org/eolang/collections/set-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.set
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.8
 
 [] > set-works

--- a/tests/org/eolang/cti-test.eo
+++ b/tests/org/eolang/cti-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > just-prints-warning

--- a/tests/org/eolang/fs/base-name-test.eo
+++ b/tests/org/eolang/fs/base-name-test.eo
@@ -21,13 +21,15 @@
 # SOFTWARE.
 
 +alias org.eolang.fs.base-name
++alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > takes-base-name-file
-  eq. > @
+  assert-that > @
     base-name
       "/tmp/foo/hello.gz"
-    "hello.gz"
+    $.equal-to
+      "hello.gz"

--- a/tests/org/eolang/fs/base-name-test.eo
+++ b/tests/org/eolang/fs/base-name-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.fs.base-name
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > takes-base-name-file

--- a/tests/org/eolang/fs/dir-name-test.eo
+++ b/tests/org/eolang/fs/dir-name-test.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.sys.uname
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > takes-name-of-directory

--- a/tests/org/eolang/fs/dir-name-test.eo
+++ b/tests/org/eolang/fs/dir-name-test.eo
@@ -21,13 +21,21 @@
 # SOFTWARE.
 
 +alias org.eolang.fs.dir-name
++alias org.eolang.hamcrest.assert-that
++alias org.eolang.sys.uname
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > takes-name-of-directory
-  eq. > @
+  assert-that > @
     dir-name
       "/tmp/foo/hello.gz"
-    "/tmp/foo"
+    $.equal-to
+      if.
+        or.
+          uname.is-unix
+          uname.is-macos
+        "/tmp/foo"
+        "\\tmp\\foo"

--- a/tests/org/eolang/fs/dir-test.eo
+++ b/tests/org/eolang/fs/dir-test.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.copied
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > makes-the-same-temp-file

--- a/tests/org/eolang/fs/dir-test.eo
+++ b/tests/org/eolang/fs/dir-test.eo
@@ -22,60 +22,71 @@
 
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.tmpdir
++alias org.eolang.hamcrest.assert-that
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.copied
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > makes-the-same-temp-file
   tmpdir.tmpfile > f!
-  eq. > @
+  assert-that > @
     f
-    f
+    $.equal-to
+      f
 
 [] > makes-new-directory
   tmpdir.tmpfile > f!
   dir > d
     f.resolve "new-dir"
-  and. > @
-    f.rm
-    d.mkdir
-    d.exists
-    d.is-dir
+  assert-that > @
+    and.
+      f.rm
+      d.mkdir
+      d.exists
+      d.is-dir
+    $.equal-to
+      TRUE
 
 [] > makes-new-directory-on-top-of-file
   tmpdir.tmpfile > f!
   dir f > d
-  and. > @
-    d.rm
-    d.mkdir
-    d.exists
-    d.is-dir
+  assert-that > @
+    and.
+      d.rm
+      d.mkdir
+      d.exists
+      d.is-dir
+    $.equal-to
+      TRUE
 
 [] > deletes-recursively
   tmpdir.tmpfile > f!
   dir f > d
-  and. > @
-    d.rm
-    d.mkdir
-    eq.
-      copied
-        bytes-as-input
-          "Hello, world".as-bytes
-        as-output.
-          d.resolve "test.txt"
-          "w"
-        1024
-      12
-    d.rm-rf
-    d.exists.not
+  assert-that > @
+    and.
+      d.rm
+      d.mkdir
+      eq.
+        copied
+          bytes-as-input
+            "Hello, world".as-bytes
+          as-output.
+            d.resolve "test.txt"
+            "w"
+          1024
+        12
+      d.rm-rf
+      d.exists.not
+    $.equal-to
+      TRUE
 
 [] > walks-recursively
   tmpdir.tmpfile > f!
   dir f > d
-  and. > @
+  seq > directory
     d.rm
     d.mkdir
     mkdir.
@@ -86,8 +97,10 @@
       dir
         d.resolve "x/y/z"
     (d.resolve "x/y/z/a.txt").touch
-    eq.
-      length.
-        d.walk
-          "**/*.txt"
+    d
+  assert-that > @
+    length.
+      directory.walk
+        "**/*.txt"
+    $.equal-to
       2

--- a/tests/org/eolang/fs/ext-name-test.eo
+++ b/tests/org/eolang/fs/ext-name-test.eo
@@ -21,13 +21,15 @@
 # SOFTWARE.
 
 +alias org.eolang.fs.ext-name
++alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > takes-extension-name
-  eq. > @
+  assert-that > @
     ext-name
       "/tmp/foo/hello.gz"
-    ".gz"
+    $.equal-to
+      ".gz"

--- a/tests/org/eolang/fs/ext-name-test.eo
+++ b/tests/org/eolang/fs/ext-name-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.fs.ext-name
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > takes-extension-name

--- a/tests/org/eolang/fs/file-test.eo
+++ b/tests/org/eolang/fs/file-test.eo
@@ -123,7 +123,6 @@
     $.equal-to
       TRUE
 
-
 [] > measures-file-size
   tmpdir.tmpfile > f!
   "hey!" > line

--- a/tests/org/eolang/fs/file-test.eo
+++ b/tests/org/eolang/fs/file-test.eo
@@ -27,8 +27,8 @@
 +alias org.eolang.txt.sprintf
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > compares-to-same-file

--- a/tests/org/eolang/fs/file-test.eo
+++ b/tests/org/eolang/fs/file-test.eo
@@ -25,40 +25,52 @@
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.copied
 +alias org.eolang.txt.sprintf
++alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > compares-to-same-file
-  eq. > @
+  assert-that > @
     file "/tmp/foo.txt"
-    file "/tmp/foo.txt"
+    $.equal-to
+      file "/tmp/foo.txt"
 
 [] > compares-to-another-file
-  not. > @
-    eq.
-      file "/tmp/foo.txt"
-      file "/tmp/bar.txt"
+  assert-that > @
+    file "/tmp/foo.txt"
+    $.not
+      $.equal-to
+        file "/tmp/bar.txt"
 
 [] > check-if-it-is-directory
-  is-dir. > @
-    file
-      "."
+  assert-that > @
+    is-dir.
+      file
+        "."
+    $.equal-to
+      TRUE
 
 [] > check-if-file-exists
-  not. > @
-    exists.
-      file
-        "some-absent-file.txt"
+  assert-that > @
+    not.
+      exists.
+        file
+          "some-absent-file.txt"
+    $.equal-to
+      TRUE
 
 [] > touches-a-file
   tmpdir.tmpfile > f!
-  and. > @
-    f.rm
-    f.exists.not
-    f.touch
-    f.exists
+  assert-that > @
+    and.
+      f.rm
+      f.exists.not
+      f.touch
+      f.exists
+    $.equal-to
+      TRUE
 
 [] > moves-a-file
   tmpdir.tmpfile.@ > src!
@@ -66,47 +78,62 @@
     sprintf
       "%s.dest"
       src
-  seq > @
-    src.touch
-    src.mv dest
-    dest.exists
-    src.exists.not
+  assert-that > @
+    seq
+      src.touch
+      src.mv dest
+      dest.exists
+      src.exists.not
+    $.equal-to
+      TRUE
 
 [] > deletes-single-file-in-temp
-  rm. > @
-    tmpfile.
-      tmpdir
+  assert-that > @
+    rm.
+      tmpfile.
+        tmpdir
+    $.equal-to
+      TRUE
 
 [] > makes-the-same-temp-file
   tmpdir.tmpfile > f!
-  eq. > @
+  assert-that > @
     f
-    f
+    $.equal-to
+      f
 
 [] > writes-string-to-file
   tmpdir.tmpfile > f!
-  eq. > @
+  assert-that > @
     copied
       bytes-as-input
         as-bytes.
           "你好, друг!"
       f.as-output "w+"
       4
-    17
+    $.equal-to
+      17
 
 [] > measures-empty-file-size
   tmpdir.tmpfile > f!
-  and. > @
-    f.touch
-    f.size.eq 0
+  assert-that > @
+    and.
+      f.touch
+      f.size.eq 0
+    $.equal-to
+      TRUE
+
 
 [] > measures-file-size
   tmpdir.tmpfile > f!
-  eq. > @
-    copied
-      bytes-as-input
-        as-bytes.
-          "hey!"
-      f.as-output "w+"
-      100
-    f.size
+  "hey!" > line
+  nop > @
+    assert-that
+      copied
+        bytes-as-input
+          as-bytes.
+            line
+        f.as-output "w+"
+        100
+      $.equal-to
+        f.size

--- a/tests/org/eolang/fs/tmpdir-test.eo
+++ b/tests/org/eolang/fs/tmpdir-test.eo
@@ -21,11 +21,15 @@
 # SOFTWARE.
 
 +alias org.eolang.fs.tmpdir
++alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.fs
-+version 0.3.5
++version 0.4.0
 
 [] > global-temp-dir-exists
-  exists. > @
-    tmpdir
+  assert-that > @
+    exists.
+      tmpdir
+    $.equal-to
+      TRUE

--- a/tests/org/eolang/fs/tmpdir-test.eo
+++ b/tests/org/eolang/fs/tmpdir-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.fs.tmpdir
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.fs
++tests
 +version 0.4.0
 
 [] > global-temp-dir-exists

--- a/tests/org/eolang/goto-tests.eo
+++ b/tests/org/eolang/goto-tests.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > goto-jumps-backwards

--- a/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > all-of-numbers-test

--- a/tests/org/eolang/hamcrest/any-of-tests.eo
+++ b/tests/org/eolang/hamcrest/any-of-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > any-of-numbers-test

--- a/tests/org/eolang/hamcrest/anything-tests.eo
+++ b/tests/org/eolang/hamcrest/anything-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > anything-two-sum-test

--- a/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > has-item-int-test

--- a/tests/org/eolang/hamcrest/blank-string-tests.eo
+++ b/tests/org/eolang/hamcrest/blank-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-blank-string

--- a/tests/org/eolang/hamcrest/close-to-tests.eo
+++ b/tests/org/eolang/hamcrest/close-to-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > float-is-close-to-float-with-delta-test

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-contains-string

--- a/tests/org/eolang/hamcrest/described-as-tests.eo
+++ b/tests/org/eolang/hamcrest/described-as-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > two-sum-described-as-equal-to-test

--- a/tests/org/eolang/hamcrest/empty-string-tests.eo
+++ b/tests/org/eolang/hamcrest/empty-string-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-empty-string

--- a/tests/org/eolang/hamcrest/equal-to-tests.eo
+++ b/tests/org/eolang/hamcrest/equal-to-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > two-sum-test

--- a/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > all-of-number-test-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > any-of-number-test-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > anything-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > arrays-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-blank-string-failed

--- a/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > float-is-close-to-float-with-delta-test-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-contains-string-failed

--- a/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > two-sum-described-as-equal-to-test-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-empty-string-failed

--- a/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.hamcrest.assert-twice-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > delayed-calculation

--- a/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > greater-than-int-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > is-failed-output-with-two-bools

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-contains-string-failed

--- a/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > less-than-int-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > matches-regex-failed-output

--- a/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > not-failed-output-two-strings

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-ends-with-string-failed

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest.failed-output
++tests
 +version 0.3.2
 
 [] > simple-starts-with-string-failed

--- a/tests/org/eolang/hamcrest/greater-than-tests.eo
+++ b/tests/org/eolang/hamcrest/greater-than-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > two-sum-greater-than-value-test

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-is-substring

--- a/tests/org/eolang/hamcrest/is-tests.eo
+++ b/tests/org/eolang/hamcrest/is-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > is-two-sum-test

--- a/tests/org/eolang/hamcrest/less-than-tests.eo
+++ b/tests/org/eolang/hamcrest/less-than-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > two-sum-less-than-value-test

--- a/tests/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/tests/org/eolang/hamcrest/matches-regex-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > matches-regex-alphabetical-test

--- a/tests/org/eolang/hamcrest/not-tests.eo
+++ b/tests/org/eolang/hamcrest/not-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > not-equal-two-sum-test

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-ends-with-string

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-hamcrest
-+junit
 +package org.eolang.hamcrest
++tests
 +version 0.3.2
 
 [] > simple-starts-with-string

--- a/tests/org/eolang/heap-tests.eo
+++ b/tests/org/eolang/heap-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.heap
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > allocates-and-uses

--- a/tests/org/eolang/int-tests.eo
+++ b/tests/org/eolang/int-tests.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > less-true

--- a/tests/org/eolang/io/bytes-as-input-test.eo
+++ b/tests/org/eolang/io/bytes-as-input-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.io.bytes-as-input
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.io
++tests
 +version 0.4.0
 
 [] > can-read-bytes-with-assert

--- a/tests/org/eolang/io/bytes-as-input-test.eo
+++ b/tests/org/eolang/io/bytes-as-input-test.eo
@@ -20,25 +20,29 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.hamcrest.assert-that
 +alias org.eolang.io.bytes-as-input
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.io
-+version 0.3.5
++version 0.4.0
 
-[] > can-read-bytes
+[] > can-read-bytes-with-assert
   bytes-as-input > i
     01-02-03-04-05-06-07-08-F5-F6
   i.read 4 > i1
   i1.read 4 > i2
   i2.read 4 > i3
-  and. > @
-    eq.
-      i1
-      01-02-03-04
-    eq.
-      i2
-      05-06-07-08
-    eq.
-      i3
-      F5-F6
+  assert-that > @
+    and.
+      eq.
+        i1
+        01-02-03-04
+      eq.
+        i2
+        05-06-07-08
+      eq.
+        i3
+        F5-F6
+    $.equal-to
+      TRUE

--- a/tests/org/eolang/io/copied-test.eo
+++ b/tests/org/eolang/io/copied-test.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.io.copied
 +alias org.eolang.io.memory-as-output
 +home https://github.com/objectionary/eo-files
-+junit
 +package org.eolang.io
++tests
 +version 0.4.0
 
 [] > copies-bytes-from-object-to-memory

--- a/tests/org/eolang/io/copied-test.eo
+++ b/tests/org/eolang/io/copied-test.eo
@@ -20,17 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.hamcrest.assert-that
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.copied
 +alias org.eolang.io.memory-as-output
 +home https://github.com/objectionary/eo-files
 +junit
 +package org.eolang.io
-+version 0.3.5
++version 0.4.0
 
 [] > copies-bytes-from-object-to-memory
   memory -- > m
-  eq. > @
+  assert-that > @
     copied
       bytes-as-input
         as-bytes.
@@ -38,4 +39,6 @@
       memory-as-output
         m
       4
-    17
+    $.equal-to
+      17
+

--- a/tests/org/eolang/io/stdout-tests.eo
+++ b/tests/org/eolang/io/stdout-tests.eo
@@ -25,8 +25,8 @@
 +alias stdout org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang.io
++tests
 +version 0.29.4
 
 [] > prints-string-to-console

--- a/tests/org/eolang/junit-tests.eo
+++ b/tests/org/eolang/junit-tests.eo
@@ -23,8 +23,8 @@
 +alias assertThat org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+junit
 +package org.eolang
++tests
 +version 0.29.3
 
 [] > x

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.math.angle
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > sin-zero

--- a/tests/org/eolang/math/e-tests.eo
+++ b/tests/org/eolang/math/e-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.math.e
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > the-eulers-number-is-correct

--- a/tests/org/eolang/math/integral-tests.eo
+++ b/tests/org/eolang/math/integral-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.math.integral
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > linear-integral-test

--- a/tests/org/eolang/math/number-tests.eo
+++ b/tests/org/eolang/math/number-tests.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.math.number
 +alias org.eolang.math.pi
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > check-is-int-positive-int

--- a/tests/org/eolang/math/pi-tests.eo
+++ b/tests/org/eolang/math/pi-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.math.pi
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > the-pi-number-is-correct

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.random
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > random-with-seed

--- a/tests/org/eolang/math/series-tests.eo
+++ b/tests/org/eolang/math/series-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.series
 +home https://github.com/objectionary/eo-math
-+junit
 +package org.eolang.math
++tests
 +version 0.3.1
 
 [] > max-of-empty-array

--- a/tests/org/eolang/memory-tests.eo
+++ b/tests/org/eolang/memory-tests.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > writes-into-memory

--- a/tests/org/eolang/nop-tests.eo
+++ b/tests/org/eolang/nop-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.nop
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > nop-is-true

--- a/tests/org/eolang/ram-tests.eo
+++ b/tests/org/eolang/ram-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.ram
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > writes-and-slice-ram

--- a/tests/org/eolang/runtime-tests.eo
+++ b/tests/org/eolang/runtime-tests.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > understands-this-correctly

--- a/tests/org/eolang/rust-tests.eo
+++ b/tests/org/eolang/rust-tests.eo
@@ -22,8 +22,8 @@
 
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > creates-object

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > seq-single-dataization-float-less-than-test

--- a/tests/org/eolang/string-tests.eo
+++ b/tests/org/eolang/string-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > calculates-length-of-spaces-only

--- a/tests/org/eolang/switch-tests.eo
+++ b/tests/org/eolang/switch-tests.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > switch-simple-case

--- a/tests/org/eolang/sys/call-test.eo
+++ b/tests/org/eolang/sys/call-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.9
 
 # Making a syscall 'getpid' and compares the result

--- a/tests/org/eolang/sys/uname-test.eo
+++ b/tests/org/eolang/sys/uname-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.9
 
 # Checks what is the family of the OS

--- a/tests/org/eolang/sys/win32-test.eo
+++ b/tests/org/eolang/sys/win32-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.9
 
 # Making a Win32 'GetCurrentProcessId' function call and compares the result

--- a/tests/org/eolang/try-tests.eo
+++ b/tests/org/eolang/try-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.try
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > simple-division-by-zero

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > makes-tuple-through-special-syntax

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+junit
++tests
 +version 0.2.0
 
 [] > matches-string-against-pattern

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
-+junit
 +package org.eolang.txt
++tests
 +version 0.2.0
 
 [] > prints-simple-string

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -26,8 +26,8 @@
 +alias org.eolang.txt.sscanf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
-+junit
 +package org.eolang.txt
++tests
 +version 0.2.0
 
 [] > sscanf-with-string

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -25,8 +25,8 @@
 +alias org.eolang.txt.text
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
-+junit
 +package org.eolang.txt
++tests
 +version 0.2.0
 
 [] > text-trimmed-1

--- a/tests/org/eolang/unit-tests.eo
+++ b/tests/org/eolang/unit-tests.eo
@@ -23,8 +23,8 @@
 +alias assertThat org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang
++tests
 +version 0.29.4
 
 [] > x


### PR DESCRIPTION
Related to: https://github.com/objectionary/eo-files/issues/73

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various packages and their versions, as well as changes some package names and architects. 

### Detailed summary
- Updates package versions for `org.eolang`, `org.eolang.math`, `org.eolang.txt`, `org.eolang.io`, `org.eolang.sys`, `org.eolang.collections`, and `org.eolang.hamcrest`
- Changes package names for `org.eolang` and `org.eolang.txt`
- Updates architect information for various packages
- Removes references to `junit` in some package tests

> The following files were skipped due to too many changes: `tests/org/eolang/hamcrest/close-to-tests.eo`, `tests/org/eolang/sys/win32-test.eo`, `objects/org/eolang/fs/file.eo`, `tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/not-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/is-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo`, `objects/org/eolang/io/copied.eo`, `tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo`, `tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo`, `objects/org/eolang/fs/base-name.eo`, `objects/org/eolang/io/memory-as-output.eo`, `objects/org/eolang/fs/dir-name.eo`, `objects/org/eolang/fs/ext-name.eo`, `objects/org/eolang/fs/tmpdir.eo`, `tests/org/eolang/fs/tmpdir-test.eo`, `tests/org/eolang/fs/ext-name-test.eo`, `tests/org/eolang/fs/base-name-test.eo`, `make/jvm/pom.xml`, `objects/org/eolang/io/bytes-as-input.eo`, `tests/org/eolang/fs/dir-name-test.eo`, `objects/org/eolang/fs/dir.eo`, `tests/org/eolang/io/copied-test.eo`, `tests/org/eolang/io/bytes-as-input-test.eo`, `tests/org/eolang/fs/dir-test.eo`, `tests/org/eolang/fs/file-test.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->