### PR TITLE
New release for eo-strings_0.4.0

### DIFF
--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -25,8 +25,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++rt jvm org.eolang:eo-strings:0.4.0
++version 0.4.0
 
 # Regular expression in Perl format.
 # Free attribute "r" is a string represenation of regex object.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++rt jvm org.eolang:eo-strings:0.4.0
++version 0.4.0
 
 [format args...] > sprintf /string

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -23,8 +23,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++rt jvm org.eolang:eo-strings:0.4.0
++version 0.4.0
 
 # Reads formatted input from a string.
 # This object with two free attributes:

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -26,8 +26,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
-+rt jvm org.eolang:eo-strings:0.2.0
-+version 0.2.0
++rt jvm org.eolang:eo-strings:0.4.0
++version 0.4.0
 
 [s] > text
   s > @
@@ -35,6 +35,35 @@
   [start len] > slice
     text > @
       ^.s.slice start len
+
+  # Returns string trimmed from left side
+  [] > left-trim
+    left-rec-trim > @
+      s
+
+    [str] > left-rec-trim
+      if. > @
+        eq.
+          length.
+            str
+          0
+        ""
+        if.
+          eq.
+            slice.
+              str
+              0
+              1
+            " "
+          left-rec-trim
+            slice.
+              str
+              1
+              plus.
+                length.
+                  str
+                -1
+          str
 
   # Trim it from both sides
   [] > trimmed
@@ -99,6 +128,27 @@
           acc.concat x.as-bytes
           (acc.concat x.as-bytes).concat s.as-bytes
     res.as-string > @
+
+  # Returns string repeated n times
+  [n] > repeated
+    rec-repeated > @
+      s
+      n
+
+    [str n] > rec-repeated
+      if. > @
+        eq.
+          n
+          0
+        ""
+        chained.
+          text
+            str
+          rec-repeated
+            str
+            minus.
+              n
+              1
 
   # Checks that string contains substr
   [substr] > contains
@@ -372,7 +422,7 @@
   # Returns an tuple of strings, separated by a given string
   [delimiter] > split /tuple
 
-  # Check that all signs in string are letters.
+  # Check that all signs in string are numbers or letters.
   # Works only for english letters
   [] > is-alphabetic
     reduced. > @
@@ -386,6 +436,49 @@
       [a x]
         as-int. > value!
           bytes-1-to-8
+            as-bytes.
+              x
+        and. > @
+          a
+          int-is-alphabetic
+            value
+
+    [b] > int-is-alphabetic
+      or. > @
+        and.
+          gte.
+            b
+            48
+          lte.
+            b
+            57
+        and.
+          gte.
+            b
+            97
+          lte.
+            b
+            122
+
+    [b] > bytes-1-to-8
+      concat. > @
+        00-00-00-00-00-00-00
+        b
+
+  # Check that all signs in string are letters.
+  # Works only for english letters
+  [] > is-alpha
+    reduced. > @
+      list
+        bytes-as-array
+          as-bytes.
+            low-cased.
+              text
+                s
+      TRUE
+      [a x]
+        as-int. > value!
+          is-alphabetic.bytes-1-to-8
             as-bytes.
               x
         and. > @
@@ -407,7 +500,35 @@
         00-00-00-00-00-00-00
         b
 
-  # Returns concatenaion of all strings
+  # Check that all signs in string are ASCII characters.
+  [] > is-ascii
+    reduced. > @
+      list
+        bytes-as-array
+          as-bytes.
+            text
+              s
+      TRUE
+      [a x]
+        as-int. > value!
+          is-alphabetic.bytes-1-to-8
+            as-bytes.
+              x
+        and. > @
+          a
+          int-is-ascii
+            value
+
+    [b] > int-is-ascii
+      and. > @
+        gte.
+          b
+          0
+        lte.
+          b
+          127
+
+  # Returns concatenation of all strings
   [others...] > chained
     text > @
       as-string.

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
 +tests
-+version 0.2.0
++version 0.4.0
 
 [] > matches-string-against-pattern
   assert-that > @
@@ -223,3 +223,58 @@
         "abxxxxxcd"
         ""
       $.equal-to "abcd"
+
+[] > replace-groups-1
+  nop > @
+    assert-that
+      regex.replaced.replacei.replace-by-groups
+        QQ.txt.text "q$0wer$1ty"
+        list
+          *
+            "GR0"
+            "GR1"
+      $.equal-to
+        "qGR0werGR1ty"
+
+[] > group-ref-0
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          regex "/(([A-Za-z])[0-9])/"
+        "A2B"
+        "G$1G"
+      $.equal-to
+        "GA2GB"
+
+[] > group-ref-1
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          QQ.txt.regex "/(([A-Za-z])[0-9])/"
+        "a1a"
+        "G$1G"
+      $.equal-to
+        "Ga1Ga"
+
+[] > group-ref-2
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          QQ.txt.regex "/([xyz]+)/"
+        "abxxxcd"
+        "$0"
+      $.equal-to "abxxxcd"
+
+[] > group-ref-3
+  nop > @
+    assert-that
+      replaced.
+        compile.
+          QQ.txt.regex "/(([A-Za-z])[0-9])/"
+        "a1a\n"
+        "$1世"
+      $.equal-to
+        "a1世a\n"

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
 +tests
-+version 0.2.0
++version 0.4.0
 
 [] > prints-simple-string
   assert-that > @

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -28,7 +28,7 @@
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
 +tests
-+version 0.2.0
++version 0.4.0
 
 [] > sscanf-with-string
   assert-that > @

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -27,7 +27,49 @@
 +home https://github.com/objectionary/eo-strings
 +package org.eolang.txt
 +tests
-+version 0.2.0
++version 0.4.0
+
+[] > text-left-trim-1
+  assert-that > @
+    left-trim.
+      text
+        "a b"
+    $.equal-to "a b"
+
+[] > text-left-trim-2
+  assert-that > @
+    left-trim.
+      text
+        "a b "
+    $.equal-to "a b "
+
+[] > text-left-trim-3
+  assert-that > @
+    left-trim.
+      text
+        " a b "
+    $.equal-to "a b "
+
+[] > text-left-trim-4
+  assert-that > @
+    left-trim.
+      text
+        " a b"
+    $.equal-to "a b"
+
+[] > text-left-trim-space
+  assert-that > @
+    left-trim.
+      text
+        " "
+    $.equal-to ""
+
+[] > text-left-trim-double-space
+  assert-that > @
+    left-trim.
+      text
+        "  "
+    $.equal-to ""
 
 [] > text-trimmed-1
   assert-that > @
@@ -489,26 +531,68 @@
         "漢"
     $.equal-to TRUE
 
-[] > check-is-alpha
+[] > check-is-alphabetic
   assert-that > @
     is-alphabetic.
       text
         "eEo"
     $.equal-to TRUE
 
-[] > check-is-alpha-2
+[] > check-is-alphabetic-2
   assert-that > @
     is-alphabetic.
+      text
+        "ab3d"
+    $.equal-to TRUE
+
+[] > check-is-alphabetic-3
+  assert-that > @
+    is-alphabetic.
+      text
+        "-w-"
+    $.equal-to FALSE
+
+[] > check-is-alpha
+  assert-that > @
+    is-alpha.
+      text
+        "eEo"
+    $.equal-to TRUE
+
+[] > check-is-alpha-2
+  assert-that > @
+    is-alpha.
       text
         "ab3d"
     $.equal-to FALSE
 
 [] > check-is-alpha-3
   assert-that > @
-    is-alphabetic.
+    is-alpha.
+      text
+        "-w-"
+    $.equal-to FALSE
+
+[] > check-is-ascii
+  assert-that > @
+    is-ascii.
+      text
+        "H311oW"
+    $.equal-to TRUE
+
+[] > check-is-ascii2
+  assert-that > @
+    is-ascii.
+      text
+        "🌵"
+    $.equal-to FALSE
+
+[] > check-is-ascii3
+  assert-that > @
+    is-ascii.
       text
         "123"
-    $.equal-to FALSE
+    $.equal-to TRUE
 
 [] > split-text
   assert-that > @
@@ -651,3 +735,63 @@
         text "漢 "
       0
     $.equal-to "漢"
+
+[] > simple-contains-string
+  assert-that > @
+    contains.
+      text "Привет, 世界"
+      "世"
+    $.equal-to TRUE
+    "constains-string"
+
+[] > check-all-contains-string
+  assert-that > @
+    and.
+      contains.
+        text "世界世界世界世界世界世界世界世界"
+        "界"
+      contains.
+        text "世界世界世界世界世界世界й世界世界"
+        "й"
+    $.equal-to TRUE
+    "constains-all-of-string"
+
+[] > repeated-empty
+  assert-that > @
+    repeated.
+      text
+        ""
+      3
+    $.equal-to ""
+
+[] > repeated-zero
+  assert-that > @
+    repeated.
+      text
+        "abc"
+      0
+    $.equal-to ""
+
+[] > repeated-one
+  assert-that > @
+    repeated.
+      text
+        "abc"
+      1
+    $.equal-to "abc"
+
+[] > repeated-many-times
+  assert-that > @
+    repeated.
+      text
+        "abc"
+      3
+    $.equal-to "abcabcabc"
+
+[] > repeated-unicode
+  assert-that > @
+    repeated.
+      text
+        "漢"
+      3
+    $.equal-to "漢漢漢"


### PR DESCRIPTION
New release for eo-strings_0.4.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `eo-strings` dependency to 0.4.0, adds new methods to `text.eo` and `regex.eo`, and includes new test cases.

### Detailed summary
- Updated `eo-strings` dependency to 0.4.0
- Added `left-trim`, `is-alpha`, `is-alphabetic`, and `is-ascii` methods to `text.eo`
- Added `replace-by-groups`, `group-ref-0`, `group-ref-1`, `group-ref-2`, `group-ref-3` methods to `regex.eo`
- Included new test cases

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->