### PR TITLE
New release for eo-0.53.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.52.0</eo.version>
+    <eo.version>0.53.0</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -43,8 +43,7 @@
             <id>objects</id>
             <goals>
               <goal>register</goal>
-              <goal>assemble</goal>
-              <goal>lint</goal>
+              <goal>compile</goal>
               <goal>transpile</goal>
             </goals>
             <configuration>
@@ -58,9 +57,7 @@
             <phase>generate-test-sources</phase>
             <goals>
               <goal>register</goal>
-              <goal>deps</goal>
-              <goal>assemble</goal>
-              <goal>lint</goal>
+              <goal>compile</goal>
               <goal>transpile</goal>
             </goals>
             <configuration>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,
@@ -65,36 +67,33 @@
         "Can't convert non 2 length bytes to i16, bytes are %x"
         * $
 
-  # Equals to another object.
-  # A condition where two objects have the same value or content.
-  [b] > eq /org.eolang.bool
+  # Returns `org.eolang.true` if current sequence of bytes equals to another object.
+  # Before the actual comparison the object `b` is dataized.
+  [b] > eq ?
 
-  # Total number of bytes.
-  # The complete count of bytes used to represent data.
-  [] > size /org.eolang.number
+  # Returns total amount of current bytes as `org.eolang.number`.
+  [] > size ?
 
-  # Represents a sub-sequence inside the current one.
-  [start len] > slice /org.eolang.bytes
+  # Represents a sub-sequence of `org.eolang.bytes` inside the current one.
+  [start len] > slice ?
 
-  # Calculate the bitwise and operation.
-  [b] > and /org.eolang.bytes
+  # Calculate the bitwise AND operation and returns result as `org.eolang.bytes`.
+  [b] > and ?
 
-  # Calculate the bitwise or operation.
-  [b] > or /org.eolang.bytes
+  # Calculate the bitwise OR operation and returns result as `org.eolang.bytes`.
+  [b] > or ?
 
-  # Calculate the bitwise xor operation.
-  [b] > xor /org.eolang.bytes
+  # Calculate the bitwise XOR operation and returns result as `org.eolang.bytes`.
+  [b] > xor ?
 
-  # Calculate the bitwise not operation.
-  [] > not /org.eolang.bytes
+  # Calculate the bitwise NOT operation and returns result as `org.eolang.bytes`.
+  [] > not ?
 
   # Calculate the bitwise left shift.
   right x.neg > [x] > left
 
-  # Calculate the bitwise right shift.
-  [x] > right /org.eolang.bytes
+  # Calculate the bitwise right shift and returns result as `org.eolang.bytes`.
+  [x] > right ?
 
-  # Concatenation of two byte sequences:
-  # the current and the provided one,
-  # as a new sequence.
-  [b] > concat /org.eolang.bytes
+  # Concatenation of two byte sequences and returns result as `org.eolang.bytes`.
+  [b] > concat ?

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Compile Time Instruction (CTI).
 #

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result
 # `bytes`.

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,16 +1,18 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint rt-without-atoms
++unlint empty-object
 
 # This object must be used in order to terminate the program
 # due to an error. Just make a copy of it with any encapsulated object.
 # The first attempt to dataize it will lead to runtime error and program
 # termination. The only way to catch such an error is by using
 # the `try` object.
-[message] > error /org.eolang.error
+[message] > error ?

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # The object is a FALSE boolean state.

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # Directory in the file system.
 # Apparently every directory is a file.
@@ -28,15 +30,16 @@
 
     # Makes a directory together with all required
     # parent directories.
+    # Returns `org.eolang.true` object.
     #
     # Attention! The object is for internal usage only, please
     # don't use it programmatically outside of `dir` object.
-    [] > mkdir /org.eolang.true
+    [] > mkdir ?
 
   # Goes though all files in the directory, recursively
   # finding them with the `glob` provided.
-  # Returns `tuple` of all files in the directory.
-  [glob] > walk /org.eolang.tuple
+  # Returns `org.eolang.tuple` of all files in the directory.
+  [glob] > walk ?
 
   # Deletes directory and all files in it, recursively.
   # Returns the deleted directory.
@@ -75,11 +78,11 @@
             * file
 
     # Creates an empty temporary file in the current directory and
-    # returns absolute path to it as `string`.
+    # returns absolute path to it as `org.eolang.string`.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of the `dir` object.
-    [] > touch /org.eolang.string
+    [] > touch ?
 
   # Opens the file for I/O operations.
   # Since current file is a directory - returns an `error`.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The file object in the filesystem.
 [path] > file
@@ -15,11 +17,11 @@
   # Convert the `file` to the `path`.
   (QQ.fs.path path).determined > as-path
 
-  # Returns `true` if current file is a directory, returns `false` otherwise.
-  [] > is-directory /org.eolang.bool
+  # Returns `org.eolang.true` if current file is a directory, returns `org.eolang.false` otherwise.
+  [] > is-directory ?
 
-  # Returns `true` if file with current `path` exists in filesystem.
-  [] > exists /org.eolang.bool
+  # Returns `org.eolang.true` if file with current `path` exists in filesystem.
+  [] > exists ?
 
   # If current file exists - returns the file.
   # If current file does not exist - create an empty file
@@ -33,11 +35,11 @@
           touch
           ^
 
-    # Creates new empty file.
+    # Creates new empty file and returns `org.eolang.true`.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of `file` object.
-    [] > touch /org.eolang.true
+    [] > touch ?
 
   # If current file exists - deletes it and returns it.
   # If current file does not exist - just returns it.
@@ -50,14 +52,14 @@
           ^
         ^
 
-    # Deletes the file and returns `true`.
+    # Deletes the file and returns `org.eolang.true`.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of `file` object.
-    [] > delete /org.eolang.true
+    [] > delete ?
 
-  # Gets the file size and returns it in bytes.
-  [] > size /org.eolang.number
+  # Gets the file size in bytes and returns it as `org.eolang.number`.
+  [] > size ?
 
   # Move current file to `target`, making and returning a new `file` from it.
   [target] > moved
@@ -65,12 +67,12 @@
       file move
 
     # Tries to move file from `^.path` to `target`
-    # and returns path of moved file as `string`.
-    # Returns `error` is failed to move the file.
+    # and returns path of moved file as `org.eolang.string`.
+    # Returns `org.eolang.error` is failed to move the file.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of `file` object.
-    [] > move /org.eolang.string
+    [] > move ?
 
   # Opens the file.
   #
@@ -156,22 +158,22 @@
     #
     # Here file stream is open, then the stream is passed to `scope`,
     # then given `scope` is dataized and stream is closed.
-    # Returns `true` if there are no errors occurred while `scope`
-    # dataization, returns `error` otherwise.
+    # Returns `org.eolang.true` if there are no errors occurred while `scope`
+    # dataization, returns `org.eolang.error` otherwise.
     #
     # The object is stream-safe, which means that stream is closed anyway,
     # even if errors are occurred while `scope` dataization.
     #
     # Attention! The object is for internal usage only, please
     # don't use the object programmatically outside of the `file` object.
-    [] > process-file /org.eolang.true
+    [] > process-file ?
 
     # File stream.
     # The objects provides an API for using file as input or output.
     [] > file-stream
       # Read `size` amount of bytes from file input stream.
       # Returns new instance of `input-block` with `buffer` read from file, or
-      # returns `error` if access mode does not allow reading operations.
+      # returns `org.eolang.error` if access mode does not allow reading operations.
       [size] > read
         ((input-block --).read size).this > @
 
@@ -185,7 +187,7 @@
 
           # Read `size` amount of bytes from file input stream.
           # Returns new instance of `input-block` with `buffer` read from file, or
-          # returns `error` if provided access mode does not allow reading operations.
+          # returns `org.eolang.error` if provided access mode does not allow reading operations.
           [size] > read
             ^.^.read-bytes size > read-bytes!
             this. > @
@@ -201,11 +203,11 @@
                   read-bytes
                   input-block read-bytes
 
-        # Bytes read from file input stream
+        # Bytes, as `org.eolang.bytes`, read from file input stream.
         #
         # Attention! The object is for internal usage only, please
         # don't use the object programmatically outside of `file` object.
-        [size] > read-bytes /org.eolang.bytes
+        [size] > read-bytes ?
 
       # Write given `buffer` to file output stream.
       # Here `buffer` is either sequence of bytes or and object that can be
@@ -242,8 +244,8 @@
                   written-bytes buffer
                   output-block
 
-        # Bytes written to file output stream.
+        # Writes given `buffer` of bytes to file output stream and returns `org.eolang.true`.
         #
         # Attention! The object is for internal usage only, please
         # don't use the object programmatically outside of `file` object.
-        [buffer] > written-bytes /org.eolang.true
+        [buffer] > written-bytes ?

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.os
@@ -9,7 +7,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.file
 +alias org.eolang.sys.getenv
@@ -7,7 +5,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Temporary directory.
 # For Unix/MacOS uses the path supplied by the first environment variable
@@ -22,7 +22,7 @@
     dir
       file
         string
-          [] > os-tmp-dir!
+          [] >>!
             getenv "TMPDIR" > tmpdir!
             getenv "TMP" > tmp!
             getenv "TEMP" > temp!

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.
@@ -17,30 +19,30 @@
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
 
-  # Convert this `i16` to `i32`.
+  # Convert this `org.eolang.i16` to `org.eolang.i32` and return it.
   # The object is an atom because it's not possible to check what
   # bytes should be added from left so the number is valid.
   # The different bytes should be added if number is positive and negative.
-  [] > as-i32 /org.eolang.i32
+  [] > as-i32 ?
 
-  # Returns `true` if `$` < `x`.
-  # Here `x` must be an `i16` object.
+  # Returns `org.eolang.true` if `$` < `x`.
+  # Here `x` must be an `org.eolang.i16` object.
   as-i32.lt x.as-i16.as-i32 > [x] > lt
 
-  # Returns `true` if `$` <= `x`.
-  # Here `x` must be an `i16` object.
+  # Returns `org.eolang.true` if `$` <= `x`.
+  # Here `x` must be an `org.eolang.i16` object.
   as-i32.lte x.as-i16.as-i32 > [x] > lte
 
-  # Returns `true` if `$` > `x`.
-  # Here `x` must be an `i16` object.
+  # Returns `org.eolang.true` if `$` > `x`.
+  # Here `x` must be an `org.eolang.i16` object.
   as-i32.gt x.as-i16.as-i32 > [x] > gt
 
-  # Returns `true` if `$` >= `x`.
-  # Here `x` must be an `i16` object.
+  # Returns `org.eolang.true` if `$` >= `x`.
+  # Here `x` must be an `org.eolang.i16` object.
   as-i32.gte x.as-i16.as-i32 > [x] > gte
 
   # Multiplication of `$` and `x`.
-  # Here `x` must be an `i16` object.
+  # Here `x` must be an `org.eolang.i16` object.
   [x] > times
     (as-i32.times x.as-i16.as-i32).as-bytes > bts
     bts.slice 0 2 > left
@@ -55,7 +57,7 @@
         i16 right
 
   # Sum of `$` and `x`.
-  # Here `x` must be an `i16` object.
+  # Here `x` must be an `org.eolang.i16` object.
   [x] > plus
     (as-i32.plus x.as-i16.as-i32).as-bytes > bts
     bts.slice 0 2 > left
@@ -70,12 +72,12 @@
         i16 right
 
   # Subtraction between `$` and `x`.
-  # Here `x` must be an `i16` object.
+  # Here `x` must be an `org.eolang.i16` object.
   plus x.as-i16.neg > [x] > minus
 
   # Quotient of the division of `$` by `x`.
-  # Here `x` must be an `i16` object.
-  # An `error` is returned if or `x` is equal to 0.
+  # Here `x` must be an `org.eolang.i16` object.
+  # An `org.eolang.error` is returned if or `x` is equal to `0`.
   [x] > div
     x.as-i16 > x-as-i16
     (as-i32.div x-as-i16.as-i32).as-bytes > bts

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.
@@ -16,15 +18,15 @@
   times -1.as-i64.as-i32 > neg
   as-i64.as-number > as-number
 
-  # Convert this `i32` to `i64`.
+  # Convert this `org.eolang.i32` to `org.eolang.i64` and return it.
   # The object is an atom because it's not possible to check what
   # bytes should be added from left so the number is valid.
   # The different bytes should be added if number is positive and negative.
-  [] > as-i64 /org.eolang.i64
+  [] > as-i64 ?
 
-  # Convert this `i32` to `i16`.
-  # The `error` is returned if the `i32` number is more than
-  # max `i16` value `32767`.
+  # Convert this `org.eolang.i32` to `org.eolang.i16`.
+  # The `org.eolang.error` is returned if the `org.eolang.i32` number is more than
+  # max `org.eolang.i16` value `32767`.
   [] > as-i16
     (as-bytes.slice 0 2).as-bytes > left
     if. > @
@@ -37,24 +39,24 @@
           "Can't convert i32 number %d to i16 because it's out of i16 bounds"
           * as-i64.as-number
 
-  # Returns `true` if `$` < `x`.
-  # Here `x` must be an `i32` object.
+  # Returns `org.eolang.true` if `$` < `x`.
+  # Here `x` must be an `org.eolang.i32` object.
   as-i64.lt x.as-i32.as-i64 > [x] > lt
 
-  # Returns `true` if `$` <= `x`.
-  # Here `x` must be an `i32` object.
+  # Returns `org.eolang.true` if `$` <= `x`.
+  # Here `x` must be an `org.eolang.i32` object.
   as-i64.lte x.as-i32.as-i64 > [x] > lte
 
-  # Returns `true` if `$` > `x`.
-  # Here `x` must be an `i32` object.
+  # Returns `org.eolang.true` if `$` > `x`.
+  # Here `x` must be an `org.eolang.i32` object.
   as-i64.gt x.as-i32.as-i64 > [x] > gt
 
-  # Returns `true` if `$` >= `x`.
-  # Here `x` must be an `i32` object.
+  # Returns `org.eolang.true` if `$` >= `x`.
+  # Here `x` must be an `org.eolang.i32` object.
   as-i64.gte x.as-i32.as-i64 > [x] > gte
 
   # Multiplication of `$` and `x`.
-  # Here `x` must be an `i32` object.
+  # Here `x` must be an `org.eolang.i32` object.
   [x] > times
     (as-i64.times x.as-i32.as-i64).as-bytes > bts
     bts.slice 0 4 > left
@@ -69,7 +71,7 @@
         i32 right
 
   # Sum of `$` and `x`.
-  # Here `x` must be an `i32` object.
+  # Here `x` must be an `org.eolang.i32` object.
   [x] > plus
     (as-i64.plus x.as-i32.as-i64).as-bytes > bts
     bts.slice 0 4 > left
@@ -84,11 +86,11 @@
         i32 right
 
   # Subtraction between `$` and `x`.
-  # Here `x` must be an `i32` object.
+  # Here `x` must be an `org.eolang.i32` object.
   plus x.as-i32.neg > [x] > minus
 
   # Quotient of the division of `$` by `x`.
-  # Here `x` must be an `i32` object.
+  # Here `x` must be an `org.eolang.i32` object.
   # An `error` is returned if or `x` is equal to 0.
   [x] > div
     x.as-i32 > x-as-i32

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.
@@ -16,9 +18,9 @@
   times -1.as-i64 > neg
   as-i32.as-i16 > as-i16
 
-  # Convert this `i64` to `i32`.
-  # The `error` is returned if the `i64` number is more than
-  # max `i32` value `2147483647`.
+  # Convert this `org.eolang.i64` to `org.eolang.i32`.
+  # The `org.eolang.error` is returned if the `org.eolang.i64` number is more than
+  # max `org.eolang.i32` value `2147483647`.
   [] > as-i32
     (as-bytes.slice 0 4).as-bytes > left
     if. > @
@@ -31,11 +33,11 @@
           "Can't convert i64 number %d to i32 because it's out of i32 bounds"
           * as-number
 
-  # Convert this `i64` to `number` object.
-  [] > as-number /org.eolang.number
+  # Convert this `org.eolang.i64` to `org.eolang.number` object and return it.
+  [] > as-number ?
 
-  # Returns `true` if `$` < `x`.
-  # Here `x` must be an `i64` object.
+  # Returns `org.eolang.true` if `$` < `x`.
+  # Here `x` must be an `org.eolang.i64` object.
   [x] > lt
     x > value!
     0.as-i64.gt > @
@@ -43,32 +45,32 @@
         i64 value
 
   # Returns `true` if `$` <= `x`.
-  # Here `x` must be an `i64` object.
+  # Here `x` must be an `org.eolang.i64` object.
   [x] > lte
     x > value!
     or. > @
       lt value
       ^.eq value
 
-  # Returns `true` if `$` > `x`.
-  # Here `x` must be an `i64` object.
-  [x] > gt /org.eolang.bool
+  # Returns `org.eolang.true` if `$` > `x`.
+  # Here `x` must be an `org.eolang.i64` object.
+  [x] > gt ?
 
   # Returns `true` if `$` >= `x`.
-  # Here `x` must be an `i64` object.
+  # Here `x` must be an `org.eolang.i64` object.
   [x] > gte
     x > value!
     or. > @
       gt value
       ^.eq value
 
-  # Multiplication of `$` and `x`.
-  # Here `x` must be an `i64` object.
-  [x] > times /org.eolang.i64
+  # Multiplication of `$` and `x` as `org.eolang.i64`.
+  # Here `x` must be an `org.eolang.i64` object.
+  [x] > times ?
 
-  # Sum of `$` and `x`.
-  # Here `x` must be an `i64` object.
-  [x] > plus /org.eolang.i64
+  # Sum of `$` and `x` as `org.eolang.i64`
+  # Here `x` must be an `org.eolang.i64` object.
+  [x] > plus ?
 
   # Subtraction between `$` and `x`.
   # Here `x` must be an `i64` object.
@@ -76,7 +78,7 @@
     x > value!
     plus (i64 value).neg > @
 
-  # Quotient of the division of `$` by `x`.
-  # Here `x` must be an `i64` object.
-  # An `error` is returned if or `x` is equal to 0.
-  [x] > div /org.eolang.i64
+  # Quotient of the division of `$` by `x` as `org.eolang.i64`.
+  # Here `x` must be an `org.eolang.i64` object.
+  # An `org.eolang.error` is returned if or `x` is equal to 0.
+  [x] > div ?

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Dead input is an input that reads from nowhere and always
 # returns empty sequence of bytes `--`.

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Dead output is an output that writes to nowhere.
 [] > dead-output

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +alias org.eolang.sys.line-separator
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
 +unlint unit-test-missing
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `stdin` object is a convenient wrapper on `console` object
 # which is used as input only and allows to read the data from console.

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `stdout` object is convenient wrapper on `console` object which
 # uses it as output only and allows to print given argument to console as `string`:

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,11 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
++unlint decorated-formation
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may
@@ -81,7 +84,8 @@
   # Allocates block in memory of given `size`. After allocation the `size` zero bytes bytes are
   # written into memory.
   [size scope] > of
-    [] > @ /org.eolang.bytes
+    # Dataizes given `scope` and returns the result of the dataization as `org.eolang.bytes`.
+    [] > @ ?
 
     # Allocated block in memory that provides an API for writing and reading.
     [id] > allocated
@@ -89,13 +93,14 @@
       # Just get all the data from the allocated block in memory.
       read 0 size > get
 
-      # Returns size of allocated block in memory.
-      [] > size /org.eolang.number
+      # Returns size of allocated block in memory as `org.eolang.number`.
+      [] > size ?
 
       # Resizes allocated block in memory and returns `true`.
       # Here `new-size` must be positive `number`.
       # The `error` returned if failed to resize block in memory.
-      [new-size] > resized /org.eolang.malloc.of.allocated
+      # Returns `org.eolang.malloc.of.allocated` object.
+      [new-size] > resized ?
 
       # Reads the data from block in memory with with offset `source` and `length` and writes
       # to the block with offset `target`.
@@ -105,11 +110,13 @@
           target
           read source length
 
-      # Read `length` bytes with `offset` from the allocated block in memory.
-      [offset length] > read /org.eolang.bytes
+      # Read `length` bytes with `offset` from the allocated block in memory and return them
+      # as `org.eolang.bytes`.
+      [offset length] > read ?
 
-      # Write `data` with `offset` to the allocated block in memory.
-      [offset data] > write /org.eolang.true
+      # Write `data` with `offset` to the allocated block in memory
+      # and return `org.eolang.true`.
+      [offset data] > write ?
 
       # Put `object` into the allocated block in memory. The `object` is supposed to be dataizable.
       [object] > put

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -1,12 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++unlint rt-without-atoms
++unlint empty-object
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.
@@ -24,13 +26,13 @@
       $.times pi
       180.0
 
-  # Sine of current angle.
+  # Calculates sine of current angle and returns it as `org.eolang.number`.
   # Please note, that `sin` is calculated from the angle in radians.
-  [] > sin /org.eolang.number
+  [] > sin ?
 
-  # Cosine of current angle.
+  # Calculates cosine of current angle and returns it as `org.eolang.number`.
   # Please note, that `cos` is calculated from the angle in radians.
-  [] > cos /org.eolang.number
+  [] > cos ?
 
   # Tangent of current angle.
   # Please note, that `tan` is calculated from the angle in radians.

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
 +unlint unit-test-missing
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The Euler's number.
 # A fundamental mathematical constant approximately equal to 2.7182818284590452354.

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Counts integral from `a` to `b`.
 # Here `func` is integration function, `a` is an upper limit,

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Returns an approximate PI number.

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Generates a pseudo-random number.
 [seed] > random
@@ -41,6 +41,7 @@
     17 > const-3
     00-00-00-00-00-00-00-01 > one
     random time-seed > @
+    (posix "gettimeofday" *).output > timeval
     as-number. > time-seed
       plus.
         as-i64.
@@ -61,9 +62,7 @@
         if.
           os.is-windows
           (win32 "GetSystemTime" *).milliseconds
-          []
-            (posix "gettimeofday" *).output > timeval
-            plus. > @
-              timeval.tv-sec.times 1000
-              as-number.
-                timeval.tv-usec.as-i64.div 1000.as-i64
+          plus.
+            timeval.tv-sec.times 1000
+            as-number.
+              timeval.tv-usec.as-i64.div 1000.as-i64

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -1,18 +1,20 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.e
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # Returns a floating point number.
 [num] > real
   num > @
   # Returns Euler's number raised to the power of a `num`.
-  (QQ.math.real e).pow num > exp
+  (real e).pow num > exp
 
   # Calculate MOD.
   # An operation that finds the remainder after dividing one number by another.
@@ -44,19 +46,19 @@
       value
       value.neg
 
-  # Make `^.num` power `x`.
-  # An operation that raises ^.num (a number) to the power of x.
-  [x] > pow /org.eolang.number
+  # An operation that raises `^.num` (a number) to the power of `x` and returns the result as
+  # `org.eolang.number`.
+  [x] > pow ?
 
-  # Returns the positive square root of a `num`.
-  [] > sqrt /org.eolang.number
+  # Returns the positive square root of a `num` as `org.eolang.number`.
+  [] > sqrt ?
 
-  # Returns the natural logarithm `e` of a `num`.
-  [] > ln /org.eolang.number
+  # Returns the natural logarithm `e` of a `num` as `org.eolang.number`.
+  [] > ln ?
 
-  # Calculates arc cosine of a `num`.
-  [] > acos /org.eolang.number
+  # Calculates arc cosine of a `num` as `org.eolang.number`.
+  [] > acos ?
 
-  # Calculates arc sine of a `num`.
+  # Calculates arc sine of a `num` as `org.eolang.number`.
   # An operation that finds the angle whose sine is num.
-  [] > asin /org.eolang.number
+  [] > asin ?

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
@@ -7,7 +5,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Socket.

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,11 +1,13 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.
@@ -26,8 +28,8 @@
         eq positive-infinity
         eq negative-infinity
 
-  # Convert this `number` to `i64` object.
-  [] > as-i64 /org.eolang.i64
+  # Convert this `org.eolang.number` to `org.eolang.i64` object and return it.
+  [] > as-i64 ?
 
   # Returns true if `$` = `x` in terms of bytes.
   # Here `x` can be a `number` or any other object which
@@ -71,10 +73,10 @@
       lt value
       eq value
 
-  # Returns `true` if `$` > `x`.
+  # Returns `org.eolang.true` if `$` > `x`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > gt /org.eolang.bool
+  [x] > gt ?
 
   # Returns `true` if `$` > `x`.
   # Here `x` can be a `number` or any other object which
@@ -85,15 +87,15 @@
       gt value
       eq value
 
-  # Multiplication of `$` and `x`.
+  # Multiplication of `$` and `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > times /org.eolang.number
+  [x] > times ?
 
-  # Sum of `$` and `x`.
+  # Sum of `$` and `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > plus /org.eolang.number
+  [x] > plus ?
 
   # Difference between `$` and `x`.
   # Here `x` can be a `number` or any other object which
@@ -103,11 +105,12 @@
     plus > @
       (number value).neg
 
-  # Quotient of the division of `$` by `x`.
+  # Quotient of the division of `$` by `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > div /org.eolang.number
+  [x] > div ?
 
-  # The object rounds down the original `number`  to the nearest
-  # whole `number` that is less than or equal to the original one.
-  [] > floor /org.eolang.number
+  # The object rounds down the original `number` to the nearest
+  # whole `number` that is less than or equal to the original one
+  # and returns the result as `org.eolang.number`.
+  [] > floor ?

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Sequence.
 # The object, when being dataized, dataizes all provided

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Represents sequence of bytes as array.
 # Here `bts` is `bytes` objects, the return value is `tuple` where

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Hash code - the pseudo-unique float numeric
 # representation of an object.

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.
@@ -13,6 +13,10 @@
   # A check to determine if an object contains no elements or data.
   0.eq origin.length > is-empty
   # Returns a new list sorted via `.lt` method.
+  # @todo #3251:30min The object does not work. After moving `list` object
+  #  to eo-runtime this is the only method which does not work because it's quite
+  #  hard to implement properly, especially after big changes in EO semantic.
+  #  We need to get it done and write some tests for it.
   $ > sorted
 
   # Create a new list with this element added to the end of it.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.hash-code-of
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.
@@ -76,6 +76,14 @@
     # or `false` if was not.
     # The `get` attribute returns either found object, or `error` if
     # the object wasn't found.
+    # @todo #3251:30min Find a way to link hash code and index of key.
+    #  Right now map is implemented as `tuple` of objects where every
+    #  element is composition of three entities: hash, key and value.
+    #  When we try to find an element in hash map by key (K1) we're
+    #  calculating hash of K1 (H1) and trying to find the entity where
+    #  `entity.hash` (H2) is equal to H1. This search is implemented by
+    #  simple reducing initial hash map `tuple` and obviously slow - O(n).
+    #  We need to find a way to get a right index of entity in hash map
     # `tuple` just by applying some simple operation on H1, similar to it's
     #  implemented in other programming languages. Then we'll get O(1) on
     #  `found` operation.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Get environment variable as `string`.

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # Returns the system-dependent line separator string.

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -1,17 +1,20 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
-# Represents the name of the operating system.
+# Represents the current operating system.
 [] > os
   name > @
 
+  # Returns `org.eolang.true` if current OS belongs to `Windows` OS family.
   [] > is-windows
     name > os-name!
     and. > @
@@ -20,4 +23,5 @@
   ((regex "/linux/i").matches name).as-bool > is-linux
   ((regex "/mac/i").matches name).as-bool > is-macos
 
-  [] > name /org.eolang.string
+  # Returns the name of the current operation system as `org.eolang.string`.
+  [] > name ?

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -1,14 +1,19 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
++unlint decorated-formation
 
-# Makes a Unix syscall by name with POSIX interface.
-# See https://filippo.io/linux-syscall-table/.
+# Makes a Unix syscall by `name` with POSIX interface.
+# Here `args` is a `org.eolang.tuple` of arguments required for
+# the particular syscall.
+# See the linux syscall [table](https://filippo.io/linux-syscall-table) for more info.
 [name args] > posix
   0 > stdin-fileno
   1 > stdout-fileno
@@ -17,7 +22,9 @@
   6 > ipproto-tcp
   -1 > inaddr-none
 
-  [] > @ /org.eolang.sys.posix.return
+  # Makes an actual syscall to operating system
+  # Returns `org.eolang.sys.posix.return` object.
+  [] > @ ?
 
   [code output] > return
     $ > called

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -1,12 +1,15 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint many-free-attributes
++unlint rt-without-atoms
++unlint empty-object
++unlint decorated-formation
 
 # Makes a kernel32.dll function call by name.
 #
@@ -25,7 +28,9 @@
   -1 > inaddr-none
   02-02 > winsock-version-2-2
 
-  [] > @ /org.eolang.sys.win32.return
+  # Makes an actual function call to operating system
+  # Returns `org.eolang.sys.win32.return` object.
+  [] > @ ?
 
   [code output] > return
     $ > called

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # The object is a TRUE boolean state.

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,14 +1,27 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # Try, catch and finally. This object helps catch errors created by the
-# `error` object. When being dataized, such objects will crash the problem.
+# `org.eolang.error` object. When being dataized, such objects will crash the program.
 # Decorate them with `try` and errors will be caught by the `catch`
 # abstract object here and the enclosure of the `error` will be passed to it.
-[main catch finally] > try /org.eolang.bytes
+# When object `try` is dataized - it tries to dataize its `main` attribute.
+# If the error is occurred during the dataization - it caches it and tries
+# to dataize its `catch` attribute. After one the attributes is dataized - it just dataizes
+# its `finally` attribute and returns the result of dataization of `main` or `catch`
+# attribute as `org.eolang.bytes`.
+#
+# @todo #3648:30min Remove all `+unlint rt-without-atoms`, `+unlint empty-object`
+#  and `+unlit decorated-formation` metas from `eo-runtime`.
+#  These metas were added after we removed `@atom` attribute from XMIR.
+#  Now atoms have empty object with greek lambda as `@name` attribute. When these changes are fixed
+#  in `lints` repository we should update its version and remove all the possible `+unlint` metas.
+[main catch finally] > try ?

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,15 +1,18 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
++unlint decorated-formation
 
 # Regular expression in Perl format.
-# Here `pattern` is a string pattern.
-# It starts and ends with slash (e.g. "/(your-pattern)/"),
+# Here `expression` is a string pattern.
+# It starts and ends with slash (e.g. "/(your-expression)/"),
 # Also it can be specified by the flag option,
 # e.g.
 # ```
@@ -23,23 +26,31 @@
 # /s - Enables dotall mode.
 # /u - Enables Unicode-aware case folding.
 [expression] > regex
-  compiled > @
-
   # Compile regular expression into pattern.
-  # Compilation step is mandatory for usage of `regex` object.
-  # But since `regex` object decorates `compiled` object,
-  # it's not mandatory to write it in EO.
   # ```
   # (regex "/[a-z]+/").compiled.matches "hello"
   # (regex "/[a-z]+").matches "hello"
   # ```
-  # The two lines of code above works the same.
-  [] > compiled /org.eolang.txt.regex.pattern
+  # The two lines of code above works the same, but the usage of `.compiled`
+  # allows you utilize object cache in order to avoid double pattern compilation.
+  # ```
+  # regex "/[a-z]+/" > ptn1
+  # ptn1.matches "hey"                  # compiles regex
+  # ptn1.matches "hello"                # recompiles regex again
+  #
+  # (regex "/[a-z]+/").compiled > ptn2
+  # ptn2.matches "hey"                  # compiles regex
+  # ptn2.matches "hello"                # doesn't recompile regex
+  # ```
+  # Returns `org.eolang.txt.regex.pattern` object.
+  [] > @ ?
 
   # Regular expression compiled into pattern.
   # Here `serialized` is `bytes` which represents serialized structure in memory
   # that is built after compilation.
   [serialized] > pattern
+    $ > compiled
+
     # Returns `true` of given `txt` matches against
     # the provided regular expression pattern.
     (match txt).next.exists > [txt] > matches
@@ -49,12 +60,12 @@
       (matched-from-index 1 0).matched > next
 
       # Get `position`-th block matched from `start` position.
-      # If string subsequence is found - returns `matched` object,
-      # returns `not-matched` otherwise.
+      # If string subsequence is found - returns `org.eolang.txt.regex.pattern.match.matched`
+      # object, returns `org.eolang.txt.regex.pattern.match.not-matched` otherwise.
       #
       # Attention! The object is for internal usage only, please
       # don't use the object programmatically outside of `regex` object.
-      [position start] > matched-from-index /org.eolang.txt.regex.pattern.match.matched
+      [position start] > matched-from-index ?
 
       # Block matched the pattern.
       # Here:

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,14 +1,17 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
-# The sprintf object allows you to format and output text depending
-# on the arguments passed to it.
+# The `sprintf` object allows you to format and output text depending
+# on the arguments passed to it and return it as `org.eolang.string`.
+#
 # When arguments are processed - they're dataized and converted to objects
 # depending on next flags:
 # - %s - converts object to `string`
@@ -16,4 +19,4 @@
 # - %f - converts object to `float`
 # - %x - converts object to `bytes`
 # - %b - converts object to boolean, `true` or `false`.
-[format args] > sprintf /org.eolang.string
+[format args] > sprintf ?

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -1,19 +1,21 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.52.0
++rt jvm org.eolang:eo-runtime:0.53.0
 +rt node eo2js-runtime:0.0.0
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint rt-without-atoms
++unlint empty-object
 
 # Reads formatted input from a string.
 # This object has two free attributes:
 # 1. `format` - is a formatter string (e.g. "Hello, %s!")
 # 2. `read` - is a string where data exists (e.g. "Hello, John!")
-# returns a `tuple` of formatted values (e.g. * "John").
+# returns a `org.eolang.tuple` of formatted values (e.g. * "John").
 # Supported formatters are:
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
-[format read] > sscanf /org.eolang.tuple
+[format read] > sscanf ?

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
@@ -8,7 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Text.
 # A sequence of characters representing words, sentences, or data.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,9 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # The `while` object is very similar to a loop with a pre-condition.
 # Here's how you can use it:

--- a/tests/org/eolang/bool-tests.eo
+++ b/tests/org/eolang/bool-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/bytes-tests.eo
+++ b/tests/org/eolang/bytes-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/cti-tests.eo
+++ b/tests/org/eolang/cti-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/dataized-tests.eo
+++ b/tests/org/eolang/dataized-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/dir-tests.eo
+++ b/tests/org/eolang/fs/dir-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.dir
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/file-tests.eo
+++ b/tests/org/eolang/fs/file-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.file
 +alias org.eolang.fs.path
 +alias org.eolang.fs.tmpdir
@@ -9,7 +7,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/path-tests.eo
+++ b/tests/org/eolang/fs/path-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.fs.path
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/fs/tmpdir-tests.eo
+++ b/tests/org/eolang/fs/tmpdir-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.fs.tmpdir
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/go-tests.eo
+++ b/tests/org/eolang/go-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i16-tests.eo
+++ b/tests/org/eolang/i16-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i32-tests.eo
+++ b/tests/org/eolang/i32-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/i64-tests.eo
+++ b/tests/org/eolang/i64-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/bytes-as-input-tests.eo
+++ b/tests/org/eolang/io/bytes-as-input-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-makes-an-input-from-bytes-and-reads

--- a/tests/org/eolang/io/console-tests.eo
+++ b/tests/org/eolang/io/console-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.console
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/tests/org/eolang/io/dead-input-tests.eo
+++ b/tests/org/eolang/io/dead-input-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.dead-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-reads-empty-bytes

--- a/tests/org/eolang/io/dead-output-tests.eo
+++ b/tests/org/eolang/io/dead-output-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.dead-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/input-length-tests.eo
+++ b/tests/org/eolang/io/input-length-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.input-length
 +alias org.eolang.io.malloc-as-output
@@ -8,7 +6,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/malloc-as-output-tests.eo
+++ b/tests/org/eolang/io/malloc-as-output-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.malloc-as-output
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/io/stdout-tests.eo
+++ b/tests/org/eolang/io/stdout-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.stdout
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Prints a simple message to the console. We can't validate

--- a/tests/org/eolang/io/tee-input-tests.eo
+++ b/tests/org/eolang/io/tee-input-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.io.bytes-as-input
 +alias org.eolang.io.malloc-as-output
 +alias org.eolang.io.tee-input
@@ -7,7 +5,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/malloc-tests.eo
+++ b/tests/org/eolang/malloc-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.angle
 +alias org.eolang.math.pi
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/integral-tests.eo
+++ b/tests/org/eolang/math/integral-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.integral
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/numbers-tests.eo
+++ b/tests/org/eolang/math/numbers-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.numbers
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.random
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/math/real-tests.eo
+++ b/tests/org/eolang/math/real-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.math.e
 +alias org.eolang.math.pi
 +alias org.eolang.math.real
@@ -7,7 +5,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/nan-tests.eo
+++ b/tests/org/eolang/nan-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/negative-infinity-tests.eo
+++ b/tests/org/eolang/negative-infinity-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Equal to.

--- a/tests/org/eolang/number-tests.eo
+++ b/tests/org/eolang/number-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/positive-infinity-tests.eo
+++ b/tests/org/eolang/positive-infinity-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # Equal to.

--- a/tests/org/eolang/runtime-tests.eo
+++ b/tests/org/eolang/runtime-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 +unlint unit-test-without-phi
 +unlint decorated-formation

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/string-tests.eo
+++ b/tests/org/eolang/string-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/bytes-as-array-tests.eo
+++ b/tests/org/eolang/structs/bytes-as-array-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.bytes-as-array
 +alias org.eolang.structs.list
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/hash-code-of-tests.eo
+++ b/tests/org/eolang/structs/hash-code-of-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.hash-code-of
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/list-tests.eo
+++ b/tests/org/eolang/structs/list-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/map-tests.eo
+++ b/tests/org/eolang/structs/map-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.map
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/range-of-ints-tests.eo
+++ b/tests/org/eolang/structs/range-of-ints-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range-of-ints
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/range-tests.eo
+++ b/tests/org/eolang/structs/range-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.range
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/structs/set-tests.eo
+++ b/tests/org/eolang/structs/set-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.set
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/switch-tests.eo
+++ b/tests/org/eolang/switch-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/os-tests.eo
+++ b/tests/org/eolang/sys/os-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/posix-tests.eo
+++ b/tests/org/eolang/sys/posix-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.posix
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/sys/win32-tests.eo
+++ b/tests/org/eolang/sys/win32-tests.eo
@@ -1,12 +1,12 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.sys.os
 +alias org.eolang.sys.win32
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/try-tests.eo
+++ b/tests/org/eolang/try-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -1,11 +1,11 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -1,13 +1,14 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 +unlint wrong-sprintf-arguments
++unlint sprintf-without-formatters
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tests-prints-simple-string

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.sprintf
 +alias org.eolang.txt.sscanf
@@ -7,7 +5,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -1,5 +1,3 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +alias org.eolang.structs.list
 +alias org.eolang.txt.regex
 +alias org.eolang.txt.text
@@ -7,7 +5,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/while-tests.eo
+++ b/tests/org/eolang/while-tests.eo
@@ -1,10 +1,10 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.52.0
++version 0.53.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.


### PR DESCRIPTION
A new release `eo-0.53.0` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.