### PR TITLE
New release for eo-0.51.6

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.51.3</eo.version>
+    <eo.version>0.51.6</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Compile Time Instruction (CTI).
 #

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result
 # `bytes`.

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # This object must be used in order to terminate the program

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # The object is a FALSE boolean state.

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Directory in the file system.
 # Apparently every directory is a file.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The file object in the filesystem.
 [path] > file

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -29,7 +29,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -27,7 +27,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 
 # Temporary directory.
 # For Unix/MacOS uses the path supplied by the first environment variable

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Dead input is an input that reads from nowhere and always
 # returns empty sequence of bytes `--`.

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Dead output is an output that writes to nowhere.
 [] > dead-output

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -25,7 +25,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # The `stdin` object is a convenient wrapper on `console` object

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # The `stdout` object is convenient wrapper on `console` object which
 # uses it as output only and allows to print given argument to console as `string`:

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # The Euler's number.

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 
 # Counts integral from `a` to `b`.
 # Here `func` is integration function, `a` is an upper limit,

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # Returns an approximate PI number.

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 
 # Generates a pseudo-random number.
 [seed] > random

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Returns a floating point number.
 [num] > real

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -27,7 +27,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # Socket.

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Sequence.
 # The object, when being dataized, dataizes all provided

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Represents sequence of bytes as array.
 # Here `bts` is `bytes` objects, the return value is `tuple` where

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Hash code - the pseudo-unique float numeric
 # representation of an object.

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.
@@ -33,6 +33,10 @@
   # A check to determine if an object contains no elements or data.
   0.eq origin.length > is-empty
   # Returns a new list sorted via `.lt` method.
+  # @todo #3251:30min The object does not work. After moving `list` object
+  #  to eo-runtime this is the only method which does not work because it's quite
+  #  hard to implement properly, especially after big changes in EO semantic.
+  #  We need to get it done and write some tests for it.
   $ > sorted
 
   # Create a new list with this element added to the end of it.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.
@@ -96,6 +96,14 @@
     # or `false` if was not.
     # The `get` attribute returns either found object, or `error` if
     # the object wasn't found.
+    # @todo #3251:30min Find a way to link hash code and index of key.
+    #  Right now map is implemented as `tuple` of objects where every
+    #  element is composition of three entities: hash, key and value.
+    #  When we try to find an element in hash map by key (K1) we're
+    #  calculating hash of K1 (H1) and trying to find the entity where
+    #  `entity.hash` (H2) is equal to H1. This search is implemented by
+    #  simple reducing initial hash map `tuple` and obviously slow - O(n).
+    #  We need to find a way to get a right index of entity in hash map
     # `tuple` just by applying some simple operation on H1, similar to it's
     #  implemented in other programming languages. Then we'll get O(1) on
     #  `found` operation.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -25,7 +25,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which
@@ -43,22 +43,23 @@
 #
 # This object returns value of only first truly statement.
 [cases] > switch
-  cases.length > len!
+  (rec-case cases).self > found
   if. > @
-    len.eq 0
-    error "switch cases are empty"
-    case-at 0
-
-  # Take case by given index.
-  # If case key is true, return case value.
-  # Otherwise take next case.
-  [index] > case-at
-    cases.at index > case
-    if. > @
-      index.eq len
+    cases.length.eq 0
+    error "Switch cases are empty"
+    if.
+      true.eq found.match
+      found.value
       true
-      if.
-        case.at 0
-        case.at 1
-        case-at
-          index.plus 1
+
+  [tup] > rec-case
+    (rec-case tup.prev).self > previous
+    if. > @
+      and.
+        tup.length.gt 1
+        previous.match
+      previous
+      [] >>
+        $ > self
+        tup.value.prev.value > match!
+        tup.value.value > value

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -26,7 +26,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # Get environment variable as `string`.

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # Returns the system-dependent line separator string.

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -24,9 +24,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Represents the name of the operating system.
 [] > os

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Makes a Unix syscall by name with POSIX interface.
 # See https://filippo.io/linux-syscall-table/.

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 +unlint many-free-attributes
 
 # Makes a kernel32.dll function call by name.

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint unit-test-missing
 
 # The object is a TRUE boolean state.

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Try, catch and finally. This object helps catch errors created by the
 # `error` object. When being dataized, such objects will crash the problem.

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Regular expression in Perl format.
 # Here `pattern` is a string pattern.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # The sprintf object allows you to format and output text depending
 # on the arguments passed to it.

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -23,9 +23,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.51.3
++rt jvm org.eolang:eo-runtime:0.51.6
 +rt node eo2js-runtime:0.0.0
-+version 0.51.3
++version 0.51.6
 
 # Reads formatted input from a string.
 # This object has two free attributes:

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -28,7 +28,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.51.3
++version 0.51.6
 
 # Text.
 # A sequence of characters representing words, sentences, or data.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -23,7 +23,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:

--- a/tests/org/eolang/bool-tests.eo
+++ b/tests/org/eolang/bool-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/bytes-tests.eo
+++ b/tests/org/eolang/bytes-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/cti-tests.eo
+++ b/tests/org/eolang/cti-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/dataized-tests.eo
+++ b/tests/org/eolang/dataized-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/dir-tests.eo
+++ b/tests/org/eolang/fs/dir-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/file-tests.eo
+++ b/tests/org/eolang/fs/file-tests.eo
@@ -29,7 +29,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/path-tests.eo
+++ b/tests/org/eolang/fs/path-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/tmpdir-tests.eo
+++ b/tests/org/eolang/fs/tmpdir-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/go-tests.eo
+++ b/tests/org/eolang/go-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i16-tests.eo
+++ b/tests/org/eolang/i16-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i32-tests.eo
+++ b/tests/org/eolang/i32-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i64-tests.eo
+++ b/tests/org/eolang/i64-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/bytes-as-input-tests.eo
+++ b/tests/org/eolang/io/bytes-as-input-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-makes-an-input-from-bytes-and-reads

--- a/tests/org/eolang/io/console-tests.eo
+++ b/tests/org/eolang/io/console-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/tests/org/eolang/io/dead-input-tests.eo
+++ b/tests/org/eolang/io/dead-input-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-reads-empty-bytes

--- a/tests/org/eolang/io/dead-output-tests.eo
+++ b/tests/org/eolang/io/dead-output-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/input-length-tests.eo
+++ b/tests/org/eolang/io/input-length-tests.eo
@@ -28,7 +28,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/malloc-as-output-tests.eo
+++ b/tests/org/eolang/io/malloc-as-output-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/stdout-tests.eo
+++ b/tests/org/eolang/io/stdout-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/tests/org/eolang/io/tee-input-tests.eo
+++ b/tests/org/eolang/io/tee-input-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/malloc-tests.eo
+++ b/tests/org/eolang/malloc-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/integral-tests.eo
+++ b/tests/org/eolang/math/integral-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/numbers-tests.eo
+++ b/tests/org/eolang/math/numbers-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/real-tests.eo
+++ b/tests/org/eolang/math/real-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/nan-tests.eo
+++ b/tests/org/eolang/nan-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/negative-infinity-tests.eo
+++ b/tests/org/eolang/negative-infinity-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # Equal to.

--- a/tests/org/eolang/number-tests.eo
+++ b/tests/org/eolang/number-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/positive-infinity-tests.eo
+++ b/tests/org/eolang/positive-infinity-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # Equal to.

--- a/tests/org/eolang/runtime-tests.eo
+++ b/tests/org/eolang/runtime-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 +unlint unit-test-without-phi
 +unlint decorated-formation

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/string-tests.eo
+++ b/tests/org/eolang/string-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/bytes-as-array-tests.eo
+++ b/tests/org/eolang/structs/bytes-as-array-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/hash-code-of-tests.eo
+++ b/tests/org/eolang/structs/hash-code-of-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/list-tests.eo
+++ b/tests/org/eolang/structs/list-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/map-tests.eo
+++ b/tests/org/eolang/structs/map-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/range-of-ints-tests.eo
+++ b/tests/org/eolang/structs/range-of-ints-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/range-tests.eo
+++ b/tests/org/eolang/structs/range-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/set-tests.eo
+++ b/tests/org/eolang/structs/set-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/switch-tests.eo
+++ b/tests/org/eolang/switch-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/os-tests.eo
+++ b/tests/org/eolang/sys/os-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/posix-tests.eo
+++ b/tests/org/eolang/sys/posix-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/win32-tests.eo
+++ b/tests/org/eolang/sys/win32-tests.eo
@@ -26,7 +26,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/try-tests.eo
+++ b/tests/org/eolang/try-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -25,7 +25,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 +unlint wrong-sprintf-arguments
 

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -27,7 +27,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/while-tests.eo
+++ b/tests/org/eolang/while-tests.eo
@@ -24,7 +24,7 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.51.3
++version 0.51.6
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.


### PR DESCRIPTION
A new release `eo-0.51.6` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.