### PR TITLE
New release for eo-0.48.1

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.46.0</eo.version>
+    <eo.version>0.48.1</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/as-phi.eo
+++ b/objects/org/eolang/as-phi.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Turns an object into a phi-term printable to console.
 #

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,
@@ -35,7 +35,6 @@
   data > @
   $ > as-bytes
   $.eq 01- > as-bool
-  string $ > as-string
 
   # Turn this chain of eight bytes into a number.
   # If there are less or more than eight bytes, there will

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Compile Time Instruction (CTI).
 #

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result
 # `bytes`.

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # This object must be used in order to terminate the program
 # due to an error. Just make a copy of it with any encapsulated object.

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The object is a FALSE boolean state.
 [] > false

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Directory in the file system.
 # Apparently every directory is a file.
@@ -90,7 +90,8 @@
   [] > tmpfile
     if. > @
       ^.exists
-      QQ.fs.file touch.as-bytes.as-string
+      QQ.fs.file
+        string touch.as-bytes
       error
         sprintf
           "Directory %s does not exist, can't create temporary file"

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # A file on the filesystem.
 [path] > file
@@ -78,7 +78,8 @@
 
   # Move current file to `target`, making and returning a new `file` from it.
   [target] > moved
-    QQ.fs.file move.as-bytes.as-string > @
+    QQ.fs.file > @
+      string move.as-bytes
 
     # Tries to move file from `^.path` to `target`
     # and returns path of moved file as `string`.

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -27,7 +27,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
@@ -43,7 +43,7 @@
   # Utility object that joins given `tuple` of paths with current OS separator
   # and normalizes result path.
   [paths] > joined
-    as-string. > joined-path
+    string > joined-path
       as-bytes.
         joined.
           text ^.separator
@@ -132,11 +132,10 @@
               --
       determined. > @
         ^.^.posix
-          as-string.
-            if.
-              normalized.eq "//"
-              "/"
-              normalized
+          if.
+            normalized.eq "//"
+            "/"
+            string normalized
 
     # Resolves `other` path against `^.uri` and returns as new `path` from it.
     # The original `uri` and resolving `other` may be:
@@ -269,7 +268,7 @@
     "\\" > separator
     determined. > @
       validated
-        as-string.
+        string
           as-bytes.
             validated.separated-correctly
               uri
@@ -397,11 +396,10 @@
                 --
         determined. > @
           ^.^.validated
-            as-string.
-              if.
-                normalized.eq "\\\\"
-                ^.separator
-                normalized
+            if.
+              normalized.eq "\\\\"
+              ^.separator
+              string normalized
 
       # Resolves `other` path against `^.uri` and returns as new `path` from it.
       # Original `uri` and `other` path for resolving may be:

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -27,7 +27,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # Temporary directory.
 # For Unix/MacOS uses the path supplied by the first environment variable

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Dead input is an input that reads from nowhere and always
 # returns empty sequence of bytes `--`.

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Dead output is an output that writes to nowhere.
 [] > dead-output

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -25,7 +25,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # The `stdin` object is a convenient wrapper on `console` object
 # which is used as input only and allows to read the data from console.

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # The `stdout` object is convenient wrapper on `console` object which
 # uses it as output only and allows to print given argument to console as `string`:

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may
@@ -81,6 +81,12 @@
 # Here the void attribute in the scope object is memory-block object which provides API to write
 # and read data to the memory.
 [] > malloc
+  # Allocates empty block in memory.
+  [scope] > empty
+    malloc.of > @
+      0
+      scope
+
   # Allocates block in memory for given `object`. After allocation the provided object is dataized
   # and the data are written into memory.
   [object scope] > for

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The angle.
 [value] > angle

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # The Euler's number
 2.7182818284590452354 > e

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # Counts integral from `a` to `b`.
 # Here `func` is integration function, `a` is an upper limit,

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # The PI number
 3.14159265358979323846 > pi

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # Pseudo random number.
 [seed] > random

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Real number.
 [num] > real

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Not a number.
 [] > nan

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Negative infinity.
 [] > negative-infinity

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -27,7 +27,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.46.0
++version 0.48.1
 
 # Socket.
 #

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Positive infinity.
 [] > positive-infinity

--- a/objects/org/eolang/rust.eo
+++ b/objects/org/eolang/rust.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Rust insert.
 [code portal params] > rust /?

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Represents sequence of bytes as array.
 # Here `bts` is `bytes` objects, the return value is `tuple` where

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Hash code - the pseudo-unique float numeric
 # representation of an object.

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `tuple`s where each sub-tuple consists of 2

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -25,7 +25,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.46.0
++version 0.48.1
 
 # Get environment variable as `string`.
 # If return `string` is empty - the variable does not exist.

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.46.0
++version 0.48.1
 
 # Returns the system-dependent line separator string.
 # On UNIX systems, it returns "\n";

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Represents the name of the operating system.
 [] > os

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Makes a Unix syscall by name with POSIX interface.
 # See https://filippo.io/linux-syscall-table/.

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Makes a kernel32.dll function call by name.
 #

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The object is a TRUE boolean state.
 [] > true

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Try, catch and finally. This object helps catch errors created by the
 # `error` object. When being dataized, such objects will crash the problem.

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Tuple.
 [head tail] > tuple

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Regular expression in Perl format.
 # Here `pattern` is a string pattern.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # The sprintf object allows you to format and output text depending
 # on the arguments passed to it.

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.46.0
++rt jvm org.eolang:eo-runtime:0.48.1
 +rt node eo2js-runtime:0.0.0
-+version 0.46.0
++version 0.48.1
 
 # Reads formatted input from a string.
 # This object has two free attributes:

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -28,7 +28,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.46.0
++version 0.48.1
 
 # Text.
 [origin] > text
@@ -108,17 +108,17 @@
     ^.origin > delimiter!
     items.at 0 > first
     items.length > len!
+    if. > not-empty!
+      1.eq len
+      first
+      concat.
+        first.as-bytes
+        with-delimiter "".as-bytes 1
     text > @
       if.
         0.eq len
         ""
-        if.
-          1.eq len
-          first
-          as-string.
-            concat.
-              first.as-bytes
-              with-delimiter "".as-bytes 1
+        string not-empty
 
     [acc index] > with-delimiter
       if. > @
@@ -146,7 +146,7 @@
         if.
           0.eq amount
           ""
-          as-string.
+          string
             rec-repeated bts 1
 
     [accum index] > rec-repeated
@@ -249,7 +249,7 @@
       number ascii-a
       ascii "A"
     text > @
-      as-string.
+      string
         reduced.
           list
             bytes-as-array
@@ -282,7 +282,7 @@
     ^.up-cased.ascii "Z" > ascii-z
     ^.up-cased.ascii "A" > ascii-a
     text > @
-      as-string.
+      string
         reduced.
           list
             bytes-as-array
@@ -349,7 +349,7 @@
                 block.from.minus start
             ^.replacement
           block.to
-        as-string.
+        string
           accum.concat
             ^.reinit.slice
               start
@@ -404,7 +404,7 @@
       0.eq others.length
       ^
       text
-        as-string.
+        string
           reduced.
             list others
             ^.origin.as-bytes

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:

--- a/tests/org/eolang/as-phi-tests.eo
+++ b/tests/org/eolang/as-phi-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > prints-itself

--- a/tests/org/eolang/bool-tests.eo
+++ b/tests/org/eolang/bool-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > compares-two-bools

--- a/tests/org/eolang/bytes-tests.eo
+++ b/tests/org/eolang/bytes-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > takes-part-of-bytes
@@ -55,7 +55,7 @@
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > turns-bytes-into-a-string
   eq. > @
-    as-string.
+    string
       E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21
     "你好, друг!"
 
@@ -351,8 +351,7 @@
     "hello ".as-bytes
     "world".as-bytes
   eq. > @
-    as-string.
-      s-bytes
+    string s-bytes
     "hello world"
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/cti-test.eo
+++ b/tests/org/eolang/cti-test.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > just-prints-warning

--- a/tests/org/eolang/dataized-tests.eo
+++ b/tests/org/eolang/dataized-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > dataized-does-not-do-recalculation

--- a/tests/org/eolang/fs/dir-tests.eo
+++ b/tests/org/eolang/fs/dir-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bound-tmpfile-does-not-recreates-file

--- a/tests/org/eolang/fs/file-tests.eo
+++ b/tests/org/eolang/fs/file-tests.eo
@@ -29,7 +29,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > check-if-current-directory-is-directory

--- a/tests/org/eolang/fs/path-tests.eo
+++ b/tests/org/eolang/fs/path-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > determines-separator-depending-on-os

--- a/tests/org/eolang/fs/tmpdir-tests.eo
+++ b/tests/org/eolang/fs/tmpdir-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 tmpdir.exists > [] > global-temp-dir-exists

--- a/tests/org/eolang/go-tests.eo
+++ b/tests/org/eolang/go-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > goto-jumps-backwards

--- a/tests/org/eolang/i16-tests.eo
+++ b/tests/org/eolang/i16-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i16-has-valid-bytes

--- a/tests/org/eolang/i32-tests.eo
+++ b/tests/org/eolang/i32-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i32-has-valid-bytes

--- a/tests/org/eolang/i64-tests.eo
+++ b/tests/org/eolang/i64-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i64-has-valid-bytes

--- a/tests/org/eolang/io/bytes-as-input-test.eo
+++ b/tests/org/eolang/io/bytes-as-input-test.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > makes-an-input-from-bytes-and-reads

--- a/tests/org/eolang/io/console-test.eo
+++ b/tests/org/eolang/io/console-test.eo
@@ -20,33 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package org.eolang
++tests
++package org.eolang.io
 +version 0.48.1
 
-# Sequence.
-# The object, when being dataized, dataizes all provided
-# "steps" (except the last one) and returns the last one.
-[steps] > seq
-  if. > @
-    steps.length.eq 0
-    true
-    loop 0
-  steps.length.minus 1 > max-len!
-
-  # Recursive steps dataization.
-  #
-  # Attention! The object is for internal usage only, please
-  # don't use the object programmatically outside of `seq` object.
-  [index] > loop
-    if. > @
-      and.
-        index.lt ^.max-len
-        or.
-          (dataized (steps.at index)).as-bool
-          true
-      ^.loop
-        index.plus 1
-      steps.at index
-
+# Prints a simple message to the console. We can't validate
+# the output, so we just run it and see if it crashes.
+[] > writes-to-console
+  console.write > @
+    "Hello, console-test!\n"

--- a/tests/org/eolang/io/dead-input-tests.eo
+++ b/tests/org/eolang/io/dead-input-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > reads-empty-bytes

--- a/tests/org/eolang/io/dead-output-tests.eo
+++ b/tests/org/eolang/io/dead-output-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 dead-output.write 01-02-03 > [] > writes-bytes-to-nowhere

--- a/tests/org/eolang/io/input-length-tests.eo
+++ b/tests/org/eolang/io/input-length-tests.eo
@@ -28,7 +28,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > reads-all-bytes-and-returns-length

--- a/tests/org/eolang/io/malloc-as-output-test.eo
+++ b/tests/org/eolang/io/malloc-as-output-test.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > makes-an-output-from-malloc-and-writes

--- a/tests/org/eolang/io/stdout-test.eo
+++ b/tests/org/eolang/io/stdout-test.eo
@@ -20,33 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+package org.eolang
++tests
++package org.eolang.io
 +version 0.48.1
 
-# Sequence.
-# The object, when being dataized, dataizes all provided
-# "steps" (except the last one) and returns the last one.
-[steps] > seq
-  if. > @
-    steps.length.eq 0
-    true
-    loop 0
-  steps.length.minus 1 > max-len!
-
-  # Recursive steps dataization.
-  #
-  # Attention! The object is for internal usage only, please
-  # don't use the object programmatically outside of `seq` object.
-  [index] > loop
-    if. > @
-      and.
-        index.lt ^.max-len
-        or.
-          (dataized (steps.at index)).as-bool
-          true
-      ^.loop
-        index.plus 1
-      steps.at index
-
+# Prints a simple message to the console. We can't validate
+# the output, so we just run it and see if it crashes.
+[] > prints-to-console
+  stdout > @
+    "Hello, stdout-test!\n"

--- a/tests/org/eolang/io/tee-input-tests.eo
+++ b/tests/org/eolang/io/tee-input-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > reads-from-bytes-and-writes-to-memory

--- a/tests/org/eolang/malloc-tests.eo
+++ b/tests/org/eolang/malloc-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > writes-into-memory-of
@@ -61,8 +61,7 @@
       [f]
         malloc.of > second
           1
-          [s] >>
-            f.put (f.as-number.plus 1) > @
+          f.put (f.as-number.plus 1) > [s] >>
         seq > @
           *
             second
@@ -168,8 +167,7 @@
     [b]
       malloc.of > @
         10
-        [m] >>
-          b.put (m.size.eq 10) > @
+        b.put (m.size.eq 10) > [m] >>
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > malloc-writes-and-reads
@@ -229,8 +227,7 @@
     0
     malloc.of
       0
-      [m]
-        m.size > @
+      m.size > [m]
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > malloc-increases-block-size
@@ -263,3 +260,8 @@
   malloc.of > @
     1
     m.resized -1 > [m]
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > malloc-empty-is-empty
+  malloc.empty > @
+    m.size.eq 0 > [m]

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sin-zero

--- a/tests/org/eolang/math/integral-tests.eo
+++ b/tests/org/eolang/math/integral-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > calculates-lineal-integral

--- a/tests/org/eolang/math/numbers-tests.eo
+++ b/tests/org/eolang/math/numbers-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 (numbers *).max > [] > throws-on-taking-max-from-empty-sequence-of-numbers

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > random-with-seed

--- a/tests/org/eolang/math/real-tests.eo
+++ b/tests/org/eolang/math/real-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > abs-int-positive

--- a/tests/org/eolang/nan-tests.eo
+++ b/tests/org/eolang/nan-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > nan-not-eq-number

--- a/tests/org/eolang/negative-infinity-tests.eo
+++ b/tests/org/eolang/negative-infinity-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.46.0
++version 0.48.1
 
 # Equal to.
 [] > negative-infinity-is-equal-to-one-div-zero

--- a/tests/org/eolang/number-tests.eo
+++ b/tests/org/eolang/number-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > int-less-true

--- a/tests/org/eolang/positive-infinity-tests.eo
+++ b/tests/org/eolang/positive-infinity-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.46.0
++version 0.48.1
 
 # Equal to.
 [] > positive-infinity-is-equal-to-one-div-zero

--- a/tests/org/eolang/runtime-tests.eo
+++ b/tests/org/eolang/runtime-tests.eo
@@ -25,7 +25,7 @@
 +tests
 +package org.eolang
 +unlint abstract-decoratee
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > understands-this-correctly

--- a/tests/org/eolang/rust-tests.eo
+++ b/tests/org/eolang/rust-tests.eo
@@ -23,7 +23,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # Works with long names correctly.
 [] > rust-long-variable

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > seq-single-dataization-float-less

--- a/tests/org/eolang/string-tests.eo
+++ b/tests/org/eolang/string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > calculates-length-of-spaces-only

--- a/tests/org/eolang/structs/bytes-as-array-tests.eo
+++ b/tests/org/eolang/structs/bytes-as-array-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > converts-bytes-to-array

--- a/tests/org/eolang/structs/hash-code-of-tests.eo
+++ b/tests/org/eolang/structs/hash-code-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > hash-code-of-bools-is-number

--- a/tests/org/eolang/structs/list-tests.eo
+++ b/tests/org/eolang/structs/list-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > list-should-not-be-empty

--- a/tests/org/eolang/structs/map-tests.eo
+++ b/tests/org/eolang/structs/map-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > map-rebuilds-itself

--- a/tests/org/eolang/structs/range-of-ints-tests.eo
+++ b/tests/org/eolang/structs/range-of-ints-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > simple-range-of-ints-from-one-to-ten

--- a/tests/org/eolang/structs/range-tests.eo
+++ b/tests/org/eolang/structs/range-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > simple-range-from-one-to-ten

--- a/tests/org/eolang/structs/set-tests.eo
+++ b/tests/org/eolang/structs/set-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > set-rebuilds-itself

--- a/tests/org/eolang/switch-tests.eo
+++ b/tests/org/eolang/switch-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > switch-simple-case

--- a/tests/org/eolang/sys/os-tests.eo
+++ b/tests/org/eolang/sys/os-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > checks-os-family

--- a/tests/org/eolang/sys/posix-tests.eo
+++ b/tests/org/eolang/sys/posix-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > invokes-getpid-correctly

--- a/tests/org/eolang/sys/win32-tests.eo
+++ b/tests/org/eolang/sys/win32-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > returns-valid-win32-inet-addr-for-localhost

--- a/tests/org/eolang/try-tests.eo
+++ b/tests/org/eolang/try-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > catches-simple-exception

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > makes-tuple-through-special-syntax

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > matches-regex-against-the-pattern

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > prints-simple-string

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-with-string

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > text-slices-the-origin-string

--- a/tests/org/eolang/while-tests.eo
+++ b/tests/org/eolang/while-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.46.0
++version 0.48.1
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > while-dataizes-only-first-cycle


### PR DESCRIPTION
A new release `eo-0.48.1` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.