### PR TITLE
added EO-net

### DIFF
--- a/make/jvm/Makefile
+++ b/make/jvm/Makefile
@@ -26,7 +26,7 @@ SHELL := /bin/bash
 .ONESHELL:
 
 all:
-	mvn --update-snapshots --errors --batch-mode test
+	mvn -X --update-snapshots --errors --batch-mode test
 
 clean:
 	mvn clean

--- a/make/jvm/Makefile
+++ b/make/jvm/Makefile
@@ -26,7 +26,7 @@ SHELL := /bin/bash
 .ONESHELL:
 
 all:
-	mvn -X --update-snapshots --errors --batch-mode test
+	mvn --update-snapshots --errors --batch-mode test
 
 clean:
 	mvn clean

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -95,7 +95,7 @@ SOFTWARE.
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.3</version>
+        <version>5.9.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.29.4</eo.version>
+    <eo.version>0.29.5</eo.version>
     <stack-size>32M</stack-size>
   </properties>
   <build>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -95,7 +95,7 @@ SOFTWARE.
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.1</version>
+        <version>5.9.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -1,0 +1,28 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 kerelape
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++home https://github.com/objectionary/eo-net
++package org.eolang.net
++rt jvm org.eolang.net:0.0.2
++version 0.0.2
+
+[address port] > socket /string

--- a/tests/org/eolang/net/socket-tests.eo
+++ b/tests/org/eolang/net/socket-tests.eo
@@ -1,3 +1,25 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2022 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 +alias org.eolang.net.socket
 +home https://github.com/objectionary/eo-net
 +package org.eolang.net

--- a/tests/org/eolang/net/socket-tests.eo
+++ b/tests/org/eolang/net/socket-tests.eo
@@ -1,0 +1,11 @@
++alias org.eolang.net.socket
++home https://github.com/objectionary/eo-net
++package org.eolang.net
++tests
+
+[] > socket-is-address
+  eq. > @
+    socket
+      "yandex.ru"
+      80
+    "yandex.ru:80"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds licensing information and metadata to `socket.eo` and `socket-tests.eo`, and modifies the `Makefile` to include debugging information during testing.

### Detailed summary
- Added MIT license and metadata to `socket.eo`
- Added MIT license, metadata, and a test suite to `socket-tests.eo`
- Modified `Makefile` to include debugging information during testing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->