### PR TITLE
EO hamcrest release `0.4.0`

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.29.3</eo.version>
+    <eo.version>0.29.4</eo.version>
     <stack-size>32M</stack-size>
   </properties>
   <build>

--- a/objects/org/eolang/hamcrest/assert-that.eo
+++ b/objects/org/eolang/hamcrest/assert-that.eo
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -41,11 +40,12 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
++alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Main object for assertions
 [actual matcher reasons...] > assert-that

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -46,10 +46,6 @@
 +rt jvm org.eolang:eo-hamcrest:0.4.0
 +version 0.4.0
 
-# @todo #167:45min Make this object decorates
-#  another one (let's call it assert). Which will
-#  be an interface for assert-that and assert-twice-that
-#  objects to avoid matchers duplication.
 # Main object for assertions with multiply dataization of actual object.
 # It should dataize twice only when we get FALSE mathcing result from the first dataization.
 [actual matcher reasons...] > assert-twice-that

--- a/objects/org/eolang/hamcrest/assert-twice-that.eo
+++ b/objects/org/eolang/hamcrest/assert-twice-that.eo
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-+alias org.eolang.collections.list
 +alias org.eolang.hamcrest.matchers.all-of-matcher
 +alias org.eolang.hamcrest.matchers.any-of-matcher
 +alias org.eolang.hamcrest.matchers.anything-matcher
@@ -40,12 +39,17 @@
 +alias org.eolang.hamcrest.matchers.matches-regex-matcher
 +alias org.eolang.hamcrest.matchers.string-ends-with-matcher
 +alias org.eolang.hamcrest.matchers.string-starts-with-matcher
++alias org.eolang.collections.list
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
+# @todo #167:45min Make this object decorates
+#  another one (let's call it assert). Which will
+#  be an interface for assert-that and assert-twice-that
+#  objects to avoid matchers duplication.
 # Main object for assertions with multiply dataization of actual object.
 # It should dataize twice only when we get FALSE mathcing result from the first dataization.
 [actual matcher reasons...] > assert-twice-that

--- a/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/all-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Calculates the logical conjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/any-of-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Calculates the logical disjunction of multiple matchers.
 # Evaluation is shortcut, so subsequent matchers are not called

--- a/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/anything-matcher.eo
@@ -22,8 +22,8 @@
 
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # A matcher that always returns true.
 [] > anything-matcher

--- a/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/array-each-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Matcher for array whose elements satisfy a sequence of matchers.
 # The array size must equal the number of element matchers.

--- a/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Tests if the examined string contains zero or more whitespace characters and nothing else.
 [] > blank-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/close-to-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Compare object that matches when an examined float
 # is equal to the specified operand, within a range of +/- error.
@@ -33,14 +33,31 @@
   memory 0 > mismatch
 
   [a] > match
-    seq > @
-      mismatch.write actual-delta
-      actual-delta.lte 0.0
+    if. > @
+      and.
+        is-float.
+          number operand
+        is-float.
+          number a
+        is-float.
+          number err
+      seq
+        mismatch.write actual-delta
+        actual-delta.lte 0.0
+      seq
+        error "some of the given arguments are not floats"
+
     [] > actual-delta
       minus. > @
-        abs.
-          number (a.minus operand)
+        float-abs
+          a.minus operand
         err
+
+    [value] > float-abs
+      if. > @
+        value.gte 0.0
+        value
+        value.neg
 
   [act] > describe-mismatch
     sprintf > @
@@ -51,6 +68,6 @@
 
   [] > description-of
     sprintf > @
-      "a numeric value within <%s> of <%s>"
+      "a float value within <%s> of <%s>"
       operand
       err

--- a/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Matcher that matches if the examined string contains the specified string anywhere.
 [str] > contains-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Wraps an existing matcher, overriding its description with that specified.
 # All other functions are delegated to the decorated matcher,
@@ -32,6 +32,9 @@
 [matcher format args...] > described-as-matcher
   matcher > @
 
+  # @todo #3:45min Here we got an object printed
+  #  instead of data. The .map [i] i.as-string didn't work.
+  #  We need to convert varargs to data[] somehow.
   [] > description-of
     sprintf > @
       format

--- a/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/described-as-matcher.eo
@@ -32,9 +32,6 @@
 [matcher format args...] > described-as-matcher
   matcher > @
 
-  # @todo #3:45min Here we got an object printed
-  #  instead of data. The .map [i] i.as-string didn't work.
-  #  We need to convert varargs to data[] somehow.
   [] > description-of
     sprintf > @
       format

--- a/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/empty-string-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Tests if the examined string contains zero characters and nothing else.
 [] > empty-string-matcher

--- a/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/equal-to-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Is the value equal to another value
 [x] > equal-to-matcher

--- a/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/greater-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Compare object that matches when the examined object
 # is greater than the specified value

--- a/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Wraps an existing matcher and apply it to every item in array.
 [matcher] > has-item-matcher
@@ -53,6 +53,10 @@
             acc
             apply x
 
+  # @todo #37:30min This string formatting doesn't work correctly.
+  #  Here we got message like: [was <[Lorg.eolang.Phi;@1189dd52>]
+  #  and possibly we need to change code below when string manipulation
+  #  objects will be created.
   [act] > describe-mismatch
     sprintf > @
       "mismatches: [%s]"

--- a/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-item-matcher.eo
@@ -53,10 +53,6 @@
             acc
             apply x
 
-  # @todo #37:30min This string formatting doesn't work correctly.
-  #  Here we got message like: [was <[Lorg.eolang.Phi;@1189dd52>]
-  #  and possibly we need to change code below when string manipulation
-  #  objects will be created.
   [act] > describe-mismatch
     sprintf > @
       "mismatches: [%s]"

--- a/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/has-items-matcher.eo
@@ -25,8 +25,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Wraps an array of matchers and apply them to every item in array.
 [matchers...] > has-items-matcher

--- a/objects/org/eolang/hamcrest/matchers/is-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Decorates another Matcher, retaining the behaviour
 # but allowing tests to be slightly more expressive.

--- a/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/is-substring-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Tests if the argument is a substring of the actual string.
 [str] > is-substring-matcher

--- a/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/less-than-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Compare object that matches when the examined object
 # is less than the specified value

--- a/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/matches-regex-matcher.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Checks if given string can be generated
 # by the regular expression.

--- a/objects/org/eolang/hamcrest/matchers/not-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/not-matcher.eo
@@ -23,8 +23,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Calculates the logical negation of a matcher
 [matcher] > not-matcher

--- a/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-ends-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Tests if the argument is a string that ends with a specific substring.
 [str] > string-ends-with-matcher

--- a/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
+++ b/objects/org/eolang/hamcrest/matchers/string-starts-with-matcher.eo
@@ -24,8 +24,8 @@
 +alias sprintf org.eolang.txt.sprintf
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.matchers
-+rt jvm org.eolang:eo-hamcrest:0.3.2
-+version 0.3.2
++rt jvm org.eolang:eo-hamcrest:0.4.0
++version 0.4.0
 
 # Tests if the argument is a string that starts with a specific substring.
 [str] > string-starts-with-matcher

--- a/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -25,8 +25,12 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
+# @todo #167:45min To add more tests with a new
+#  assert-twice-that object to make sure it
+#  works well. This task is only about passed tests,
+#  for failed tests there will be another one.
 [] > all-of-numbers-test
   assert-that > @
     150.minus 50

--- a/tests/org/eolang/hamcrest/all-of-tests.eo
+++ b/tests/org/eolang/hamcrest/all-of-tests.eo
@@ -27,10 +27,6 @@
 +tests
 +version 0.4.0
 
-# @todo #167:45min To add more tests with a new
-#  assert-twice-that object to make sure it
-#  works well. This task is only about passed tests,
-#  for failed tests there will be another one.
 [] > all-of-numbers-test
   assert-that > @
     150.minus 50

--- a/tests/org/eolang/hamcrest/any-of-tests.eo
+++ b/tests/org/eolang/hamcrest/any-of-tests.eo
@@ -23,9 +23,9 @@
 +alias org.eolang.hamcrest.assert-that
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-hamcrest
-+package org.eolang.hamcrest
 +tests
-+version 0.3.2
++package org.eolang.hamcrest
++version 0.4.0
 
 [] > any-of-numbers-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/anything-tests.eo
+++ b/tests/org/eolang/hamcrest/anything-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > anything-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
+++ b/tests/org/eolang/hamcrest/arrays-matchers-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > has-item-int-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/blank-string-tests.eo
+++ b/tests/org/eolang/hamcrest/blank-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-blank-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/close-to-tests.eo
+++ b/tests/org/eolang/hamcrest/close-to-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > float-is-close-to-float-with-delta-test
   assert-that > @
@@ -40,3 +40,42 @@
   assert-that > @
     -123456789.123456
     $.close-to -123456789.0 0.2
+
+[] > check-switch-close-1
+  assert-that > @
+    switch
+      *
+        TRUE
+        1.0
+    $.close-to
+      1.0
+      0.1
+
+[] > slow-test-with-switch
+  assert-that > @
+    switch
+      *
+        TRUE
+        switch
+          *
+            TRUE
+            1.0
+    $.close-to
+      1.0
+      0.1
+
+[] > switch-in-switch-in-switch-close-to
+  assert-that > @
+    switch
+      *
+        TRUE
+        switch
+          *
+            TRUE
+            switch
+              *
+                TRUE
+                1.0
+    $.close-to
+      1.0
+      0.1

--- a/tests/org/eolang/hamcrest/contains-string-tests.eo
+++ b/tests/org/eolang/hamcrest/contains-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-contains-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/described-as-tests.eo
+++ b/tests/org/eolang/hamcrest/described-as-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > two-sum-described-as-equal-to-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/empty-string-tests.eo
+++ b/tests/org/eolang/hamcrest/empty-string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-empty-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/equal-to-tests.eo
+++ b/tests/org/eolang/hamcrest/equal-to-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -27,10 +27,6 @@
 +tests
 +version 0.4.0
 
-# @todo #167:45min To add more tests with a new
-#  assert-twice-that object to make sure failed output messages
-#  work well. This task is only about failed tests,
-#  for successfully passed tests there will be another one.
 [] > all-of-number-test-failed-output
   [] > suggestion
     assert-that > @

--- a/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo
@@ -25,8 +25,12 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
+# @todo #167:45min To add more tests with a new
+#  assert-twice-that object to make sure failed output messages
+#  work well. This task is only about failed tests,
+#  for successfully passed tests there will be another one.
 [] > all-of-number-test-failed-output
   [] > suggestion
     assert-that > @
@@ -64,4 +68,4 @@
       "all of conditions"
   assert-that > @
     suggestion
-    $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a numeric value within <20.0> of <2.2>\n     but: a value was <42.0>"
+    $.equal-to "all of conditions\nExpected: <1.0> equal to value and <100.0> less than value and a float value within <20.0> of <2.2>\n     but: a value was <42.0>"

--- a/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -49,10 +49,6 @@
     suggestion
     $.equal-to "\nExpected: <1> equal to value or <100> less than value or <-6> greater than value\n     but: a value was <3>"
 
-# @todo #149:30min To remove this nop object
-#  when this test will be stable. To do that we
-#  need to find out why this test is fail in some
-#  workflow checks.
 [] > any-of-close-to-failed-output
   nop > @
     [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/any-of-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > any-of-number-test-failed-output
   [] > suggestion
@@ -49,6 +49,10 @@
     suggestion
     $.equal-to "\nExpected: <1> equal to value or <100> less than value or <-6> greater than value\n     but: a value was <3>"
 
+# @todo #149:30min To remove this nop object
+#  when this test will be stable. To do that we
+#  need to find out why this test is fail in some
+#  workflow checks.
 [] > any-of-close-to-failed-output
   nop > @
     [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/anything-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > anything-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/arrays-matchers-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > arrays-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/blank-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-blank-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > float-is-close-to-float-with-delta-test-failed-output
   [] > suggestion
@@ -33,7 +33,7 @@
       $.close-to 2.5 0.4
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <2.5> of <0.4>\n     but: <3.0> differed by <0.09> more than delta <0.4>"
+    $.equal-to "\nExpected: a float value within <2.5> of <0.4>\n     but: <3.0> differed by <0.09> more than delta <0.4>"
 
 [] > zero-is-close-to-float-with-delta-test-failed-output
   [] > suggestion
@@ -42,7 +42,7 @@
       $.close-to 0.5 0.4
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <0.5> of <0.4>\n     but: <0.0> differed by <0.09> more than delta <0.4>"
+    $.equal-to "\nExpected: a float value within <0.5> of <0.4>\n     but: <0.0> differed by <0.09> more than delta <0.4>"
 
 [] > neg-float-is-close-to-neg-float-with-delta-test-failed-output
   [] > suggestion
@@ -51,4 +51,4 @@
       $.close-to -123456788.0 0.2
   assert-that > @
     suggestion
-    $.equal-to "\nExpected: a numeric value within <-1.23456788E8> of <0.2>\n     but: <-1.23456789123456E8> differed by <0.92> more than delta <0.2>"
+    $.equal-to "\nExpected: a float value within <-1.23456788E8> of <0.2>\n     but: <-1.23456789123456E8> differed by <0.92> more than delta <0.2>"

--- a/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/contains-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-contains-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/described-as-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > two-sum-described-as-equal-to-test-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/empty-string-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-empty-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -72,10 +72,6 @@
     suggestion
     "\nExpected: <11.0> equal to value\n     but: was <44.0>"
 
-# @todo #180:45min To remove nop object from this test.
-#  Since while object was changed, we need to figure out
-#  why this object failed. I suggest doubled dataization
-#  of actual object in assert-twice-that object.
 [] > equal-to-assert-twice-that-failed-output
   nop > @
     [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/equal-to-failed-output.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > delayed-calculation
   memory 0 > m
@@ -72,6 +72,10 @@
     suggestion
     "\nExpected: <11.0> equal to value\n     but: was <44.0>"
 
+# @todo #180:45min To remove nop object from this test.
+#  Since while object was changed, we need to figure out
+#  why this object failed. I suggest doubled dataization
+#  of actual object in assert-twice-that object.
 [] > equal-to-assert-twice-that-failed-output
   nop > @
     [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/greater-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > greater-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > is-failed-output-with-two-bools
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/is-substring-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-contains-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/less-than-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > less-than-int-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/matches-regex-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > matches-regex-failed-output
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/not-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > not-failed-output-two-strings
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-ends-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-ends-with-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
+++ b/tests/org/eolang/hamcrest/failed-output/string-starts-with-failed-output.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest.failed-output
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-starts-with-string-failed
   [] > suggestion

--- a/tests/org/eolang/hamcrest/greater-than-tests.eo
+++ b/tests/org/eolang/hamcrest/greater-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > two-sum-greater-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/is-substring-tests.eo
+++ b/tests/org/eolang/hamcrest/is-substring-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-is-substring
   assert-that > @

--- a/tests/org/eolang/hamcrest/is-tests.eo
+++ b/tests/org/eolang/hamcrest/is-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > is-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/less-than-tests.eo
+++ b/tests/org/eolang/hamcrest/less-than-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > two-sum-less-than-value-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/matches-regex-tests.eo
+++ b/tests/org/eolang/hamcrest/matches-regex-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > matches-regex-alphabetical-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/not-tests.eo
+++ b/tests/org/eolang/hamcrest/not-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > not-equal-two-sum-test
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-ends-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-ends-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-ends-with-string
   assert-that > @

--- a/tests/org/eolang/hamcrest/string-starts-with-tests.eo
+++ b/tests/org/eolang/hamcrest/string-starts-with-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo-hamcrest
 +package org.eolang.hamcrest
 +tests
-+version 0.3.2
++version 0.4.0
 
 [] > simple-starts-with-string
   assert-that > @


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `org.eolang.hamcrest` package and its dependencies and adds new test cases. 

### Detailed summary
- Updated `org.eolang.hamcrest` package version from `0.3.2` to `0.4.0`
- Updated dependencies to version `0.4.0`
- Added new test cases for various matchers

> The following files were skipped due to too many changes: `objects/org/eolang/hamcrest/matchers/blank-string-matcher.eo`, `objects/org/eolang/hamcrest/matchers/contains-string-matcher.eo`, `objects/org/eolang/hamcrest/matchers/array-each-matcher.eo`, `objects/org/eolang/hamcrest/matchers/described-as-matcher.eo`, `tests/org/eolang/hamcrest/close-to-tests.eo`, `tests/org/eolang/hamcrest/failed-output/all-of-failed-output.eo`, `objects/org/eolang/hamcrest/assert-that.eo`, `objects/org/eolang/hamcrest/assert-twice-that.eo`, `objects/org/eolang/hamcrest/matchers/close-to-matcher.eo`, `tests/org/eolang/hamcrest/failed-output/close-to-failed-output.eo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->