### PR TITLE
New release for eo-0.56.2

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.56.0</eo.version>
+    <eo.version>0.56.2</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,13 +1,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
-+unlint empty-object
 
 # This object must be used in order to terminate the program
 # due to an error. Just make a copy of it with any encapsulated object.

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,10 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint no-attribute-formation:11
 
 # The object is a FALSE boolean state.
 [] > false

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Directory in the file system.
 # Apparently every directory is a file.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The file object in the filesystem.
 [path] > file

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,10 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
-+unlint empty-object
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,9 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Returns a floating point number.
 [num] > real

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -13,10 +13,6 @@
   # A check to determine if an object contains no elements or data.
   0.eq origin.length > is-empty
   # Returns a new list sorted via `.lt` method.
-  # @todo #3251:30min The object does not work. After moving `list` object
-  #  to eo-runtime this is the only method which does not work because it's quite
-  #  hard to implement properly, especially after big changes in EO semantic.
-  #  We need to get it done and write some tests for it.
   $ > sorted
 
   # Create a new list with this element added to the end of it.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -76,14 +76,6 @@
     # or `false` if was not.
     # The `get` attribute returns either found object, or `error` if
     # the object wasn't found.
-    # @todo #3251:30min Find a way to link hash code and index of key.
-    #  Right now map is implemented as `tuple` of objects where every
-    #  element is composition of three entities: hash, key and value.
-    #  When we try to find an element in hash map by key (K1) we're
-    #  calculating hash of K1 (H1) and trying to find the entity where
-    #  `entity.hash` (H2) is equal to H1. This search is implemented by
-    #  simple reducing initial hash map `tuple` and obviously slow - O(n).
-    #  We need to find a way to get a right index of entity in hash map
     # `tuple` just by applying some simple operation on H1, similar to it's
     #  implemented in other programming languages. Then we'll get O(1) on
     #  `found` operation.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,12 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Represents the current operating system.
 [] > os

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Makes a Unix syscall by `name` with POSIX interface.
 # Here `args` is a `org.eolang.tuple` of arguments required for

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -1,13 +1,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint many-free-attributes
-+unlint empty-object
++unlint many-free-attributes:36
 
 # Makes a kernel32.dll function call by name.
 #

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,10 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint no-attribute-formation:11
 
 # The object is a TRUE boolean state.
 [] > true

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Try, catch and finally. This object helps catch errors created by the
 # `org.eolang.error` object. When being dataized, such objects will crash the program.
@@ -17,10 +16,4 @@
 # to dataize its `catch` attribute. After one the attributes is dataized - it just dataizes
 # its `finally` attribute and returns the result of dataization of `main` or `catch`
 # attribute as `org.eolang.bytes`.
-#
-# @todo #3648:30min Remove all `+unlint rt-without-atoms`, `+unlint empty-object`
-#  and `+unlit decorated-formation` metas from `eo-runtime`.
-#  These metas were added after we removed `@atom` attribute from XMIR.
-#  Now atoms have empty object with greek lambda as `@name` attribute. When these changes are fixed
-#  in `lints` repository we should update its version and remove all the possible `+unlint` metas.
 [main catch finally] > try ?

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Regular expression in Perl format.
 # Here `expression` is a string pattern.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # The `sprintf` object allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.0
++rt jvm org.eolang:eo-runtime:0.56.2
 +rt node eo2js-runtime:0.0.0
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint empty-object
 
 # Reads formatted input from a string.
 # This object has two free attributes:

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/tests/org/eolang/bool-tests.eo
+++ b/tests/org/eolang/bool-tests.eo
@@ -2,63 +2,62 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bool-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-bools
+  [] +> tests-compares-two-bools
     eq. > @
       true
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-true-as-bool
+  [] +> tests-true-as-bool
     true.as-bool > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-different-bool-types
+  [] +> tests-compares-two-different-bool-types
     not. > @
       eq.
         true
         42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-bool-to-bytes
+  [] +> tests-compares-bool-to-bytes
     and. > @
       true.eq 01-
       false.eq 00-
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-bool-to-string
+  [] +> tests-compares-bool-to-string
     and. > @
       true.eq "\001"
       false.eq "\000"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-bool-to-bytes-reverse
+  [] +> tests-compares-bool-to-bytes-reverse
     and. > @
       01-.as-bytes.eq true
       00-.as-bytes.eq false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-true-not-is-false
+  [] +> tests-true-not-is-false
     eq. > @
       true.not
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-true-and-false-is-false
+  [] +> tests-true-and-false-is-false
     not. > @
       and.
         true
         false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-forks-on-true-condition
+  [] +> tests-forks-on-true-condition
     eq. > @
       if.
         5.eq 5
@@ -67,7 +66,7 @@
       123
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-forks-on-false-condition
+  [] +> tests-forks-on-false-condition
     eq. > @
       if.
         5.eq 8

--- a/tests/org/eolang/bytes-tests.eo
+++ b/tests/org/eolang/bytes-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bytes-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-takes-part-of-bytes
+  [] +> tests-takes-part-of-bytes
     eq. > @
       slice.
         20-1F-EE-B5-90
@@ -19,7 +19,7 @@
       1F-EE-B5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-size-of-part-is-correct
+  [] +> tests-size-of-part-is-correct
     eq. > @
       size.
         slice.
@@ -29,42 +29,42 @@
       3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-counts-size-of-bytes
+  [] +> tests-counts-size-of-bytes
     eq. > @
       size.
         F1-20-5F-EC-B5-90-32
       7
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-turns-bytes-into-a-string
+  [] +> tests-turns-bytes-into-a-string
     eq. > @
       string
         E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21
       "你好, друг!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-zero
+  [] +> tests-left-zero
     not. > @
       eq.
         0.as-bytes.left 1
         -1.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-with-zero
+  [] +> tests-left-with-zero
     not. > @
       eq.
         2.as-bytes.left 0
         -3.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-with-odd-neg
+  [] +> tests-left-with-odd-neg
     not. > @
       eq.
         -17.as-bytes.left 1
         33.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-with-minus-one
+  [] +> tests-left-with-minus-one
     eq. > @
       eq.
         -1.as-bytes.left 3
@@ -73,55 +73,55 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (-18.left 2).eq 71.not.
-  [] > tests-left-with-even-neg
+  [] +> tests-left-with-even-neg
     eq. > @
       FF-FF-FF-FF-FF-FF-FF-EE.left 2
       00-00-00-00-00-00-00-47.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-with-even-plus
+  [] +> tests-left-with-even-plus
     not. > @
       eq.
         4.as-bytes.left 3
         -33.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-left-with-odd-plus
+  [] +> tests-left-with-odd-plus
     not. > @
       eq.
         5.as-bytes.left 3
         -41.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-zero
+  [] +> tests-right-with-zero
     not. > @
       eq.
         0.as-bytes.right 2
         -1.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-odd-neg
+  [] +> tests-right-with-odd-neg
     not. > @
       eq.
         -37.as-bytes.right 3
         4.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-minus-one
+  [] +> tests-right-with-minus-one
     not. > @
       eq.
         -1.as-bytes.right 4
         0.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-even-neg
+  [] +> tests-right-with-even-neg
     not. > @
       eq.
         -38.as-bytes.right 1
         18.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-even-plus
+  [] +> tests-right-with-even-plus
     eq. > @
       eq.
         36.as-bytes.right 2
@@ -129,14 +129,14 @@
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-with-odd-plus
+  [] +> tests-right-with-odd-plus
     not. > @
       eq.
         37.as-bytes.right 3
         -5.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-and-with-zero
+  [] +> tests-and-with-zero
     not. > @
       eq.
         and.
@@ -145,14 +145,14 @@
         -1.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-and-with-two-neg
+  [] +> tests-and-with-two-neg
     not. > @
       eq.
         -6.as-bytes.and -4.as-bytes
         7.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-and-with-two-plus
+  [] +> tests-and-with-two-plus
     not. > @
       eq.
         and.
@@ -161,91 +161,91 @@
         -1.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-and-with-one-neg-one-plus
+  [] +> tests-and-with-one-neg-one-plus
     not. > @
       eq.
         -7.as-bytes.and 7.as-bytes
         -2.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-or-with-zero
+  [] +> tests-or-with-zero
     not. > @
       eq.
         -11.as-bytes.or 0.as-bytes
         10.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-or-with-two-neg
+  [] +> tests-or-with-two-neg
     not. > @
       eq.
         -27.as-bytes.or -13.as-bytes
         8.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-or-with-two-plus
+  [] +> tests-or-with-two-plus
     not. > @
       eq.
         5.as-bytes.or 14.as-bytes
         -16.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-or-with-one-neg-one-plus
+  [] +> tests-or-with-one-neg-one-plus
     not. > @
       eq.
         -7.as-bytes.or 23.as-bytes
         0.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-xor-with-zero
+  [] +> tests-xor-with-zero
     not. > @
       eq.
         0.as-bytes.xor 29.as-bytes
         -30.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-xor-with-two-neg
+  [] +> tests-xor-with-two-neg
     not. > @
       eq.
         -1.as-bytes.xor -123.as-bytes
         -123.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-xor-with-two-plus
+  [] +> tests-xor-with-two-plus
     not. > @
       eq.
         53.as-bytes.xor 24.as-bytes
         -46.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-xor-with-one-neg-one-plus
+  [] +> tests-xor-with-one-neg-one-plus
     not. > @
       eq.
         -36.as-bytes.xor 43.as-bytes
         8.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-not-with-zero
+  [] +> tests-not-with-zero
     not. > @
       eq.
         0.as-bytes
         0.as-bytes.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-not-with-neg
+  [] +> tests-not-with-neg
     not. > @
       eq.
         -1.as-bytes
         -1.as-bytes.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-not-with-plus
+  [] +> tests-not-with-plus
     not. > @
       eq.
         53.as-bytes
         53.as-bytes.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-conjunction-of-bytes
+  [] +> tests-conjunction-of-bytes
     eq. > @
       a.and b
       02-23-C0-05-5E-70-10
@@ -253,7 +253,7 @@
     12-33-C1-B5-5E-71-55 > b
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-written-in-several-lines
+  [] +> tests-written-in-several-lines
     eq. > @
       size.
         CA-FE-
@@ -261,7 +261,7 @@
       4
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-bitwise-works
+  [] +> tests-bitwise-works
     eq. > @
       as-number.
         and.
@@ -270,7 +270,7 @@
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-convertible-to-bool
+  [] +> tests-convertible-to-bool
     not. > @
       eq.
         01-.as-bool
@@ -278,7 +278,7 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (-127.or 127).eq -1.
-  [] > tests-bitwise-works-negative
+  [] +> tests-bitwise-works-negative
     eq. > @
       as-number.
         or.
@@ -287,7 +287,7 @@
       FF-FF-FF-FF-FF-FF-FF-FF
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concatenation-of-bytes
+  [] +> tests-concatenation-of-bytes
     eq. > @
       a.concat b
       02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
@@ -295,7 +295,7 @@
     12-33-C1-B5-5E-71-55 > b
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concat-bools-as-bytes
+  [] +> tests-concat-bools-as-bytes
     eq. > @
       concat.
         b1
@@ -305,7 +305,7 @@
     false.as-bytes > b2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concat-with-empty
+  [] +> tests-concat-with-empty
     eq. > @
       concat.
         05-5E-78
@@ -313,7 +313,7 @@
       05-5E-78
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concat-empty-with
+  [] +> tests-concat-empty-with
     eq. > @
       concat.
         --
@@ -321,7 +321,7 @@
       05-5E-78
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concat-empty
+  [] +> tests-concat-empty
     eq. > @
       concat.
         --
@@ -329,7 +329,7 @@
       --
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concat-strings
+  [] +> tests-concat-strings
     eq. > @
       string s-bytes
       "hello world"
@@ -339,94 +339,94 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (2397719729.xor 4294967295).eq 1897247566.
-  [] > tests-xor-works
+  [] +> tests-xor-works
     eq. > @
       00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
       00-00-00-00-71-15-B3-4E
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-one-xor-one-as-number
+  [] +> tests-one-xor-one-as-number
     eq. > @
       (1.as-bytes.xor 1.as-bytes).as-number
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (2397719729.or -4294967296).eq -1897247567.
-  [] > tests-or-neg-bytes-with-leading-zeroes
+  [] +> tests-or-neg-bytes-with-leading-zeroes
     eq. > @
       00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-8E-EA-4C-B1
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (2397719729.and -4294967296).eq 0.
-  [] > tests-and-neg-bytes-as-number-with-leading-zeroes
+  [] +> tests-and-neg-bytes-as-number-with-leading-zeroes
     eq. > @
       (00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00).as-number
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (2397719729.xor -4294967296).eq -1897247567.
-  [] > tests-xor-neg-bytes-with-leading-zeroes
+  [] +> tests-xor-neg-bytes-with-leading-zeroes
     eq. > @
       00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-8E-EA-4C-B1
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (4294967295.or -4294967296).eq -1.
-  [] > tests-or-neg-bytes-without-leading-zeroes
+  [] +> tests-or-neg-bytes-without-leading-zeroes
     eq. > @
       00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
       FF-FF-FF-FF-FF-FF-FF-FF
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (4294967295.and -4294967296).eq 0.
-  [] > tests-and-neg-bytes-as-number-without-leading-zeroes
+  [] +> tests-and-neg-bytes-as-number-without-leading-zeroes
     eq. > @
       (00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00).as-number
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (4294967295.xor -4294967296).eq -1.
-  [] > tests-xor-neg-bytes-as-number-without-leading-zeroes
+  [] +> tests-xor-neg-bytes-as-number-without-leading-zeroes
     eq. > @
       (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
       FF-FF-FF-FF-FF-FF-FF-FF
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-or-neg-bytes-as-number-with-zero
+  [] +> tests-or-neg-bytes-as-number-with-zero
     eq. > @
       (-4294967296.as-bytes.or 0.as-bytes).as-number
       -4294967296
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (-4294967296L.or 1).eq -4294967295L.
-  [] > tests-or-neg-bytes-with-one
+  [] +> tests-or-neg-bytes-with-one
     eq. > @
       FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
       FF-FF-FF-FF-00-00-00-01
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-bytes-of-wrong-size-as-number
+  [] +> throws-on-bytes-of-wrong-size-as-number
     01-01-01-01.as-number > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-bytes-of-wrong-size-as-i64
+  [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-bytes-converts-to-i64
+  [] +> tests-bytes-converts-to-i64
     eq. > @
       00-00-00-00-00-00-00-2A.as-i64
       42.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-bytes-converts-to-i64-and-back
+  [] +> tests-bytes-converts-to-i64-and-back
     eq. > @
       00-00-00-00-00-00-00-33.as-i64.as-bytes
       00-00-00-00-00-00-00-33
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
+  [] +> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
     not. > @
       eq.
         00-00-00-00-00-00-00-2A.as-i64.as-bytes

--- a/tests/org/eolang/cti-tests.eo
+++ b/tests/org/eolang/cti-tests.eo
@@ -2,10 +2,9 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 +unlint cti
 +unlint incorrect-unlint
 +unlint unlint-non-existing-defect
@@ -13,7 +12,7 @@
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > cti-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tests-just-prints-warning
+  [] +> tests-tests-just-prints-warning
     eq. > @
       cti
         2.times 2

--- a/tests/org/eolang/dataized-tests.eo
+++ b/tests/org/eolang/dataized-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > dataized-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-dataized-does-not-do-recalculation
+  [] +> tests-dataized-does-not-do-recalculation
     eq. > @
       malloc.for
         0
@@ -27,7 +27,7 @@
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-dataizes-as-bytes-behaves-as-exclamationed
+  [] +> tests-dataizes-as-bytes-behaves-as-exclamationed
     seq > @
       *
         cached1

--- a/tests/org/eolang/fs/dir-tests.eo
+++ b/tests/org/eolang/fs/dir-tests.eo
@@ -4,22 +4,22 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > dir-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-makes-new-directory
+  [] +> tests-makes-new-directory
     and. > @
       d.exists
       d.is-directory
     (tmpdir.tmpfile.deleted.as-path.resolved "foo-new").as-dir.made > d
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-deletes-empty-directory
+  [] +> tests-deletes-empty-directory
     tmpdir
     .tmpfile
     .deleted
@@ -33,13 +33,13 @@
     .not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-opening-directory
+  [] +> throws-on-opening-directory
     tmpdir.open > @
       "w"
       true > [d]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-deletes-directory-with-files-recursively
+  [] +> tests-deletes-directory-with-files-recursively
     and. > @
       and.
         and.
@@ -54,7 +54,7 @@
     d.tmpfile > second
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-deletes-directory-with-file-and-dir
+  [] +> tests-deletes-directory-with-file-and-dir
     and. > @
       and.
         and.
@@ -71,7 +71,7 @@
     d.tmpfile > f
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-walks-recursively
+  [] +> tests-walks-recursively
     seq > @
       *
         (d.resolved "foo/bar").as-dir.made

--- a/tests/org/eolang/fs/file-tests.eo
+++ b/tests/org/eolang/fs/file-tests.eo
@@ -7,57 +7,57 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > file-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-check-if-current-directory-is-directory
+  [] +> tests-check-if-current-directory-is-directory
     (file ".").is-directory > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-check-if-absent-file-does-not-exist
+  [] +> tests-check-if-absent-file-does-not-exist
     (file "absent.txt").exists.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-self-after-deleting
+  [] +> tests-returns-self-after-deleting
     temp.deleted.path.eq temp.path > @
     tmpdir.tmpfile > temp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-self-after-touching
+  [] +> tests-returns-self-after-touching
     temp.deleted.touched.path.eq temp.path > @
     tmpdir.tmpfile > temp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-file-does-not-exist-after-deleting
+  [] +> tests-checks-file-does-not-exist-after-deleting
     tmpdir.tmpfile.deleted.exists.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-touches-a-file
+  [] +> tests-touches-a-file
     tmpdir.tmpfile.deleted.touched.exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-measures-empty-file-after-touching
+  [] +> tests-measures-empty-file-after-touching
     tmpdir.tmpfile.deleted.touched.size.eq 0 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-fail-on-double-touching
+  [] +> tests-does-not-fail-on-double-touching
     tmpdir.tmpfile.deleted.touched.touched.exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-fail-on-double-deleting
+  [] +> tests-does-not-fail-on-double-deleting
     tmpdir.tmpfile.deleted.deleted.exists.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-an-error-on-touching-temp-file-in-absent-dir
+  [] +> throws-an-error-on-touching-temp-file-in-absent-dir
     (tmpdir.as-path.resolved "foo").as-dir.tmpfile > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-and-touches
+  [] +> tests-resolves-and-touches
     seq > @
       *
         resolved.deleted.made
@@ -72,7 +72,7 @@
     resolved.tmpfile > f
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-moves-a-file
+  [] +> tests-moves-a-file
     and. > @
       (temp.moved dest).exists
       temp.exists.not
@@ -82,7 +82,7 @@
       * temp.path
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-opening-with-wrong-mode
+  [] +> throws-on-opening-with-wrong-mode
     tmpdir
     .tmpfile
     .open > @
@@ -90,7 +90,7 @@
       f > [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-reading-from-not-existed-file
+  [] +> throws-on-reading-from-not-existed-file
     tmpdir
     .tmpfile
     .deleted
@@ -99,7 +99,7 @@
       f > [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-reading-or-writing-from-not-existed-file
+  [] +> throws-on-reading-or-writing-from-not-existed-file
     tmpdir
     .tmpfile
     .deleted
@@ -108,7 +108,7 @@
       f > [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-touches-absent-file-on-opening-for-writing
+  [] +> tests-touches-absent-file-on-opening-for-writing
     tmpdir
     .tmpfile
     .deleted
@@ -118,7 +118,7 @@
     .exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-touches-absent-file-on-opening-for-appending
+  [] +> tests-touches-absent-file-on-opening-for-appending
     tmpdir
     .tmpfile
     .deleted
@@ -128,7 +128,7 @@
     .exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-touches-absent-file-on-opening-for-writing-or-reading
+  [] +> tests-touches-absent-file-on-opening-for-writing-or-reading
     tmpdir
     .tmpfile
     .deleted
@@ -138,7 +138,7 @@
     .exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-touches-absent-file-on-opening-for-reading-or-appending
+  [] +> tests-touches-absent-file-on-opening-for-reading-or-appending
     tmpdir
     .tmpfile
     .deleted
@@ -148,7 +148,7 @@
     .exists > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-writes-data-to-file
+  [] +> tests-writes-data-to-file
     tmpdir
     .tmpfile
     .open
@@ -158,7 +158,7 @@
     .eq 12 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-appending-data-to-file
+  [] +> tests-appending-data-to-file
     tmpdir
     .tmpfile
     .open
@@ -171,7 +171,7 @@
     .eq 13 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-truncates-file-opened-for-writing
+  [] +> tests-truncates-file-opened-for-writing
     tmpdir
     .tmpfile
     .open
@@ -184,7 +184,7 @@
     .eq 0 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-truncates-file-opened-for-writing-or-reading
+  [] +> tests-truncates-file-opened-for-writing-or-reading
     tmpdir
     .tmpfile
     .open
@@ -197,7 +197,7 @@
     .eq 0 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-truncate-file-opened-for-appending
+  [] +> tests-does-not-truncate-file-opened-for-appending
     tmpdir
     .tmpfile
     .open
@@ -210,7 +210,7 @@
     .eq 12 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-truncate-file-opened-for-reading-or-appending
+  [] +> tests-does-not-truncate-file-opened-for-reading-or-appending
     tmpdir
     .tmpfile
     .open
@@ -223,7 +223,7 @@
     .eq 12 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-truncate-file-opened-for-reading
+  [] +> tests-does-not-truncate-file-opened-for-reading
     tmpdir
     .tmpfile
     .open
@@ -236,7 +236,7 @@
     .eq 12 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-writing-with-wrong-mode
+  [] +> throws-on-writing-with-wrong-mode
     tmpdir
     .tmpfile
     .open > @
@@ -244,7 +244,7 @@
       f.write "Hello" > [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-file
+  [] +> tests-reads-from-file
     malloc
     .of
       12
@@ -265,7 +265,7 @@
     .eq "Hello, world" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-reading-from-file-with-wrong-mode
+  [] +> throws-on-reading-from-file-with-wrong-mode
     tmpdir
     .tmpfile
     .open > @
@@ -273,7 +273,7 @@
       f.read 12 > [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-file-from-different-instances
+  [] +> tests-reads-from-file-from-different-instances
     seq * > @
       temp.open
         "w"
@@ -294,7 +294,7 @@
     temp.path > src
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-writes-to-file-from-different-instances
+  [] +> tests-writes-to-file-from-different-instances
     seq > @
       *
         temp
@@ -323,7 +323,7 @@
     temp.path > src
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-file-sequentially
+  [] +> tests-reads-from-file-sequentially
     malloc
     .of
       5
@@ -345,7 +345,7 @@
     .eq "world" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-writes-to-file-sequentially
+  [] +> tests-writes-to-file-sequentially
     tmpdir
     .tmpfile
     .open

--- a/tests/org/eolang/fs/path-tests.eo
+++ b/tests/org/eolang/fs/path-tests.eo
@@ -4,15 +4,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > path-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-determines-separator-depending-on-os
+  [] +> tests-determines-separator-depending-on-os
     eq. > @
       path.separator
       if.
@@ -21,13 +20,13 @@
         path.posix.separator
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-detects-absolute-posix-path
+  [] +> tests-detects-absolute-posix-path
     and. > @
       (path.posix "/var/www/html").is-absolute
       (path.posix "foo/bar/baz").is-absolute.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-detects-absolute-win32-path
+  [] +> tests-detects-absolute-win32-path
     and. > @
       and.
         (path.win32 "C:\\Windows\\Users").is-absolute
@@ -35,151 +34,151 @@
       (path.win32 "temp\\var").is-absolute.not
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-posix-path
+  [] +> tests-normalizes-posix-path
     eq. > @
       (path.posix "/foo/bar/.//./baz//../x/").normalized
       "/foo/bar/x/"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-posix-relative-path
+  [] +> tests-normalizes-posix-relative-path
     eq. > @
       (path.posix "../../foo/./bar/../x/../y").normalized
       "../../foo/y"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-empty-posix-path-to-current-dir
+  [] +> tests-normalizes-empty-posix-path-to-current-dir
     eq. > @
       (path.posix "").normalized
       "."
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-path-to-root
+  [] +> tests-normalizes-path-to-root
     eq. > @
       (path.posix "/foo/bar/baz/../../../../").normalized
       "/"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-absolute-win32-path-without-drive
+  [] +> tests-normalizes-absolute-win32-path-without-drive
     eq. > @
       (path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\").normalized
       "\\Windows\\App\\Local\\"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-absolute-win32-path-with-drive
+  [] +> tests-normalizes-absolute-win32-path-with-drive
     eq. > @
       (path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal").normalized
       "C:\\Users\\AppLocal"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-relative-win32-path
+  [] +> tests-normalizes-relative-win32-path
     eq. > @
       (path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\").normalized
       "..\\..\\foo\\x\\y\\"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-empty-win32-driveless-path-to-current-dir
+  [] +> tests-normalizes-empty-win32-driveless-path-to-current-dir
     eq. > @
       (path.win32 "").normalized
       "."
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-win32-path-down-to-drive-with-separator
+  [] +> tests-normalizes-win32-path-down-to-drive-with-separator
     eq. > @
       (path.win32 "C:\\Windows\\..").normalized
       "C:\\"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-win32-path-down-to-drive-without-separator
+  [] +> tests-normalizes-win32-path-down-to-drive-without-separator
     eq. > @
       (path.win32 "C:hello\\..").normalized
       "C:"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-normalizes-win32-path-with-replacing-slashes
+  [] +> tests-normalizes-win32-path-with-replacing-slashes
     eq. > @
       (path.win32 "/var/www/../html/").normalized
       "\\var\\html\\"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-posix-absolute-path-against-other-absolute-path
+  [] +> tests-resolves-posix-absolute-path-against-other-absolute-path
     eq. > @
       (path.posix "/var/temp").resolved "/www/html"
       "/www/html"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-posix-absolute-path-against-other-relative-path
+  [] +> tests-resolves-posix-absolute-path-against-other-relative-path
     eq. > @
       (path.posix "/var/temp").resolved "./www/html"
       "/var/temp/www/html"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-posix-relative-path-against-other-absolute-path
+  [] +> tests-resolves-posix-relative-path-against-other-absolute-path
     eq. > @
       (path.posix "./var/temp").resolved "/www/html"
       "/www/html"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-posix-relative-path-against-other-relative-path
+  [] +> tests-resolves-posix-relative-path-against-other-relative-path
     eq. > @
       (path.posix "./var/temp").resolved "../www/html"
       "var/www/html"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-relative-path-against-other-relative-path
+  [] +> tests-resolves-win32-relative-path-against-other-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved ".\\..\\x"
       "temp\\x"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-relative-path-against-other-drive-relative-path
+  [] +> tests-resolves-win32-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved "C:\\Windows\\Users"
       "C:\\Windows\\Users"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-relative-path-against-other-root-relative-path
+  [] +> tests-resolves-win32-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 ".\\temp\\var").resolved "\\Windows\\Users"
       "\\Windows\\Users"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-drive-relative-path-against-other-relative-path
+  [] +> tests-resolves-win32-drive-relative-path-against-other-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved ".\\var\\temp"
       "C:\\users\\local\\var\\temp"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
+  [] +> tests-resolves-win32-drive-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved "D:\\local\\var"
       "D:\\local\\var"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-drive-relative-path-against-other-root-relative-path
+  [] +> tests-resolves-win32-drive-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 "C:\\users\\local").resolved "\\local\\var"
       "C:\\local\\var"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-root-relative-path-against-other-relative-path
+  [] +> tests-resolves-win32-root-relative-path-against-other-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved ".\\hello\\var"
       "\\users\\local\\hello\\var"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-root-relative-path-against-other-drive-relative-path
+  [] +> tests-resolves-win32-root-relative-path-against-other-drive-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved "D:\\hello\\var"
       "D:\\hello\\var"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-resolves-win32-root-relative-path-against-other-root-relative-path
+  [] +> tests-resolves-win32-root-relative-path-against-other-root-relative-path
     eq. > @
       (path.win32 "\\users\\local").resolved "\\hello\\var"
       "\\hello\\var"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-takes-valid-basename
+  [] +> tests-takes-valid-basename
     eq. > @
       basename.
         path.joined
@@ -187,7 +186,7 @@
       "hello.eo"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-empty-basename-from-path-ended-with-separator
+  [] +> tests-returns-empty-basename-from-path-ended-with-separator
     eq. > @
       basename.
         path.joined
@@ -195,19 +194,19 @@
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-base-with-backslash-in-path-on-posix
+  [] +> tests-returns-base-with-backslash-in-path-on-posix
     eq. > @
       (path.posix "/var/www/html/foo\\bar").basename
       "foo\\bar"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-the-same-string-if-no-separator-is-found
+  [] +> tests-returns-the-same-string-if-no-separator-is-found
     eq. > @
       (path "Somebody").basename
       "Somebody"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-takes-file-extname
+  [] +> tests-takes-file-extname
     eq. > @
       extname.
         path.joined
@@ -215,7 +214,7 @@
       ".txt"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-take-extname-on-file-without-extension
+  [] +> tests-does-not-take-extname-on-file-without-extension
     eq. > @
       extname.
         path.joined
@@ -223,7 +222,7 @@
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-take-extname-if-ends-with-separator
+  [] +> tests-does-not-take-extname-if-ends-with-separator
     eq. > @
       extname.
         path.joined
@@ -231,7 +230,7 @@
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-dirname-from-file-path
+  [] +> tests-returns-valid-dirname-from-file-path
     eq. > @
       dirname.
         path.joined
@@ -240,7 +239,7 @@
         * "var" "www"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-dirname-from-dir-path
+  [] +> tests-returns-valid-dirname-from-dir-path
     eq. > @
       dirname.
         path.joined
@@ -249,7 +248,7 @@
         * "var" "www"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-dirname-from-file-path-without-extension
+  [] +> tests-returns-valid-dirname-from-file-path-without-extension
     eq. > @
       dirname.
         path.joined

--- a/tests/org/eolang/fs/tmpdir-tests.eo
+++ b/tests/org/eolang/fs/tmpdir-tests.eo
@@ -3,21 +3,20 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.fs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tmpdir-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  tmpdir.exists > [] > global-temp-dir-exists
+  tmpdir.exists > [] +> global-temp-dir-exists
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  tmpdir.is-directory > [] > global-temp-dir-is-directory
+  tmpdir.is-directory > [] +> global-temp-dir-is-directory
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  tmpdir.path.eq tmpdir.path > [] > returns-the-same-tmpdir
+  tmpdir.path.eq tmpdir.path > [] +> returns-the-same-tmpdir
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  tmpdir.tmpfile.exists > [] > creates-tmpfile
+  tmpdir.tmpfile.exists > [] +> creates-tmpfile

--- a/tests/org/eolang/go-tests.eo
+++ b/tests/org/eolang/go-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > go-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-goto-jumps-backwards
+  [] +> tests-goto-jumps-backwards
     eq. > @
       malloc.of
         8
@@ -31,7 +31,7 @@
       10
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-goto-jumps-forward
+  [] +> tests-goto-jumps-forward
     and. > @
       eq.
         div 7
@@ -54,7 +54,7 @@
                   r.put (42.div x)
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-from-method-body
+  [] +> tests-returns-from-method-body
     eq. > @
       max 7 42
       42
@@ -70,7 +70,7 @@
               b
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nested-goto
+  [] +> tests-nested-goto
     eq. > @
       go.to
         [g1]

--- a/tests/org/eolang/i16-tests.eo
+++ b/tests/org/eolang/i16-tests.eo
@@ -2,152 +2,151 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i16-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-has-valid-bytes
+  [] +> tests-i16-has-valid-bytes
     eq. > @
       42.as-i64.as-i32.as-i16.as-bytes
       00-2A
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-i16-has-valid-bytes
+  [] +> tests-negative-i16-has-valid-bytes
     eq. > @
       -200.as-i64.as-i32.as-i16.as-bytes
       FF-38
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-less-true
+  [] +> tests-i16-less-true
     lt. > @
       10.as-i64.as-i32.as-i16
       50.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-less-equal
+  [] +> tests-i16-less-equal
     not. > @
       lt.
         10.as-i64.as-i32.as-i16
         10.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-less-false
+  [] +> tests-i16-less-false
     not. > @
       lt.
         10.as-i64.as-i32.as-i16
         -5.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-greater-true
+  [] +> tests-i16-greater-true
     gt. > @
       -200.as-i64.as-i32.as-i16
       -1000.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-greater-false
+  [] +> tests-i16-greater-false
     not. > @
       gt.
         0.as-i64.as-i32.as-i16
         100.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-greater-equal
+  [] +> tests-i16-greater-equal
     not. > @
       gt.
         0.as-i64.as-i32.as-i16
         0.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-lte-true
+  [] +> tests-i16-lte-true
     lte. > @
       -200.as-i64.as-i32.as-i16
       -100.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-lte-equal
+  [] +> tests-i16-lte-equal
     lte. > @
       50.as-i64.as-i32.as-i16
       50.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-lte-false
+  [] +> tests-i16-lte-false
     not. > @
       lte.
         0.as-i64.as-i32.as-i16
         -10.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-gte-true
+  [] +> tests-i16-gte-true
     gte. > @
       -1000.as-i64.as-i32.as-i16
       -1100.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-gte-equal
+  [] +> tests-i16-gte-equal
     gte. > @
       113.as-i64.as-i32.as-i16
       113.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-gte-false
+  [] +> tests-i16-gte-false
     not. > @
       gte.
         0.as-i64.as-i32.as-i16
         10.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-zero-eq-to-i16-zero
+  [] +> tests-i16-zero-eq-to-i16-zero
     eq. > @
       0.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-eq-true
+  [] +> tests-i16-eq-true
     eq. > @
       123.as-i64.as-i32.as-i16
       123.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-eq-false
+  [] +> tests-i16-eq-false
     not. > @
       eq.
         123.as-i64.as-i32.as-i16
         42.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-one-plus-i16-one
+  [] +> tests-i16-one-plus-i16-one
     eq. > @
       1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
       2.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-plus-with-overflow
+  [] +> tests-i16-plus-with-overflow
     eq. > @
       32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
       -32768.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-one-minus-i16-one
+  [] +> tests-i16-one-minus-i16-one
     eq. > @
       1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-minus-with-overflow
+  [] +> tests-i16-minus-with-overflow
     eq. > @
       -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
       32767.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] > throws-on-division-i16-by-i16-zero
+  2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] +> throws-on-division-i16-by-i16-zero
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks that division by one returns the dividend.
-  [] > tests-i16-div-by-i16-one
+  [] +> tests-i16-div-by-i16-one
     eq. > @
       dividend.div 1.as-i64.as-i32.as-i16
       dividend
@@ -155,25 +154,25 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks div with remainder.
-  [] > tests-i16-div-with-remainder
+  [] +> tests-i16-div-with-remainder
     eq. > @
       13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
       -2.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-div-less-than-i16-one
+  [] +> tests-i16-div-less-than-i16-one
     lt. > @
       1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
       1.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-multiply-by-zero
+  [] +> tests-i16-multiply-by-zero
     eq. > @
       1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
       0.as-i64.as-i32.as-i16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i16-times-with-overflow
+  [] +> tests-i16-times-with-overflow
     eq. > @
       32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
       -2.as-i64.as-i32.as-i16

--- a/tests/org/eolang/i32-tests.eo
+++ b/tests/org/eolang/i32-tests.eo
@@ -2,167 +2,166 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i32-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-has-valid-bytes
+  [] +> tests-i32-has-valid-bytes
     eq. > @
       42.as-i64.as-i32.as-bytes
       00-00-00-2A
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-i32-has-valid-bytes
+  [] +> tests-negative-i32-has-valid-bytes
     eq. > @
       -200.as-i64.as-i32.as-bytes
       FF-FF-FF-38
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-to-i16-and-back
+  [] +> tests-i32-to-i16-and-back
     eq. > @
       123.as-i64.as-i32
       123.as-i64.as-i32.as-i16.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-i32-to-i16-and-back
+  [] +> tests-negative-i32-to-i16-and-back
     eq. > @
       -123.as-i64.as-i32
       -123.as-i64.as-i32.as-i16.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-less-true
+  [] +> tests-i32-less-true
     lt. > @
       10.as-i64.as-i32
       50.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-less-equal
+  [] +> tests-i32-less-equal
     not. > @
       lt.
         10.as-i64.as-i32
         10.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-less-false
+  [] +> tests-i32-less-false
     not. > @
       lt.
         10.as-i64.as-i32
         -5.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-greater-true
+  [] +> tests-i32-greater-true
     gt. > @
       -200.as-i64.as-i32
       -1000.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-greater-false
+  [] +> tests-i32-greater-false
     not. > @
       gt.
         0.as-i64.as-i32
         100.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-greater-equal
+  [] +> tests-i32-greater-equal
     not. > @
       gt.
         0.as-i64.as-i32
         0.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-lte-true
+  [] +> tests-i32-lte-true
     lte. > @
       -200.as-i64.as-i32
       -100.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-lte-equal
+  [] +> tests-i32-lte-equal
     lte. > @
       50.as-i64.as-i32
       50.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-lte-false
+  [] +> tests-i32-lte-false
     not. > @
       lte.
         0.as-i64.as-i32
         -10.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-gte-true
+  [] +> tests-i32-gte-true
     gte. > @
       -1000.as-i64.as-i32
       -1100.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-gte-equal
+  [] +> tests-i32-gte-equal
     gte. > @
       113.as-i64.as-i32
       113.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-gte-false
+  [] +> tests-i32-gte-false
     not. > @
       gte.
         0.as-i64.as-i32
         10.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-zero-eq-to-i32-zero
+  [] +> tests-i32-zero-eq-to-i32-zero
     eq. > @
       0.as-i64.as-i32
       0.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-eq-true
+  [] +> tests-i32-eq-true
     eq. > @
       123.as-i64.as-i32
       123.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-eq-false
+  [] +> tests-i32-eq-false
     not. > @
       eq.
         123.as-i64.as-i32
         42.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-one-plus-i32-one
+  [] +> tests-i32-one-plus-i32-one
     eq. > @
       1.as-i64.as-i32.plus 1.as-i64.as-i32
       2.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-plus-with-overflow
+  [] +> tests-i32-plus-with-overflow
     eq. > @
       2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
       -2147483648.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-one-minus-i32-one
+  [] +> tests-i32-one-minus-i32-one
     eq. > @
       1.as-i64.as-i32.minus 1.as-i64.as-i32
       0.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-minus-with-overflow
+  [] +> tests-i32-minus-with-overflow
     eq. > @
       -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
       2147483647.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  2.as-i64.as-i32.div 0.as-i64.as-i32 > [] > throws-on-division-i32-by-i32-zero
+  2.as-i64.as-i32.div 0.as-i64.as-i32 > [] +> throws-on-division-i32-by-i32-zero
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  247483647.as-i64.as-i32.as-i16 > [] > throws-on-converting-to-i16-if-out-of-bounds
+  247483647.as-i64.as-i32.as-i16 > [] +> throws-on-converting-to-i16-if-out-of-bounds
 
   # Checks that division by one returns the dividend.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-div-by-i32-one
+  [] +> tests-i32-div-by-i32-one
     eq. > @
       dividend.div 1.as-i64.as-i32
       dividend
@@ -170,25 +169,25 @@
 
   # Checks div with remainder
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-div-with-remainder
+  [] +> tests-i32-div-with-remainder
     eq. > @
       13.as-i64.as-i32.div -5.as-i64.as-i32
       -2.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-div-less-than-i32-one
+  [] +> tests-i32-div-less-than-i32-one
     lt. > @
       1.as-i64.as-i32.div 5.as-i64.as-i32
       1.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-multiply-by-zero
+  [] +> tests-i32-multiply-by-zero
     eq. > @
       1000.as-i64.as-i32.times 0.as-i64.as-i32
       0.as-i64.as-i32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i32-times-with-overflow
+  [] +> tests-i32-times-with-overflow
     eq. > @
       2147483647.as-i64.as-i32.times 2.as-i64.as-i32
       -2.as-i64.as-i32

--- a/tests/org/eolang/i64-tests.eo
+++ b/tests/org/eolang/i64-tests.eo
@@ -2,155 +2,154 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > i64-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-has-valid-bytes
+  [] +> tests-i64-has-valid-bytes
     eq. > @
       42.as-i64.as-bytes
       00-00-00-00-00-00-00-2A
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-as-bytes-is-not-equal-to-number-bytes
+  [] +> tests-i64-as-bytes-is-not-equal-to-number-bytes
     not. > @
       eq.
         i64 234.as-bytes
         234.as-i64.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-to-i32-and-back
+  [] +> tests-i64-to-i32-and-back
     eq. > @
       234.as-i64
       234.as-i64.as-i32.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-i64-to-i32-and-back
+  [] +> tests-negative-i64-to-i32-and-back
     eq. > @
       -234.as-i64
       -234.as-i64.as-i32.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  3147483647.as-i64.as-i32 > [] > throws-on-converting-to-i32-if-out-of-bounds
+  3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-less-true
+  [] +> tests-i64-less-true
     lt. > @
       10.as-i64
       50.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-less-equal
+  [] +> tests-i64-less-equal
     not. > @
       lt.
         10.as-i64
         10.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-less-false
+  [] +> tests-i64-less-false
     not. > @
       lt.
         10.as-i64
         -5.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-greater-true
+  [] +> tests-i64-greater-true
     gt. > @
       -200.as-i64
       -1000.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-greater-false
+  [] +> tests-i64-greater-false
     not. > @
       gt.
         0.as-i64
         100.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-greater-equal
+  [] +> tests-i64-greater-equal
     not. > @
       gt.
         0.as-i64
         0.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-lte-true
+  [] +> tests-i64-lte-true
     lte. > @
       -200.as-i64
       -100.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-lte-equal
+  [] +> tests-i64-lte-equal
     lte. > @
       50.as-i64
       50.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-lte-false
+  [] +> tests-i64-lte-false
     not. > @
       lte.
         0.as-i64
         -10.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-gte-true
+  [] +> tests-i64-gte-true
     gte. > @
       -1000.as-i64
       -1100.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-gte-equal
+  [] +> tests-i64-gte-equal
     gte. > @
       113.as-i64
       113.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-gte-false
+  [] +> tests-i64-gte-false
     not. > @
       gte.
         0.as-i64
         10.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-zero-eq-to-i64-zero
+  [] +> tests-i64-zero-eq-to-i64-zero
     eq. > @
       0.as-i64
       0.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-eq-true
+  [] +> tests-i64-eq-true
     eq. > @
       123.as-i64
       123.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-eq-false
+  [] +> tests-i64-eq-false
     not. > @
       eq.
         123.as-i64
         42.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-one-plus-i64-one
+  [] +> tests-i64-one-plus-i64-one
     eq. > @
       1.as-i64.plus 1.as-i64
       2.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-one-minus-i64-one
+  [] +> tests-i64-one-minus-i64-one
     eq. > @
       1.as-i64.minus 1.as-i64
       0.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  2.as-i64.div 0.as-i64 > [] > throws-on-division-i64-by-i64-zero
+  2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
 
   # Checks that division by one returns the dividend.
-  [] > tests-i64-div-by-i64-one
+  [] +> tests-i64-div-by-i64-one
     eq. > @
       dividend.div 1.as-i64
       dividend
@@ -158,19 +157,19 @@
 
   # Checks div with remainder
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-div-with-remainder
+  [] +> tests-i64-div-with-remainder
     eq. > @
       13.as-i64.div -5.as-i64
       -2.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-div-less-than-i64-one
+  [] +> tests-i64-div-less-than-i64-one
     lt. > @
       1.as-i64.div 5.as-i64
       1.as-i64
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-i64-multiply-by-zero
+  [] +> tests-i64-multiply-by-zero
     eq. > @
       1000.as-i64.times 0.as-i64
       0.as-i64

--- a/tests/org/eolang/io/bytes-as-input-tests.eo
+++ b/tests/org/eolang/io/bytes-as-input-tests.eo
@@ -3,13 +3,13 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bytes-as-input-tests
-  [] > tests-makes-an-input-from-bytes-and-reads
+  [] +> tests-makes-an-input-from-bytes-and-reads
     and. > @
       and.
         and.

--- a/tests/org/eolang/io/console-tests.eo
+++ b/tests/org/eolang/io/console-tests.eo
@@ -3,15 +3,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > console-tests
   # Prints a simple message to the console. We can't validate
   # the output, so we just run it and see if it crashes.
-  [] > tests-writes-to-console
+  [] +> tests-writes-to-console
     console.write > @
       "Hello, console-test!\n"

--- a/tests/org/eolang/io/dead-input-tests.eo
+++ b/tests/org/eolang/io/dead-input-tests.eo
@@ -3,14 +3,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > dead-input-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-empty-bytes
+  [] +> tests-reads-empty-bytes
     and. > @
       i1.eq --
       i2.eq --

--- a/tests/org/eolang/io/dead-output-tests.eo
+++ b/tests/org/eolang/io/dead-output-tests.eo
@@ -3,12 +3,11 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > dead-output-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  dead-output.write 01-02-03 > [] > writes-bytes-to-nowhere
+  dead-output.write 01-02-03 > [] +> writes-bytes-to-nowhere

--- a/tests/org/eolang/io/input-length-tests.eo
+++ b/tests/org/eolang/io/input-length-tests.eo
@@ -6,15 +6,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > input-length-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-all-bytes-and-returns-length
+  [] +> tests-reads-all-bytes-and-returns-length
     eq. > @
       input-length
         bytes-as-input
@@ -22,7 +21,7 @@
       10
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-copies-all-bytes-to-output-and-returns-length
+  [] +> tests-copies-all-bytes-to-output-and-returns-length
     eq. > @
       malloc.of
         10

--- a/tests/org/eolang/io/malloc-as-output-tests.eo
+++ b/tests/org/eolang/io/malloc-as-output-tests.eo
@@ -3,30 +3,29 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > malloc-as-output-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-makes-an-output-from-malloc-and-writes
+  [] +> tests-makes-an-output-from-malloc-and-writes
     eq. > @
       malloc.of
         10
-        [m]
+        [mem]
           seq > @
             *
               o2.write 08-09-A0
-              m
-          malloc-as-output m > output
-          output.write 01-02-03 > o1
+              mem
+          malloc-as-output mem > out
+          out.write 01-02-03 > o1
           o1.write 04-05-06-07 > o2
       01-02-03-04-05-06-07-08-09-A0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-writing-more-than-allocated
+  [] +> throws-on-writing-more-than-allocated
     malloc.of > @
       2
       [m]

--- a/tests/org/eolang/io/stdout-tests.eo
+++ b/tests/org/eolang/io/stdout-tests.eo
@@ -3,15 +3,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > stdout-tests
   # Prints a simple message to the console. We can't validate
   # the output, so we just run it and see if it crashes.
-  [] > tests-prints-to-console
+  [] +> tests-prints-to-console
     stdout > @
       "Hello, stdout-test!\n"

--- a/tests/org/eolang/io/tee-input-tests.eo
+++ b/tests/org/eolang/io/tee-input-tests.eo
@@ -5,28 +5,27 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.io
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tee-input-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-bytes-and-writes-to-memory
+  [] +> tests-reads-from-bytes-and-writes-to-memory
     eq. > @
       malloc.of
         5
-        [m]
+        [mem]
           read. > @
             tee-input
               bytes-as-input 01-02-03-04-05
-              malloc-as-output m
+              malloc-as-output mem
             5
       01-02-03-04-05
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-bytes-and-writes-to-memory-by-portions
+  [] +> tests-reads-from-bytes-and-writes-to-memory-by-portions
     eq. > @
       malloc.of
         5
@@ -43,7 +42,7 @@
       01-02-03-04-05
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-from-bytes-and-writes-to-two-memory-blocks
+  [] +> tests-reads-from-bytes-and-writes-to-two-memory-blocks
     eq. > @
       malloc.of
         6

--- a/tests/org/eolang/malloc-tests.eo
+++ b/tests/org/eolang/malloc-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > malloc-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-writes-into-memory-of
+  [] +> tests-writes-into-memory-of
     mem.eq 10 > @
     malloc.of > mem
       8
@@ -21,14 +21,14 @@
             m
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-puts-into-memory-for
+  [] +> tests-puts-into-memory-for
     mem.eq 10 > @
     malloc.for > mem
       0
       m.put 10 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-size-from-scope
+  [] +> tests-returns-size-from-scope
     eq. > @
       malloc.of
         5
@@ -36,7 +36,7 @@
       5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-scope-is-dataized-twice
+  [] +> tests-malloc-scope-is-dataized-twice
     eq. > @
       2
       malloc.for
@@ -51,7 +51,7 @@
             f.put (f.as-number.plus 1) > [s] >>
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-for-writes-first-init-value
+  [] +> tests-malloc-for-writes-first-init-value
     eq. > @
       malloc.for
         42
@@ -59,7 +59,7 @@
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-puts-over-the-previous-data
+  [] +> tests-malloc-puts-over-the-previous-data
     eq. > @
       42.as-bytes.concat
         "orld!".as-bytes
@@ -73,7 +73,7 @@
             m.put 42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-rewrites-and-increments-itself
+  [] +> tests-malloc-rewrites-and-increments-itself
     mem.eq 6 > @
     malloc.of > mem
       8
@@ -84,7 +84,7 @@
             m.put (m.as-number.plus 5)
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-writes-into-two-malloc-objects
+  [] +> tests-writes-into-two-malloc-objects
     and. > @
       a.eq 10
       b.eq 20
@@ -96,19 +96,19 @@
       m.put 20 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-overflow-boolean-malloc
+  [] +> throws-on-overflow-boolean-malloc
     malloc.for > @
       false
       m.put 86124867.88 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-overflow-string-malloc
+  [] +> throws-on-overflow-string-malloc
     malloc.for > @
       "Hello"
       m.put "Much longer string!" > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-is-strictly-sized-int
+  [] +> tests-malloc-is-strictly-sized-int
     eq. > @
       malloc.for
         12248
@@ -116,7 +116,7 @@
       2556
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-is-strictly-typed-float
+  [] +> tests-malloc-is-strictly-typed-float
     eq. > @
       malloc.for
         245.88
@@ -124,7 +124,7 @@
       82.22
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-memory-is-strictly-sized-string
+  [] +> tests-memory-is-strictly-sized-string
     eq. > @
       malloc.for
         "Hello"
@@ -132,19 +132,19 @@
       "Proto"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-is-strictly-typed-bool
+  [] +> tests-malloc-is-strictly-typed-bool
     malloc.for > @
       false
       m.put true > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-gives-id-to-allocated-block
+  [] +> tests-malloc-gives-id-to-allocated-block
     malloc.of > @
       1
       m.put (m.id.gt 0) > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-allocates-right-size-block
+  [] +> tests-malloc-allocates-right-size-block
     malloc.of > @
       1
       [b]
@@ -153,7 +153,7 @@
           b.put (m.size.eq 10) > [m] >>
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-writes-and-reads
+  [] +> tests-malloc-writes-and-reads
     malloc.of > @
       1
       [b]
@@ -170,7 +170,7 @@
                     "Hello, Jeff!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-concacts-strings-with-offset
+  [] +> tests-malloc-concacts-strings-with-offset
     malloc.of > @
       1
       [b]
@@ -185,13 +185,13 @@
                   (m.read 0 3).eq "XYX"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-writing-more-than-allocated-to-malloc-with-offset
+  [] +> throws-on-writing-more-than-allocated-to-malloc-with-offset
     malloc.of > @
       1
       m.write 1 true > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-reads-with-offset-and-length
+  [] +> tests-malloc-reads-with-offset-and-length
     malloc.of > @
       1
       [b]
@@ -205,7 +205,7 @@
                   (m.read 2 5).eq "Hello"
 
   # Creates memory block of zero bytes (this should be a legal operation).
-  [] > tests-allocates-zero-bytes
+  [] +> tests-allocates-zero-bytes
     eq. > @
       0
       malloc.of
@@ -213,7 +213,7 @@
         m.size > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-increases-block-size
+  [] +> tests-malloc-increases-block-size
     malloc.of > @
       1
       [b]
@@ -226,7 +226,7 @@
                 m.get.eq 01-02-03-04-00-00
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-decreases-block-size
+  [] +> tests-malloc-decreases-block-size
     malloc.of > @
       1
       [b]
@@ -239,18 +239,18 @@
                 m.get.eq 01-02-03
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-changing-size-to-negative
+  [] +> throws-on-changing-size-to-negative
     malloc.of > @
       1
       m.resized -1 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-malloc-empty-is-empty
+  [] +> tests-malloc-empty-is-empty
     malloc.empty > @
       m.size.eq 0 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-copies-data-inside-itself
+  [] +> tests-copies-data-inside-itself
     malloc.for > @
       01-02-03-04-05
       [m]
@@ -259,7 +259,7 @@
           m.get.eq 01-02-02-03-05
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-copies-data-from-start-to-end
+  [] +> tests-copies-data-from-start-to-end
     malloc.for > @
       01-02-03-04-05-06
       [m]
@@ -268,19 +268,19 @@
           m.get.eq 01-02-03-01-02-03
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-copying-with-wrong-source
+  [] +> throws-on-copying-with-wrong-source
     malloc.for > @
       0
       m.copy 9 1 1 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-copying-with-wrong-target
+  [] +> throws-on-copying-with-wrong-target
     malloc.for > @
       0
       m.copy 3 9 1 > [m]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-copying-with-wrong-length
+  [] +> throws-on-copying-with-wrong-length
     malloc.for > @
       0
       m.copy 3 1 9 > [m]

--- a/tests/org/eolang/math/angle-tests.eo
+++ b/tests/org/eolang/math/angle-tests.eo
@@ -4,45 +4,44 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > angle-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sin-zero
+  [] +> tests-sin-zero
     eq. > @
       (angle 0).sin
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sin-pi-div-2
+  [] +> tests-sin-pi-div-2
     eq. > @
       (angle (pi.div 2)).sin
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sin-pi-floored
+  [] +> tests-sin-pi-floored
     eq. > @
       (angle pi).sin.floor
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-cos-zero
+  [] +> tests-cos-zero
     eq. > @
       (angle 0).cos
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-cos-pi-div-2-floored
+  [] +> tests-cos-pi-div-2-floored
     eq. > @
       (angle (pi.div 2)).cos.floor
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-cos-pi
+  [] +> tests-cos-pi
     eq. > @
       (angle pi).cos
       -1

--- a/tests/org/eolang/math/integral-tests.eo
+++ b/tests/org/eolang/math/integral-tests.eo
@@ -3,14 +3,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > integral-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-lineal-integral
+  [] +> tests-calculates-lineal-integral
     close-to > @
       lineal
       49.5
@@ -37,7 +38,7 @@
           value.neg
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-quadratic-integral
+  [] +> tests-calculates-quadratic-integral
     close-to > @
       quadratic
       333
@@ -64,7 +65,7 @@
           value.neg
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-cube-integral
+  [] +> tests-calculates-cube-integral
     close-to > @
       cube
       2499.75

--- a/tests/org/eolang/math/number-tests.eo
+++ b/tests/org/eolang/math/number-tests.eo
@@ -3,63 +3,62 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > number-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  (numbers *).max > [] > throws-on-taking-max-from-empty-sequence-of-numbers
+  (numbers *).max > [] +> throws-on-taking-max-from-empty-sequence-of-numbers
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  (numbers *).min > [] > throws-on-taking-min-from-empty-sequence-of-numbers
+  (numbers *).min > [] +> throws-on-taking-min-from-empty-sequence-of-numbers
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-max-of-one-item-array
+  [] +> tests-max-of-one-item-array
     eq. > @
       (numbers (* 42)).max
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-min-of-one-item-array
+  [] +> tests-min-of-one-item-array
     eq. > @
       (numbers (* 42)).min
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-max-of-array-is-first
+  [] +> tests-max-of-array-is-first
     eq. > @
       (numbers (* 25 12 -2)).max
       25
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-max-of-array-is-in-the-center
+  [] +> tests-max-of-array-is-in-the-center
     eq. > @
       (numbers (* 12 25 -2)).max
       25
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-max-of-array-is-last
+  [] +> tests-max-of-array-is-last
     eq. > @
       (numbers (* 12 -2 25)).max
       25
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-min-of-array-is-first
+  [] +> tests-min-of-array-is-first
     eq. > @
       (numbers (* -2 25 12)).min
       -2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-min-of-array-is-in-the-center
+  [] +> tests-min-of-array-is-in-the-center
     eq. > @
       (numbers (* 12 -2 25)).min
       -2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-min-of-array-is-last
+  [] +> tests-min-of-array-is-last
     eq. > @
       (numbers (* 12 25 -2)).min
       -2

--- a/tests/org/eolang/math/random-tests.eo
+++ b/tests/org/eolang/math/random-tests.eo
@@ -3,15 +3,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > random-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-random-with-seed
+  [] +> tests-random-with-seed
     not. > @
       eq.
         r.next
@@ -19,27 +18,27 @@
     random 51 > r
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seeded-randoms-are-equal
+  [] +> tests-seeded-randoms-are-equal
     eq. > @
       (random 1654).next.next.next
       (random 1654).next.next.next
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-random-is-in-range
+  [] +> tests-random-is-in-range
     and. > @
       and.
         and.
-          r.lt 1
-          (r.lt 0).not
+          rand.lt 1
+          (rand.lt 0).not
         and.
-          r.next.lt 1
-          (r.next.lt 0).not
+          rand.next.lt 1
+          (rand.next.lt 0).not
       and.
-        r.next.next.lt 1
-        (r.next.next.lt 0).not
-    (random 123).fixed > r
+        rand.next.next.lt 1
+        (rand.next.next.lt 0).not
+    (random 123).fixed > rand
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-two-random-numbers-not-equal
+  [] +> tests-two-random-numbers-not-equal
     not. > @
       random.pseudo.eq random.pseudo

--- a/tests/org/eolang/math/real-tests.eo
+++ b/tests/org/eolang/math/real-tests.eo
@@ -5,78 +5,77 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.math
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > real-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-abs-int-positive
-    eq. > @
+  [] +> tests-abs-int-positive
+    eq. +> @
       (real 3).abs
       3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-abs-int-negative
-    eq. > @
+  [] +> tests-abs-int-negative
+    eq. +> @
       (real -3).abs
       3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-abs-zero
-    eq. > @
+  [] +> tests-abs-zero
+    eq. +> @
       (real 0).abs
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-abs-float-positive
-    eq. > @
+  [] +> tests-abs-float-positive
+    eq. +> @
       (real 13.5).abs
       13.5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-abs-float-negative
-    eq. > @
+  [] +> tests-abs-float-negative
+    eq. +> @
       (real -17.9).abs
       17.9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-mod-n1-n2
-    eq. > @
+  [] +> tests-mod-n1-n2
+    eq. +> @
       (real 1).mod 2
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-mod-n0-n5
-    eq. > @
+  [] +> tests-mod-n0-n5
+    eq. +> @
       (real 0).mod 5
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-mod-n0-n15-neg
-    eq. > @
+  [] +> tests-mod-n0-n15-neg
+    eq. +> @
       (real 0).mod -15
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-mod-n1-neg-n7
-    eq. > @
+  [] +> tests-mod-n1-neg-n7
+    eq. +> @
       (real -1).mod 7
       -1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-mod-n16-n200-neg
-    eq. > @
+  [] +> tests-mod-n16-n200-neg
+    eq. +> @
       (real 16).mod -200
       16
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks mathematical equality
   # A = ((A div B) * B) + (A mod B).
-  [] > tests-div-mod-compatibility
-    eq. > @
+  [] +> tests-div-mod-compatibility
+    eq. +> @
       plus.
         remainder
         times.
@@ -90,266 +89,266 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks modulo: dividend < divisor.
-  [] > tests-mod-dividend-less-than-divisor
-    eq. > @
+  [] +> tests-mod-dividend-less-than-divisor
+    eq. +> @
       (real -1).mod 5
       -1
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Checks modulo by 1.
-  [] > tests-mod-dividend-by-one
-    eq. > @
+  [] +> tests-mod-dividend-by-one
+    eq. +> @
       (real 133).mod 1
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-pow-test
-    eq. > @
+  [] +> tests-pow-test
+    eq. +> @
       (real 2).pow 4
       16
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-pow-is-zero
-    eq. > @
+  [] +> tests-pow-is-zero
+    eq. +> @
       (real 2).pow 0
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-pow-is-negative
-    eq. > @
+  [] +> tests-pow-is-negative
+    eq. +> @
       (real 984782).pow -12341
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-pow-of-two
-    eq. > @
+  [] +> tests-pow-of-two
+    eq. +> @
       (real 3).pow 2
       9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-pow-of-zero
-    eq. > @
+  [] +> tests-pow-of-zero
+    eq. +> @
       (real 0).pow 145
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-negative-pow-of-zero
-    (real 0).pow -567 > @
+  [] +> throws-on-negative-pow-of-zero
+    (real 0).pow -567 +> @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Check pow works with NaNs.
-  [] > tests-nan-to-the-pow-of-nan-is-nan
-    is-nan. > @
+  [] +> tests-nan-to-the-pow-of-nan-is-nan
+    is-nan. +> @
       (real nan).pow nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-to-the-pow-of-any-is-nan
-    is-nan. > @
+  [] +> tests-nan-to-the-pow-of-any-is-nan
+    is-nan. +> @
       (real nan).pow 42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-any-to-the-pow-of-nan-is-nan
-    is-nan. > @
+  [] +> tests-any-to-the-pow-of-nan-is-nan
+    is-nan. +> @
       (real 52).pow nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Check if pow is zero.
-  [] > tests-any-int-to-the-pow-of-zero-is-one
-    eq. > @
+  [] +> tests-any-int-to-the-pow-of-zero-is-one
+    eq. +> @
       (real 42).pow 0
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-any-float-to-the-pow-of-zero-is-one
-    eq. > @
+  [] +> tests-any-float-to-the-pow-of-zero-is-one
+    eq. +> @
       (real 42.5).pow 0
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Check if pow is less than zero.
-  [] > tests-zero-to-the-negative-pow-is-positive-infinity
-    eq. > @
+  [] +> tests-zero-to-the-negative-pow-is-positive-infinity
+    eq. +> @
       (real 0).pow -52
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-zero-to-the-negative-infinity-pow-is-positive-infinity
-    eq. > @
+  [] +> tests-zero-to-the-negative-infinity-pow-is-positive-infinity
+    eq. +> @
       (real 0).pow negative-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-int-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-positive-int-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real 42).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-float-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-positive-float-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real 42.5).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-int-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-negative-int-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real -42).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-float-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-negative-float-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real -42.5).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-positive-infinity-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real positive-infinity).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-to-the-pow-of-negative-infinity-is-zero
-    eq. > @
+  [] +> tests-negative-infinity-to-the-pow-of-negative-infinity-is-zero
+    eq. +> @
       (real negative-infinity).pow negative-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-finite-negative-int-pow-is-zero
-    eq. > @
+  [] +> tests-positive-infinity-to-the-finite-negative-int-pow-is-zero
+    eq. +> @
       (real positive-infinity).pow -42
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-finite-negative-float-pow-is-zero
-    eq. > @
+  [] +> tests-positive-infinity-to-the-finite-negative-float-pow-is-zero
+    eq. +> @
       (real positive-infinity).pow -42.2
       0.0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-two-to-the-pow-of-minus-one
-    eq. > @
+  [] +> tests-two-to-the-pow-of-minus-one
+    eq. +> @
       (real 2).pow -1
       0.5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-two-to-the-pow-of-int-minus-two
-    eq. > @
+  [] +> tests-two-to-the-pow-of-int-minus-two
+    eq. +> @
       (real 2).pow -2
       0.25
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-two-to-the-pow-of-minus-three
-    eq. > @
+  [] +> tests-two-to-the-pow-of-minus-three
+    eq. +> @
       (real 2).pow -3
       0.125
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-four-to-the-pow-of-minus-three
-    eq. > @
+  [] +> tests-four-to-the-pow-of-minus-three
+    eq. +> @
       (real 4).pow -3.0
       0.015625
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # Check if pow more than zero.
-  [] > tests-zero-to-the-pow-of-positive-int-is-zero
-    eq. > @
+  [] +> tests-zero-to-the-pow-of-positive-int-is-zero
+    eq. +> @
       (real 0).pow 4
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-zero-to-the-pow-of-positive-float-is-zero
-    eq. > @
+  [] +> tests-zero-to-the-pow-of-positive-float-is-zero
+    eq. +> @
       (real 0).pow 4.2
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-zero-to-the-pow-of-positive-infinity-is-zero
-    eq. > @
+  [] +> tests-zero-to-the-pow-of-positive-infinity-is-zero
+    eq. +> @
       (real 0).pow positive-infinity
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-int-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
+  [] +> tests-negative-int-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. +> @
       (real -10).pow positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-float-to-the-pow-of-positive-infinity-is-infinity
-    eq. > @
+  [] +> tests-negative-float-to-the-pow-of-positive-infinity-is-infinity
+    eq. +> @
       (real -4.2).pow positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-int-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
+  [] +> tests-positive-int-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. +> @
       (real 42).pow positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
+  [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. +> @
       (real 42.5).pow positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
-    eq. > @
+  [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
+    eq. +> @
       (real positive-infinity).pow 42
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. > @
+  [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
+    eq. +> @
       (real positive-infinity).pow 10.8
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. > @
+  [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
+    eq. +> @
       (real positive-infinity).pow positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. > @
+  [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
+    eq. +> @
       (real negative-infinity).pow 9.9
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
-    eq. > @
+  [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
+    eq. +> @
       (real negative-infinity).pow 10
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
-    eq. > @
+  [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
+    eq. +> @
       (real negative-infinity).pow 9
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-int-to-the-pow-of-positive-int-is-int
-    eq. > @
+  [] +> tests-positive-int-to-the-pow-of-positive-int-is-int
+    eq. +> @
       (real 2).pow 3
       8
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-float-to-the-pow-of-positive-int-is-float
-    eq. > @
+  [] +> tests-positive-float-to-the-pow-of-positive-int-is-float
+    eq. +> @
       (real 3.5).pow 4
       150.0625
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-int-to-the-pow-of-positive-float-is-float
-    eq. > @
+  [] +> tests-positive-int-to-the-pow-of-positive-float-is-float
+    eq. +> @
       (real 4).pow 5
       1024
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-zero-input
-    lt. > @
+  [] +> tests-sqrt-check-zero-input
+    lt. +> @
       abs.
         real
           minus.
@@ -359,14 +358,14 @@
       0.00000000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-negative-input
-    is-nan. > @
+  [] +> tests-sqrt-check-negative-input
+    is-nan. +> @
       sqrt.
         real -0.1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-float-input
-    lt. > @
+  [] +> tests-sqrt-check-float-input
+    lt. +> @
       abs.
         real
           minus.
@@ -377,8 +376,8 @@
       0.00000000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-int-input
-    lt. > @
+  [] +> tests-sqrt-check-int-input
+    lt. +> @
       abs.
         real
           minus.
@@ -389,88 +388,88 @@
       0.00000000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-nan-input
-    is-nan. > @
+  [] +> tests-sqrt-check-nan-input
+    is-nan. +> @
       sqrt.
         real nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-infinity-n1
-    eq. > @
+  [] +> tests-sqrt-check-infinity-n1
+    eq. +> @
       sqrt.
         real positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sqrt-check-infinity-n2
-    is-nan. > @
+  [] +> tests-sqrt-check-infinity-n2
+    is-nan. +> @
       sqrt.
         real negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-negative-float-is-nan
-    is-nan. > @
+  [] +> tests-ln-of-negative-float-is-nan
+    is-nan. +> @
       ln.
         real -2.2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-zero-is-negative-infinity
-    eq. > @
+  [] +> tests-ln-of-zero-is-negative-infinity
+    eq. +> @
       ln.
         real 0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-one-is-zero
-    eq. > @
+  [] +> tests-ln-of-one-is-zero
+    eq. +> @
       ln.
         real 1
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-e-one-is-one
-    eq. > @
+  [] +> tests-ln-of-e-one-is-one
+    eq. +> @
       ln.
         real e
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-negative-int-is-nan
-    is-nan. > @
+  [] +> tests-ln-of-negative-int-is-nan
+    is-nan. +> @
       ln.
         real -42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-int-zero-is-negative-infinity
-    eq. > @
+  [] +> tests-ln-of-int-zero-is-negative-infinity
+    eq. +> @
       ln.
         real 0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-int-one-is-zero
-    eq. > @
+  [] +> tests-ln-of-int-one-is-zero
+    eq. +> @
       ln.
         real 1
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ln-of-twenty
-    eq. > @
+  [] +> tests-ln-of-twenty
+    eq. +> @
       ln.
         real 20
       2.995732273553991
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-negative-one-test
-    eq. > @
+  [] +> tests-arccos-negative-one-test
+    eq. +> @
       acos.
         real -1.0
       pi
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-zero-test
-    eq. > @
+  [] +> tests-arccos-zero-test
+    eq. +> @
       acos.
         real 0
       div.
@@ -478,15 +477,15 @@
         2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-one-test
-    eq. > @
+  [] +> tests-arccos-one-test
+    eq. +> @
       acos.
         real 1.0
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-positive-calculated-test
-    lt. > @
+  [] +> tests-arccos-positive-calculated-test
+    lt. +> @
       abs.
         real
           minus.
@@ -496,8 +495,8 @@
       0.000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-negative-calculated-test
-    lt. > @
+  [] +> tests-arccos-negative-calculated-test
+    lt. +> @
       abs.
         real
           minus.
@@ -507,19 +506,19 @@
       0.000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-nan-positive-value-test
-    is-nan. > @
+  [] +> tests-arccos-nan-positive-value-test
+    is-nan. +> @
       acos.
         real 2.0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-arccos-nan-negative-value-test
-    is-nan. > @
+  [] +> tests-arccos-nan-negative-value-test
+    is-nan. +> @
       (real -2.0).acos
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-n0
-    lt. > @
+  [] +> tests-exp-check-n0
+    lt. +> @
       abs.
         real
           minus.
@@ -528,8 +527,8 @@
       0.00000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-n1
-    lt. > @
+  [] +> tests-exp-check-n1
+    lt. +> @
       abs.
         real
           minus.
@@ -538,8 +537,8 @@
       0.00000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-n2
-    lt. > @
+  [] +> tests-exp-check-n2
+    lt. +> @
       abs.
         real
           minus.
@@ -548,8 +547,8 @@
       0.00000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-n3
-    lt. > @
+  [] +> tests-exp-check-n3
+    lt. +> @
       abs.
         real
           minus.
@@ -558,8 +557,8 @@
       0.0000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-n4
-    lt. > @
+  [] +> tests-exp-check-n4
+    lt. +> @
       abs.
         real
           minus.
@@ -568,18 +567,18 @@
       0.000000000001
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-nan
-    is-nan. > @
+  [] +> tests-exp-check-nan
+    is-nan. +> @
       (real nan).exp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-infinity-n1
-    eq. > @
+  [] +> tests-exp-check-infinity-n1
+    eq. +> @
       (real positive-infinity).exp
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-exp-check-infinity-n2
-    eq. > @
+  [] +> tests-exp-check-infinity-n2
+    eq. +> @
       (real negative-infinity).exp
       0

--- a/tests/org/eolang/nan-tests.eo
+++ b/tests/org/eolang/nan-tests.eo
@@ -2,140 +2,139 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > nan-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-eq-number
+  [] +> tests-nan-not-eq-number
     not. > @
       eq.
         nan
         42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-eq-nan
+  [] +> tests-nan-not-eq-nan
     not. > @
       eq.
         nan
         nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-lt-number
+  [] +> tests-nan-not-lt-number
     eq. > @
       nan.lt 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-lt-nan
+  [] +> tests-nan-not-lt-nan
     eq. > @
       nan.lt nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-lte-number
+  [] +> tests-nan-not-lte-number
     eq. > @
       nan.lte 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-lte-nan
+  [] +> tests-nan-not-lte-nan
     eq. > @
       nan.lte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-gt-number
+  [] +> tests-nan-not-gt-number
     eq. > @
       nan.gt 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-gt-nan
+  [] +> tests-nan-not-gt-nan
     eq. > @
       nan.gt nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-gte-number
+  [] +> tests-nan-not-gte-number
     eq. > @
       nan.gte 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-not-gte-nan
+  [] +> tests-nan-not-gte-nan
     eq. > @
       nan.gte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-times-number-is-nan
+  [] +> tests-nan-times-number-is-nan
     eq. > @
       (nan.times 42).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-times-nan-is-nan
+  [] +> tests-nan-times-nan-is-nan
     eq. > @
       (nan.times nan).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-div-number-is-nan
+  [] +> tests-nan-div-number-is-nan
     eq. > @
       (nan.div 42).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-div-nan-is-nan
+  [] +> tests-nan-div-nan-is-nan
     eq. > @
       (nan.div nan).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-plus-number-is-nan
+  [] +> tests-nan-plus-number-is-nan
     eq. > @
       (nan.plus 42).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-plus-nan-is-nan
+  [] +> tests-nan-plus-nan-is-nan
     eq. > @
       (nan.plus nan).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-neg-is-nan
+  [] +> tests-nan-neg-is-nan
     eq. > @
       nan.neg.as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-minus-number-is-nan
+  [] +> tests-nan-minus-number-is-nan
     eq. > @
       (nan.minus 42).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-minus-nan-is-nan
+  [] +> tests-nan-minus-nan-is-nan
     eq. > @
       (nan.minus nan).as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nan-as-bytes-is-bytes-of-zero-div-zero
+  [] +> tests-nan-as-bytes-is-bytes-of-zero-div-zero
     eq. > @
       nan.as-bytes
       (0.0.div 0.0).as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  nan.is-nan > [] > nan-is-nan
+  nan.is-nan > [] +> nan-is-nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  nan.is-finite.not > [] > nan-is-not-finite
+  nan.is-finite.not > [] +> nan-is-not-finite
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  nan.is-integer.not > [] > nan-is-not-integer
+  nan.is-integer.not > [] +> nan-is-not-integer

--- a/tests/org/eolang/negative-infinity-tests.eo
+++ b/tests/org/eolang/negative-infinity-tests.eo
@@ -2,49 +2,48 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > negative-infinity-tests
   # Equal to.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-is-equal-to-one-div-zero
+  [] +> tests-negative-infinity-is-equal-to-one-div-zero
     eq. > @
       negative-infinity
       -1.0.div 0.0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-eq-negative-infinity
+  [] +> tests-negative-infinity-eq-negative-infinity
     eq. > @
       negative-infinity
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-eq-positive-infinity
+  [] +> tests-negative-infinity-not-eq-positive-infinity
     not. > @
       eq.
         negative-infinity
         positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-eq-nan
+  [] +> tests-negative-infinity-not-eq-nan
     not. > @
       eq.
         negative-infinity
         nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-eq-int
+  [] +> tests-negative-infinity-not-eq-int
     not. > @
       eq.
         negative-infinity
         42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-eq-float
+  [] +> tests-negative-infinity-not-eq-float
     not. > @
       eq.
         negative-infinity
@@ -52,380 +51,380 @@
 
   # Less than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lt-negative-infinity
+  [] +> tests-negative-infinity-lt-negative-infinity
     eq. > @
       negative-infinity.lt negative-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lt-positive-infinity
+  [] +> tests-negative-infinity-lt-positive-infinity
     eq. > @
       negative-infinity.lt positive-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-lt-nan
+  [] +> tests-negative-infinity-not-lt-nan
     eq. > @
       negative-infinity.lt nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lt-int
+  [] +> tests-negative-infinity-lt-int
     lt. > @
       negative-infinity
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lt-float
+  [] +> tests-negative-infinity-lt-float
     lt. > @
       negative-infinity
       42.5
 
   # Less or equal than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lte-negative-infinity
+  [] +> tests-negative-infinity-lte-negative-infinity
     eq. > @
       negative-infinity.lte negative-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lte-positive-infinity
+  [] +> tests-negative-infinity-lte-positive-infinity
     eq. > @
       negative-infinity.lte positive-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-lte-nan
+  [] +> tests-negative-infinity-not-lte-nan
     eq. > @
       negative-infinity.lte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lte-int
+  [] +> tests-negative-infinity-lte-int
     eq. > @
       negative-infinity.lte 42
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-lte-float
+  [] +> tests-negative-infinity-lte-float
     eq. > @
       negative-infinity.lte 42.5
       true
 
   # Greater than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-gt-negative-infinity
+  [] +> tests-negative-infinity-gt-negative-infinity
     not. > @
       gt.
         negative-infinity
         negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gt-positive-infinity
+  [] +> tests-negative-infinity-not-gt-positive-infinity
     eq. > @
       negative-infinity.gt positive-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gt-nan
+  [] +> tests-negative-infinity-not-gt-nan
     eq. > @
       negative-infinity.gt nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gt-int
+  [] +> tests-negative-infinity-not-gt-int
     eq. > @
       negative-infinity.gt 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gt-float
+  [] +> tests-negative-infinity-not-gt-float
     eq. > @
       negative-infinity.gt 42.5
       false
 
   # Greater or equal than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-gte-negative-infinity
+  [] +> tests-negative-infinity-gte-negative-infinity
     eq. > @
       negative-infinity.gte negative-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gte-positive-infinity
+  [] +> tests-negative-infinity-not-gte-positive-infinity
     eq. > @
       negative-infinity.gte positive-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gte-nan
+  [] +> tests-negative-infinity-not-gte-nan
     eq. > @
       negative-infinity.gte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gte-int
+  [] +> tests-negative-infinity-not-gte-int
     eq. > @
       negative-infinity.gte 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-not-gte-float
+  [] +> tests-negative-infinity-not-gte-float
     eq. > @
       negative-infinity.gte 42.5
       false
 
   # Times.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-float-zero
+  [] +> tests-negative-infinity-times-float-zero
     eq. > @
       as-bytes.
         negative-infinity.times 0.0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-neg-float-zero
+  [] +> tests-negative-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
         negative-infinity.times -0.0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-int-zero
+  [] +> tests-negative-infinity-times-int-zero
     eq. > @
       as-bytes.
         positive-infinity.times 0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-nan
+  [] +> tests-negative-infinity-times-nan
     eq. > @
       as-bytes.
         negative-infinity.times nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-positive-infinity
+  [] +> tests-negative-infinity-times-positive-infinity
     eq. > @
       negative-infinity.times positive-infinity
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-negative-infinity
+  [] +> tests-negative-infinity-times-negative-infinity
     eq. > @
       negative-infinity.times negative-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-positive-float
+  [] +> tests-negative-infinity-times-positive-float
     eq. > @
       negative-infinity.times 42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-positive-int
+  [] +> tests-negative-infinity-times-positive-int
     eq. > @
       negative-infinity.times 42
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-negative-float
+  [] +> tests-negative-infinity-times-negative-float
     eq. > @
       negative-infinity.times -42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-times-negative-int
+  [] +> tests-negative-infinity-times-negative-int
     eq. > @
       negative-infinity.times -42
       positive-infinity
 
   # Plus.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-nan
+  [] +> tests-negative-infinity-plus-nan
     eq. > @
       as-bytes.
         negative-infinity.plus nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-positive-infinity
+  [] +> tests-negative-infinity-plus-positive-infinity
     eq. > @
       as-bytes.
         negative-infinity.plus positive-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-negative-infinity
+  [] +> tests-negative-infinity-plus-negative-infinity
     eq. > @
       negative-infinity
       negative-infinity.plus negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-positive-float
+  [] +> tests-negative-infinity-plus-positive-float
     eq. > @
       negative-infinity.plus 42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-positive-int
+  [] +> tests-negative-infinity-plus-positive-int
     eq. > @
       negative-infinity.plus 42
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-negative-float
+  [] +> tests-negative-infinity-plus-negative-float
     eq. > @
       negative-infinity.plus -42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-plus-negative-int
+  [] +> tests-negative-infinity-plus-negative-int
     eq. > @
       negative-infinity.plus -42
       negative-infinity
 
   # Negation.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-neg-is-positive-infinity
+  [] +> tests-negative-infinity-neg-is-positive-infinity
     eq. > @
       negative-infinity.neg
       positive-infinity
 
   # Minus.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-nan
+  [] +> tests-negative-infinity-minus-nan
     eq. > @
       as-bytes.
         negative-infinity.minus nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-negative-infinity
+  [] +> tests-negative-infinity-minus-negative-infinity
     eq. > @
       as-bytes.
         negative-infinity.minus negative-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-positive-infinity
+  [] +> tests-negative-infinity-minus-positive-infinity
     eq. > @
       negative-infinity.minus positive-infinity
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-positive-float
+  [] +> tests-negative-infinity-minus-positive-float
     eq. > @
       negative-infinity.minus 42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-positive-int
+  [] +> tests-negative-infinity-minus-positive-int
     eq. > @
       negative-infinity.minus 42
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-negative-float
+  [] +> tests-negative-infinity-minus-negative-float
     eq. > @
       negative-infinity.minus -42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-minus-negative-int
+  [] +> tests-negative-infinity-minus-negative-int
     eq. > @
       negative-infinity.minus -42
       negative-infinity
 
   # Division.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-float-zero
+  [] +> tests-negative-infinity-div-float-zero
     eq. > @
       negative-infinity.div 0.0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-neg-float-zero
+  [] +> tests-negative-infinity-div-neg-float-zero
     eq. > @
       negative-infinity.div -0.0
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-int-zero
+  [] +> tests-negative-infinity-div-int-zero
     eq. > @
       negative-infinity.div 0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-neg-int-zero
+  [] +> tests-negative-infinity-div-neg-int-zero
     eq. > @
       negative-infinity.div -0
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-nan
+  [] +> tests-negative-infinity-div-nan
     eq. > @
       as-bytes.
         negative-infinity.div nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-positive-infinity
+  [] +> tests-negative-infinity-div-positive-infinity
     eq. > @
       as-bytes.
         negative-infinity.div positive-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-negative-infinity
+  [] +> tests-negative-infinity-div-negative-infinity
     eq. > @
       as-bytes.
         negative-infinity.div negative-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-positive-float
+  [] +> tests-negative-infinity-div-positive-float
     eq. > @
       negative-infinity.div 42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-positive-int
+  [] +> tests-negative-infinity-div-positive-int
     eq. > @
       negative-infinity.div 42
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-negative-float
+  [] +> tests-negative-infinity-div-negative-float
     eq. > @
       negative-infinity.div -42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-div-negative-int
+  [] +> tests-negative-infinity-div-negative-int
     eq. > @
       negative-infinity.div -42
       positive-infinity
 
   # Bytes.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-as-bytes-is-valid
+  [] +> tests-negative-infinity-as-bytes-is-valid
     eq. > @
       negative-infinity.as-bytes
       (-1.0.div 0.0).as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-floor-is-equal-to-self
+  [] +> tests-negative-infinity-floor-is-equal-to-self
     negative-infinity.floor.eq negative-infinity > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-is-not-nan
+  [] +> tests-negative-infinity-is-not-nan
     negative-infinity.is-nan.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-is-not-finite
+  [] +> tests-negative-infinity-is-not-finite
     negative-infinity.is-finite.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-negative-infinity-is-not-integer
+  [] +> tests-negative-infinity-is-not-integer
     negative-infinity.is-integer.not > @

--- a/tests/org/eolang/number-tests.eo
+++ b/tests/org/eolang/number-tests.eo
@@ -2,21 +2,21 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > number-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-less-true
+  [] +> tests-int-less-true
     lt. > @
       10
       50
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-less-equal
+  [] +> tests-int-less-equal
     eq. > @
       not.
         lt.
@@ -25,7 +25,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-less-false
+  [] +> tests-int-less-false
     eq. > @
       not.
         lt.
@@ -34,7 +34,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-greater-true
+  [] +> tests-int-greater-true
     eq. > @
       gt.
         -200
@@ -42,7 +42,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-greater-false
+  [] +> tests-int-greater-false
     eq. > @
       not.
         gt.
@@ -51,7 +51,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-greater-equal
+  [] +> tests-int-greater-equal
     eq. > @
       not.
         gt.
@@ -60,7 +60,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-leq-true
+  [] +> tests-int-leq-true
     eq. > @
       lte.
         -200
@@ -68,7 +68,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-leq-equal
+  [] +> tests-int-leq-equal
     eq. > @
       lte.
         50
@@ -76,7 +76,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-leq-false
+  [] +> tests-int-leq-false
     eq. > @
       not.
         lte.
@@ -85,7 +85,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-gte-true
+  [] +> tests-int-gte-true
     eq. > @
       gte.
         -1000
@@ -93,7 +93,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-gte-equal
+  [] +> tests-int-gte-equal
     eq. > @
       gte.
         113
@@ -101,7 +101,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-gte-false
+  [] +> tests-int-gte-false
     eq. > @
       not.
         gte.
@@ -110,7 +110,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-equal-to-nan-and-infinites-is-false
+  [] +> tests-int-equal-to-nan-and-infinites-is-false
     eq. > @
       and.
         and.
@@ -126,7 +126,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-zero-eq-to-zero
+  [] +> tests-int-zero-eq-to-zero
     eq. > @
       eq.
         0
@@ -134,7 +134,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-zero-eq-to-float-zero
+  [] +> tests-int-zero-eq-to-float-zero
     eq. > @
       eq.
         0
@@ -142,7 +142,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-eq-true
+  [] +> tests-int-eq-true
     eq. > @
       eq.
         123
@@ -150,7 +150,7 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-int-eq-false
+  [] +> tests-int-eq-false
     eq. > @
       not.
         eq.
@@ -159,25 +159,25 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-one-plus-one
+  [] +> tests-one-plus-one
     eq. > @
       1.plus 1
       2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-one-minus-one
+  [] +> tests-one-minus-one
     eq. > @
       1.minus 1
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-different-number-types
+  [] +> tests-compares-two-different-number-types
     eq. > @
       68.eq "12345678"
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-fibonacci-number-with-recursion
+  [] +> tests-calculates-fibonacci-number-with-recursion
     eq. > @
       fibo 4
       3
@@ -190,7 +190,7 @@
           fibo (n.minus 2)
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-fibonacci-number-with-tail
+  [] +> tests-calculates-fibonacci-number-with-tail
     eq. > @
       fibonacci 4
       3
@@ -214,7 +214,7 @@
           rec (n.minus 1) (minus1.plus minus2) minus1
 
   # Checks that division by zero does not return an error object.
-  [] > tests-zero-division
+  [] +> tests-zero-division
     try > @
       seq
         *
@@ -224,7 +224,7 @@
       false
 
   # Checks that division by one returns the dividend.
-  [] > tests-division-by-one
+  [] +> tests-division-by-one
     eq. > @
       dividend.div 1
       dividend
@@ -232,27 +232,27 @@
 
   # Checks that div works properly with dividends greater than zero
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-div-for-dividend-greater-than-zero
+  [] +> tests-div-for-dividend-greater-than-zero
     eq. > @
       256.div 16
       16
 
   # Checks div with remainder
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-div-with-remainder
+  [] +> tests-div-with-remainder
     eq. > @
       floor.
         13.div -5
       -2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-div-less-than-one
+  [] +> tests-div-less-than-one
     lt. > @
       1.div 5
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-to-bytes-and-backwards
+  [] +> tests-to-bytes-and-backwards
     eq. > @
       as-number.
         as-bytes.
@@ -260,40 +260,40 @@
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-as-bytes-equals-to-int
+  [] +> tests-as-bytes-equals-to-int
     eq. > @
       42
       42.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-as-bytes-equals-to-int-backwards
+  [] +> tests-as-bytes-equals-to-int-backwards
     eq. > @
       42.as-bytes
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-multiply-by-zero
+  [] +> tests-multiply-by-zero
     eq. > @
       1000.times 0
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-number-is-not-nan
+  [] +> tests-simple-number-is-not-nan
     42.5.is-nan.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  32.is-integer > [] > int-number-is-integer
+  32.is-integer > [] +> int-number-is-integer
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  32.5.is-integer.not > [] > float-number-is-not-integer
+  32.5.is-integer.not > [] +> float-number-is-not-integer
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  32.is-finite > [] > simple-number-is-finite
+  32.is-finite > [] +> simple-number-is-finite
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-number-with-nan-bytes-is-nan
+  [] +> tests-number-with-nan-bytes-is-nan
     (number nan.as-bytes).is-nan > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-number-with-infinite-bytes-is-not-finite
+  [] +> tests-number-with-infinite-bytes-is-not-finite
     (number positive-infinity.as-bytes).is-finite.not > @

--- a/tests/org/eolang/positive-infinity-tests.eo
+++ b/tests/org/eolang/positive-infinity-tests.eo
@@ -2,49 +2,49 @@
 +home https://github.com/objectionary/eo
 +package org.eolang
 +tests
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > positive-infinity-tests
   # Equal to.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-is-equal-to-one-div-zero
+  [] +> tests-positive-infinity-is-equal-to-one-div-zero
     eq. > @
       positive-infinity
       1.0.div 0.0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-eq-positive-infinity
+  [] +> tests-positive-infinity-eq-positive-infinity
     eq. > @
       positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-eq-negative-infinity
+  [] +> tests-positive-infinity-not-eq-negative-infinity
     not. > @
       eq.
         positive-infinity
         negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-eq-nan
+  [] +> tests-positive-infinity-not-eq-nan
     not. > @
       eq.
         positive-infinity
         nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-eq-int
+  [] +> tests-positive-infinity-not-eq-int
     not. > @
       eq.
         positive-infinity
         42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-eq-float
+  [] +> tests-positive-infinity-not-eq-float
     not. > @
       eq.
         positive-infinity
@@ -52,132 +52,132 @@
 
   # Less than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-lt-positive-infinity
+  [] +> tests-positive-infinity-lt-positive-infinity
     eq. > @
       positive-infinity.lt positive-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lt-negative-infinity
+  [] +> tests-positive-infinity-not-lt-negative-infinity
     eq. > @
       positive-infinity.lt negative-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lt-nan
+  [] +> tests-positive-infinity-not-lt-nan
     eq. > @
       positive-infinity.lt nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lt-int
+  [] +> tests-positive-infinity-not-lt-int
     eq. > @
       positive-infinity.lt 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lt-float
+  [] +> tests-positive-infinity-not-lt-float
     eq. > @
       positive-infinity.lt 42.5
       false
 
   # Less or equal than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-lte-positive-infinity
+  [] +> tests-positive-infinity-lte-positive-infinity
     eq. > @
       positive-infinity.lte positive-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lte-negative-infinity
+  [] +> tests-positive-infinity-not-lte-negative-infinity
     eq. > @
       positive-infinity.lte negative-infinity
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lte-nan
+  [] +> tests-positive-infinity-not-lte-nan
     eq. > @
       positive-infinity.lte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lte-int
+  [] +> tests-positive-infinity-not-lte-int
     eq. > @
       positive-infinity.lte 42
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-lte-float
+  [] +> tests-positive-infinity-not-lte-float
     eq. > @
       positive-infinity.lte 42.5
       false
 
   # Greater than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gt-positive-infinity
+  [] +> tests-positive-infinity-gt-positive-infinity
     not. > @
       gt.
         positive-infinity
         positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gt-negative-infinity
+  [] +> tests-positive-infinity-gt-negative-infinity
     gt. > @
       positive-infinity
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-gt-nan
+  [] +> tests-positive-infinity-not-gt-nan
     not. > @
       gt.
         positive-infinity
         nan
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gt-int
+  [] +> tests-positive-infinity-gt-int
     gt. > @
       positive-infinity
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gt-float
+  [] +> tests-positive-infinity-gt-float
     gt. > @
       positive-infinity
       42.5
 
   # Greater or equal than.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gte-positive-infinity
+  [] +> tests-positive-infinity-gte-positive-infinity
     eq. > @
       positive-infinity.gte positive-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gte-negative-infinity
+  [] +> tests-positive-infinity-gte-negative-infinity
     eq. > @
       positive-infinity.gte negative-infinity
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-not-gte-nan
+  [] +> tests-positive-infinity-not-gte-nan
     eq. > @
       positive-infinity.gte nan
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gte-int
+  [] +> tests-positive-infinity-gte-int
     eq. > @
       positive-infinity.gte 42
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-gte-float
+  [] +> tests-positive-infinity-gte-float
     eq. > @
       positive-infinity.gte 42.5
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-float-equal-to-nan-and-infinites-is-false-highload
+  [] +> tests-float-equal-to-nan-and-infinites-is-false-highload
     eq. > @
       and.
         and.
@@ -207,238 +207,238 @@
 
   # Times.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-float-zero
+  [] +> tests-positive-infinity-times-float-zero
     eq. > @
       as-bytes.
         positive-infinity.times 0.0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-neg-float-zero
+  [] +> tests-positive-infinity-times-neg-float-zero
     eq. > @
       as-bytes.
         positive-infinity.times -0.0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-int-zero
+  [] +> tests-positive-infinity-times-int-zero
     eq. > @
       as-bytes.
         positive-infinity.times 0
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-nan
+  [] +> tests-positive-infinity-times-nan
     eq. > @
       as-bytes.
         positive-infinity.times nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-negative-infinity
+  [] +> tests-positive-infinity-times-negative-infinity
     eq. > @
       positive-infinity.times neg-inf
       neg-inf
     negative-infinity > neg-inf
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-positive-infinity
+  [] +> tests-positive-infinity-times-positive-infinity
     eq. > @
       positive-infinity.times positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-positive-float
+  [] +> tests-positive-infinity-times-positive-float
     eq. > @
       positive-infinity.times 42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-positive-int
+  [] +> tests-positive-infinity-times-positive-int
     eq. > @
       positive-infinity.times 42
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-negative-float
+  [] +> tests-positive-infinity-times-negative-float
     eq. > @
       positive-infinity.times -42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-times-negative-int
+  [] +> tests-positive-infinity-times-negative-int
     eq. > @
       positive-infinity.times -42
       negative-infinity
 
   # Plus
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-plus-nan
+  [] +> tests-positive-infinity-plus-nan
     eq. > @
       as-bytes.
         positive-infinity.plus nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-plus-negative-infinity
+  [] +> tests-positive-infinity-plus-negative-infinity
     eq. > @
       as-bytes.
         positive-infinity.plus negative-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-plus-positive-infinity
+  [] +> tests-positive-infinity-plus-positive-infinity
     eq. > @
       positive-infinity.plus positive-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-plus-positive-float
+  [] +> tests-positive-infinity-plus-positive-float
     eq. > @
       positive-infinity.plus 42.5
       positive-infinity
 
   # Negation
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-neg-is-negative-infinity
+  [] +> tests-positive-infinity-neg-is-negative-infinity
     eq. > @
       positive-infinity.neg
       negative-infinity
 
   # Minus
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-nan
+  [] +> tests-positive-infinity-minus-nan
     eq. > @
       as-bytes.
         positive-infinity.minus nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-positive-infinity
+  [] +> tests-positive-infinity-minus-positive-infinity
     eq. > @
       as-bytes.
         positive-infinity.minus positive-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-negative-infinity
+  [] +> tests-positive-infinity-minus-negative-infinity
     eq. > @
       positive-infinity.minus negative-infinity
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-positive-float
+  [] +> tests-positive-infinity-minus-positive-float
     eq. > @
       positive-infinity.minus 42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-positive-int
+  [] +> tests-positive-infinity-minus-positive-int
     eq. > @
       positive-infinity.minus 42
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-negative-float
+  [] +> tests-positive-infinity-minus-negative-float
     eq. > @
       positive-infinity.minus -42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-minus-negative-int
+  [] +> tests-positive-infinity-minus-negative-int
     eq. > @
       positive-infinity.minus -42
       positive-infinity
 
   # Division
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-float-zero
+  [] +> tests-positive-infinity-div-float-zero
     eq. > @
       positive-infinity.div 0.0
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-neg-float-zero
+  [] +> tests-positive-infinity-div-neg-float-zero
     eq. > @
       positive-infinity.div -0.0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-int-zero
+  [] +> tests-positive-infinity-div-int-zero
     eq. > @
       positive-infinity.div 0
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-neg-int-zero
+  [] +> tests-positive-infinity-div-neg-int-zero
     eq. > @
       positive-infinity.div -0
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-nan
+  [] +> tests-positive-infinity-div-nan
     eq. > @
       as-bytes.
         positive-infinity.div nan
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-negative-infinity
+  [] +> tests-positive-infinity-div-negative-infinity
     eq. > @
       as-bytes.
         positive-infinity.div negative-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-positive-infinity
+  [] +> tests-positive-infinity-div-positive-infinity
     eq. > @
       as-bytes.
         positive-infinity.div positive-infinity
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-positive-float
+  [] +> tests-positive-infinity-div-positive-float
     eq. > @
       positive-infinity.div 42.5
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-positive-int
+  [] +> tests-positive-infinity-div-positive-int
     eq. > @
       positive-infinity.div 42
       positive-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-negative-float
+  [] +> tests-positive-infinity-div-negative-float
     eq. > @
       positive-infinity.div -42.5
       negative-infinity
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-div-negative-int
+  [] +> tests-positive-infinity-div-negative-int
     eq. > @
       positive-infinity.div -42
       negative-infinity
 
   # Bytes.
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-as-bytes-is-valid
+  [] +> tests-positive-infinity-as-bytes-is-valid
     eq. > @
       positive-infinity.as-bytes
       (1.0.div 0.0).as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-floor-is-equal-to-self
+  [] +> tests-positive-infinity-floor-is-equal-to-self
     positive-infinity.floor.eq positive-infinity > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-is-not-nan
+  [] +> tests-positive-infinity-is-not-nan
     positive-infinity.is-nan.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-is-not-finite
+  [] +> tests-positive-infinity-is-not-finite
     positive-infinity.is-finite.not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-positive-infinity-is-not-integer
+  [] +> tests-positive-infinity-is-not-integer
     positive-infinity.is-integer.not > @

--- a/tests/org/eolang/runtime-tests.eo
+++ b/tests/org/eolang/runtime-tests.eo
@@ -2,12 +2,11 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
-+unlint unit-test-without-phi
 +unlint decorated-formation
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the globals bound objects work as tests.
 [] > runtime-tests
@@ -15,7 +14,7 @@
   true > global-test
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-understands-this-correctly
+  [] +> tests-understands-this-correctly
     eq. > @
       a 42
       42
@@ -23,7 +22,7 @@
       $.x > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-takes-parent-object
+  [] +> tests-takes-parent-object
     eq. > @
       a 42
       42
@@ -33,7 +32,7 @@
         ^.x > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-makes-object-a-constant
+  [] +> tests-makes-object-a-constant
     eq. > @
       f
       f
@@ -44,7 +43,7 @@
     foo.@ > f!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-takes-parent-through-attribute
+  [] +> tests-takes-parent-through-attribute
     [] > @
       [] > @
         [] > @
@@ -55,14 +54,14 @@
     $ > this
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-when-applies-to-closed-object
+  [] +> throws-when-applies-to-closed-object
     closed true > @
     [x] > a
       x > @
     a false > closed
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-makes-deep-object-recursively
+  [] +> tests-makes-deep-object-recursively
     eq. > @
       x 5
       0
@@ -74,7 +73,7 @@
           i.minus 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-only-once
+  [] +> tests-calculates-only-once
     eq. > @
       malloc.for
         0
@@ -91,7 +90,7 @@
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-recursion-without-arguments
+  [] +> tests-recursion-without-arguments
     eq. > @
       malloc.for 4 [m]>>
         func m > @
@@ -106,19 +105,19 @@
         n
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-unescapes-slashes
+  [] +> tests-unescapes-slashes
     eq. > @
       "x\\b\\f\\u\\r\\t\\n\\'"
       78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-unescapes-symbols
+  [] +> tests-unescapes-symbols
     eq. > @
       "\b\f\n\r\t\u27E6"
       08-0C-0A-0D-09-E2-9F-A6
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compiles-correctly-with-long-duplicate-names
+  [] +> tests-compiles-correctly-with-long-duplicate-names
     true > @
     [] > long-object-name
       [] > long-object-name
@@ -128,7 +127,7 @@
               42 > x
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-named-inner-abstract-object
+  [] +> tests-named-inner-abstract-object
     seq > @
       *
         [] > b
@@ -137,7 +136,7 @@
           true > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-app-that-calls-func
+  [] +> tests-app-that-calls-func
     eq. > @
       output
       2
@@ -150,7 +149,7 @@
     app > output
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-directly-accesses-objects-from-root
+  [] +> tests-directly-accesses-objects-from-root
     eq. > @
       Q.org.eolang.malloc.of
         8
@@ -163,7 +162,7 @@
       40
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-directly-accesses-objects-from-standard-root
+  [] +> tests-directly-accesses-objects-from-standard-root
     eq. > @
       QQ.malloc.of
         8
@@ -176,7 +175,7 @@
       40
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-standard-root-and-root
+  [] +> tests-standard-root-and-root
     eq. > @
       root
       stand-root
@@ -184,7 +183,7 @@
     Q.org.eolang.sys.os > root
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-extract-attribute-from-decoratee
+  [] +> tests-extract-attribute-from-decoratee
     eq. > @
       a.foo
       43
@@ -196,7 +195,7 @@
           1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-constant-defends-against-side-effects
+  [] +> tests-constant-defends-against-side-effects
     eq. > @
       malloc.for 7 [m]>>
         m.put > @
@@ -214,7 +213,7 @@
           x.as-number
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-parent-in-vertical-notation
+  [] +> tests-parent-in-vertical-notation
     eq. > @
       value
       5
@@ -226,7 +225,7 @@
             ^
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-parent-in-horizontal-notation
+  [] +> tests-parent-in-horizontal-notation
     eq. > @
       value
       5
@@ -236,7 +235,7 @@
         ^.^.m > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-phi-in-vertical-notation
+  [] +> tests-phi-in-vertical-notation
     eq. > @
       @.
         value
@@ -246,7 +245,7 @@
         100 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-phi-in-horizontal-notation
+  [] +> tests-phi-in-horizontal-notation
     eq. > @
       value.@
       100
@@ -255,7 +254,7 @@
         100 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-right-way-to-use-hierarchy
+  [] +> tests-right-way-to-use-hierarchy
     ((pyint 1).add (pyint 3)).eq (pyint 4) > @
     [value] > pybool
       value > @
@@ -266,7 +265,7 @@
         ^.^.pyint (^.value.plus x.value) > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-check-triple-quotes
+  [] +> tests-check-triple-quotes
     eq. > @
       """
       Hello
@@ -276,7 +275,7 @@
       "Hello\n\nHello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-correctly-handles-same-name-attrs-simplified
+  [] +> tests-correctly-handles-same-name-attrs-simplified
     eq. > @
       calc
         []
@@ -294,7 +293,7 @@
         second
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-correctly-handles-same-name-attrs
+  [] +> tests-correctly-handles-same-name-attrs
     eq. > @
       calc
         []
@@ -320,7 +319,7 @@
         s.next
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-with-void-phi
+  [] +> tests-with-void-phi
     and. > @
       (five.plus 5).eq 10
       five.hello.eq "Hello"
@@ -329,10 +328,10 @@
     x 5 > five
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] (seq (* (five.eq 5) true) > @) (5 > five) > complex-horizontal
+  [] (seq (* (five.eq 5) true) > @) (5 > five) +> complex-horizontal
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-vertical-bound-method
+  [] +> tests-vertical-bound-method
     eq. > @
       if.
         true
@@ -342,7 +341,7 @@
       "first"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-methods-by-position
+  [] +> tests-methods-by-position
     and. > @
       bound.~0.eq 1
       bound.~1.eq "Hey"
@@ -350,7 +349,7 @@
     obj 1 "Hey" > bound
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-nesting-blah-test
+  [] +> tests-nesting-blah-test
     blah0 > @
     [] > blah0
       blah1 > @

--- a/tests/org/eolang/seq-tests.eo
+++ b/tests/org/eolang/seq-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > seq-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-float-less
+  [] +> tests-seq-single-dataization-float-less
     malloc.of > @
       1
       [b]
@@ -26,7 +26,7 @@
                 1.1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-float-greater
+  [] +> tests-seq-single-dataization-float-greater
     malloc.of > @
       1
       [b]
@@ -42,7 +42,7 @@
                 0.9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-int-less
+  [] +> tests-seq-single-dataization-int-less
     malloc.of > @
       1
       [b]
@@ -58,7 +58,7 @@
                 2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-int-less-or-equal
+  [] +> tests-seq-single-dataization-int-less-or-equal
     malloc.of > @
       1
       [b]
@@ -74,7 +74,7 @@
                 1
 
   # This test should have acceptable time to pass.
-  [] > tests-very-long-seq
+  [] +> tests-very-long-seq
     eq. > @
       true
       seq
@@ -123,7 +123,7 @@
           true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-int-equal-to-test
+  [] +> tests-seq-single-dataization-int-equal-to-test
     malloc.of > @
       1
       [b]
@@ -140,7 +140,7 @@
                 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-single-dataization-int-equal-to-cache-problem-test
+  [] +> tests-seq-single-dataization-int-equal-to-cache-problem-test
     malloc.of > @
       1
       [b]
@@ -159,7 +159,7 @@
                 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-calculates-and-returns
+  [] +> tests-seq-calculates-and-returns
     eq. > @
       1
       seq
@@ -168,7 +168,7 @@
           1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-seq-calculates-and-returns-object
+  [] +> tests-seq-calculates-and-returns-object
     eq. > @
       "Hello!"
       seq

--- a/tests/org/eolang/string-tests.eo
+++ b/tests/org/eolang/string-tests.eo
@@ -2,53 +2,53 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > string-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-calculates-length-of-spaces-only
+  [] +> tests-calculates-length-of-spaces-only
     eq. > @
       " ".length
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-turns-string-into-bytes
+  [] +> tests-turns-string-into-bytes
     eq. > @
       "€ друг".as-bytes
       E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-bytes-equal-to-string
+  [] +> tests-bytes-equal-to-string
     eq. > @
       D0-B4-D1-80-D1-83-D0-B3
       "друг"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-string-equals-to-bytes
+  [] +> tests-string-equals-to-bytes
     eq. > @
       "друг"
       D0-B4-D1-80-D1-83-D0-B3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-the-length-with-n2-byte-characters
+  [] +> tests-reads-the-length-with-n2-byte-characters
     and. > @
       str.length.eq 12
       str.as-bytes.size.eq 16
     "Hello, друг!" > str
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-the-length-with-n3-byte-characters
+  [] +> tests-reads-the-length-with-n3-byte-characters
     and. > @
       str.length.eq 16
       str.as-bytes.size.eq 18
     "The अ devanagari" > str
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reads-the-length-with-n4-byte-characters
+  [] +> tests-reads-the-length-with-n4-byte-characters
     and. > @
       str.length.eq 11
       str.as-bytes.size.eq 14
@@ -57,39 +57,39 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   # The smile emoji is F0-9F-98-80 in bytes. Here we check if string.length fails if it faces
   # incomplete 4 byte character.
-  [] > throws-on-taking-length-of-incomplete-n4-byte-character
+  [] +> throws-on-taking-length-of-incomplete-n4-byte-character
     should-be-smile.length > @
     string F0-9F-98 > should-be-smile
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-different-string-types
+  [] +> tests-compares-two-different-string-types
     not. > @
       eq.
         "Hello"
         42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-string-with-nan
+  [] +> tests-compares-string-with-nan
     not. > @
       eq.
         nan
         "друг"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-string-with-positive-infinity
+  [] +> tests-compares-string-with-positive-infinity
     eq. > @
       positive-infinity.eq "друг"
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-string-with-negative-infinity
+  [] +> tests-compares-string-with-negative-infinity
     not. > @
       eq.
         negative-infinity
         "друг"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-block-one-line
+  [] +> tests-text-block-one-line
     eq. > @
       """
       Abc
@@ -97,7 +97,7 @@
       "Abc"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-block-tree-lines
+  [] +> tests-text-block-tree-lines
     eq. > @
       """
       e
@@ -107,7 +107,7 @@
       65-0A-65-0A-65
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-block-with-margin
+  [] +> tests-text-block-with-margin
     eq. > @
       """
        z
@@ -117,20 +117,20 @@
       7A-0A-20-20-79-0A-20-78
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-different-strings
+  [] +> tests-compares-two-different-strings
     not. > @
       eq.
         "Hello"
         "Good bye"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-supports-escape-sequences
+  [] +> tests-supports-escape-sequences
     eq. > @
       "Hello, \u0434\u0440\u0443\u0433!\n"
       "Hello, друг!\n"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-supports-escape-sequences-in-text
+  [] +> tests-supports-escape-sequences-in-text
     eq. > @
       """
       Hello, \u0434\u0440\u0443\u0433!\n
@@ -138,7 +138,7 @@
       "Hello, друг!\n"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-preserves-indentation-in-text
+  [] +> tests-preserves-indentation-in-text
     eq. > @
       """
       a
@@ -148,7 +148,7 @@
       "a\n b\n  c"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-compares-two-strings
+  [] +> tests-compares-two-strings
     eq. > @
       eq.
         "x"
@@ -156,55 +156,55 @@
       true
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-one-symbol-string-compares
+  [] +> tests-one-symbol-string-compares
     eq. > @
       "Ф"
       "Ф"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-supports-escape-sequences-line-break
+  [] +> tests-supports-escape-sequences-line-break
     eq. > @
       "\n"
       "\012"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-supports-escape-sequences-unicode
+  [] +> tests-supports-escape-sequences-unicode
     eq. > @
       "\u0424"
       "Ф"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-from-start
+  [] +> tests-slice-from-start
     eq. > @
       "hello".slice 0 1
       "h"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-in-the-middle
+  [] +> tests-slice-in-the-middle
     eq. > @
       "hello".slice 2 3
       "llo"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-from-the-end
+  [] +> tests-slice-from-the-end
     eq. > @
       "hello".slice 4 1
       "o"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-empty-string
+  [] +> tests-slice-empty-string
     eq. > @
       "".slice 0 0
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-no-slice-string
+  [] +> tests-no-slice-string
     eq. > @
       "no slice".slice 0 0
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-escape-sequences-line-break
+  [] +> tests-slice-escape-sequences-line-break
     eq. > @
       "\n".slice
         0
@@ -212,7 +212,7 @@
       "\012"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-escape-sequences-unicode
+  [] +> tests-slice-escape-sequences-unicode
     eq. > @
       "\u0424".slice
         0
@@ -220,25 +220,25 @@
       "Ф"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-with-n2-byte-characters
+  [] +> tests-slice-with-n2-byte-characters
     eq. > @
       "привет".slice 1 2
       "ри"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-with-n3-byte-characters
+  [] +> tests-slice-with-n3-byte-characters
     eq. > @
       "The अ is अ".slice 1 6
       "he अ i"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-with-n4-byte-characters
+  [] +> tests-slice-with-n4-byte-characters
     eq. > @
       "One 😀 and 😀 another".slice 3 8
       " 😀 and 😀"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-slice-foreign-literals
+  [] +> tests-slice-foreign-literals
     eq. > @
       "hello, 大家!".slice
         7
@@ -246,21 +246,21 @@
       "大"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-slicing-start-below-zero
+  [] +> throws-on-slicing-start-below-zero
     slice. > @
       "some string"
       -1
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-slicing-end-below-start
+  [] +> throws-on-slicing-end-below-start
     slice. > @
       "some string"
       2
       -1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-slicing-end-greater-actual
+  [] +> throws-on-slicing-end-greater-actual
     slice. > @
       "some string"
       7

--- a/tests/org/eolang/structs/bytes-as-array-tests.eo
+++ b/tests/org/eolang/structs/bytes-as-array-tests.eo
@@ -4,15 +4,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > bytes-as-array-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-bytes-to-array
+  [] +> tests-converts-bytes-to-array
     eq. > @
       list
         bytes-as-array
@@ -20,7 +19,7 @@
       * 20- 1F- EE- B5- FF-
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-single-byte-to-array
+  [] +> tests-single-byte-to-array
     eq. > @
       list
         bytes-as-array
@@ -28,7 +27,7 @@
       * 1F-
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-zero-bytes-to-array
+  [] +> tests-zero-bytes-to-array
     eq. > @
       list
         bytes-as-array

--- a/tests/org/eolang/structs/hash-code-of-tests.eo
+++ b/tests/org/eolang/structs/hash-code-of-tests.eo
@@ -3,15 +3,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > hash-code-of-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-code-of-bools-is-number
+  [] +> tests-hash-code-of-bools-is-number
     and. > @
       true-code.as-bytes.size.eq 8
       false-code.as-bytes.size.eq 8
@@ -19,7 +19,7 @@
     hash-code-of false > false-code
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-code-of-int-is-int
+  [] +> tests-hash-code-of-int-is-int
     eq. > @
       1
       div.
@@ -28,34 +28,34 @@
     hash-code-of 42 > num-code!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-big-ints-are-equal
+  [] +> tests-hash-codes-of-the-same-big-ints-are-equal
     eq. > @
       hash-code-of big-int
       hash-code-of big-int
     123456789012345678 > big-int
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-ints-are-equal
+  [] +> tests-hash-codes-of-the-same-ints-are-equal
     eq. > @
       hash-code-of 42
       hash-code-of 42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-ints-are-not-equal
+  [] +> tests-hash-codes-of-different-ints-are-not-equal
     not. > @
       eq.
         hash-code-of 42
         hash-code-of 24
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-sign-ints-are-not-equal
+  [] +> tests-hash-codes-of-different-sign-ints-are-not-equal
     not. > @
       eq.
         hash-code-of 42
         hash-code-of -42
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-code-of-string-is-int
+  [] +> tests-hash-code-of-string-is-int
     eq. > @
       1
       div.
@@ -64,27 +64,27 @@
     hash-code-of "hello" > str-code!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-strings-are-equal
+  [] +> tests-hash-codes-of-the-same-strings-are-equal
     eq. > @
       hash-code-of "Hello"
       hash-code-of "Hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-same-length-strings-are-not-equal
+  [] +> tests-hash-codes-of-same-length-strings-are-not-equal
     not. > @
       eq.
         hash-code-of "one"
         hash-code-of "two"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-strings-are-not-equal
+  [] +> tests-hash-codes-of-different-strings-are-not-equal
     not. > @
       eq.
         hash-code-of "hello"
         hash-code-of "bye!!!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-code-of-abstract-object-is-int
+  [] +> tests-hash-code-of-abstract-object-is-int
     eq. > @
       1
       div.
@@ -95,7 +95,7 @@
     hash-code-of (obj 42) > obj-code!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-abstract-objects-are-equal
+  [] +> tests-hash-codes-of-the-same-abstract-objects-are-equal
     eq. > @
       hash-code-of forty-two-obj
       hash-code-of forty-two-obj
@@ -104,7 +104,7 @@
     obj 42 > forty-two-obj
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-abstract-objects-are-not-equal
+  [] +> tests-hash-codes-of-different-abstract-objects-are-not-equal
     not. > @
       eq.
         hash-code-of (obj 42)
@@ -113,7 +113,7 @@
       x > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-code-of-float-is-int
+  [] +> tests-hash-code-of-float-is-int
     eq. > @
       1
       div.
@@ -122,28 +122,28 @@
     hash-code-of 42.42 > float-code!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-floats-are-equal
+  [] +> tests-hash-codes-of-the-same-floats-are-equal
     eq. > @
       hash-code-of emergency
       hash-code-of emergency
     0.911 > emergency
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-the-same-big-floats-are-equal
+  [] +> tests-hash-codes-of-the-same-big-floats-are-equal
     eq. > @
       hash-code-of big-float
       hash-code-of big-float
     42.42e42 > big-float!
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-floats-are-not-equal
+  [] +> tests-hash-codes-of-different-floats-are-not-equal
     not. > @
       eq.
         hash-code-of 3.14
         hash-code-of 2.72
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-hash-codes-of-different-sign-floats-are-not-equal
+  [] +> tests-hash-codes-of-different-sign-floats-are-not-equal
     not. > @
       eq.
         hash-code-of 3.22

--- a/tests/org/eolang/structs/list-tests.eo
+++ b/tests/org/eolang/structs/list-tests.eo
@@ -4,15 +4,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > list-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-should-not-be-empty
+  [] +> tests-list-should-not-be-empty
     not. > @
       is-empty.
         list
@@ -22,7 +22,7 @@
   (list *).is-empty > [] > list-should-be-empty
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-should-not-be-empty-with-three-objects
+  [] +> tests-list-should-not-be-empty-with-three-objects
     (list xs).is-empty.not > @
     * > xs
       [x]
@@ -30,13 +30,13 @@
       [z]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-should-not-be-empty-with-one-anon-object
+  [] +> tests-list-should-not-be-empty-with-one-anon-object
     (list xs).is-empty.not > @
     * > xs
       [f]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-simple-with
+  [] +> tests-list-simple-with
     eq. > @
       with.
         list
@@ -45,7 +45,7 @@
       * 1 2 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-insert
+  [] +> tests-simple-insert
     eq. > @
       withi.
         list
@@ -55,7 +55,7 @@
       * 1 2 3 "hello" 4 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-insert-with-zero-index
+  [] +> tests-insert-with-zero-index
     eq. > @
       withi.
         list
@@ -65,7 +65,7 @@
       * "hello" 1 2 3 4 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-reduce-list-with-index
+  [] +> tests-reduce-list-with-index
     eq. > @
       6
       reducedi.
@@ -80,7 +80,7 @@
     * 2 2 > src
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-reducedi-long-int-array
+  [] +> tests-list-reducedi-long-int-array
     eq. > @
       reducedi.
         list
@@ -90,7 +90,7 @@
       1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-reducedi-bools-array
+  [] +> tests-list-reducedi-bools-array
     not. > @
       reducedi.
         list
@@ -99,7 +99,7 @@
         x.and a > [a x i]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-reducedi-nested-functions
+  [] +> tests-list-reducedi-nested-functions
     eq. > @
       reducedi.
         list
@@ -117,7 +117,7 @@
         0.minus 500
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-reduce-without-index
+  [] +> tests-list-reduce-without-index
     eq. > @
       reduced.
         list
@@ -127,7 +127,7 @@
       -24
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-reduced-printing
+  [] +> tests-list-reduced-printing
     eq. > @
       reduced.
         list
@@ -141,7 +141,7 @@
       "01"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-complex-objects-list-comparison
+  [] +> tests-complex-objects-list-comparison
     list > res
       *
         list (* 0 1)
@@ -154,7 +154,7 @@
         * 7 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-mappedi-should-work
+  [] +> tests-list-mappedi-should-work
     eq. > @
       mappedi.
         list
@@ -172,7 +172,7 @@
       * 2 4 6
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterates-with-eachi
+  [] +> tests-iterates-with-eachi
     eq. > @
       malloc.for
         0
@@ -188,7 +188,7 @@
       9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterates-with-each
+  [] +> tests-iterates-with-each
     eq. > @
       malloc.for
         0
@@ -200,7 +200,7 @@
       6
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-withouti
+  [] +> tests-list-withouti
     eq. > @
       withouti.
         list
@@ -209,7 +209,7 @@
       * 1 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-withouti-complex-case
+  [] +> tests-list-withouti-complex-case
     eq. > @
       foo
         * 1 "text" "f"
@@ -220,7 +220,7 @@
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-withouti-nested-array
+  [] +> tests-list-withouti-nested-array
     eq. > @
       withouti.
         list
@@ -230,7 +230,7 @@
     * 3 2 1 > nested
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-without
+  [] +> tests-list-without
     eq. > @
       without.
         list
@@ -239,14 +239,14 @@
       * 1 1 1 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-equality-test
+  [] +> tests-equality-test
     eq. > @
       list
         * 1 2 3
       * 1 2 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-not-equality-test
+  [] +> tests-not-equality-test
     not. > @
       eq.
         list
@@ -254,7 +254,7 @@
         * 3 2 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concatenates-lists
+  [] +> tests-concatenates-lists
     and. > @
       eq.
         1
@@ -271,7 +271,7 @@
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-concatenates-with-tuple
+  [] +> tests-concatenates-with-tuple
     eq. > @
       concat.
         list
@@ -280,7 +280,7 @@
       * 0 1 2 4
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-index-of
+  [] +> tests-returns-index-of
     eq. > @
       1
       index-of.
@@ -289,7 +289,7 @@
         2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-first-index-of-element
+  [] +> tests-returns-first-index-of-element
     eq. > @
       0
       index-of.
@@ -298,7 +298,7 @@
         -1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-find-index-of
+  [] +> tests-does-not-find-index-of
     eq. > @
       -1
       index-of.
@@ -307,7 +307,7 @@
         7
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-index-of-string
+  [] +> tests-finds-index-of-string
     eq. > @
       1
       index-of.
@@ -316,7 +316,7 @@
         "qwerty"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-last-index-of
+  [] +> tests-finds-last-index-of
     eq. > @
       1
       last-index-of.
@@ -325,7 +325,7 @@
         2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-last-index-of-repeated
+  [] +> tests-finds-last-index-of-repeated
     eq. > @
       2
       last-index-of.
@@ -334,7 +334,7 @@
         24
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-not-found
+  [] +> tests-last-index-of-not-found
     eq. > @
       -1
       last-index-of.
@@ -343,7 +343,7 @@
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-empty
+  [] +> tests-last-index-of-empty
     eq. > @
       -1
       last-index-of.
@@ -351,7 +351,7 @@
         "abc"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-unicode
+  [] +> tests-last-index-of-unicode
     eq. > @
       3
       last-index-of.
@@ -360,21 +360,21 @@
         "Привет"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-contains-string
+  [] +> tests-list-contains-string
     contains. > @
       list
         * "qwerty" "asdfgh" 3 "qwerty"
       "qwerty"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-contains-number
+  [] +> tests-list-contains-number
     contains. > @
       list
         * "qwerty" "asdfgh" 3 "qwerty"
       3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-does-not-contain
+  [] +> tests-list-does-not-contain
     not. > @
       contains.
         list
@@ -382,7 +382,7 @@
         "Hi"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filteredi-with-lt
+  [] +> tests-filteredi-with-lt
     eq. > @
       filteredi.
         list
@@ -391,7 +391,7 @@
       * 1 2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filteredi-with-string-length
+  [] +> tests-filteredi-with-string-length
     eq. > @
       filteredi.
         list
@@ -400,7 +400,7 @@
       * "Hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filteredi-with-empty-list
+  [] +> tests-filteredi-with-empty-list
     is-empty. > @
       filteredi.
         list
@@ -408,7 +408,7 @@
         v.lt 3 > [v i]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filteredi-by-index
+  [] +> tests-filteredi-by-index
     eq. > @
       filteredi.
         list
@@ -417,7 +417,7 @@
       * 1 4
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filteredi-with-bools
+  [] +> tests-filteredi-with-bools
     eq. > @
       filteredi.
         list
@@ -426,7 +426,7 @@
       * false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-filtered
+  [] +> tests-simple-filtered
     eq. > @
       filtered.
         list
@@ -435,7 +435,7 @@
       * 3 4 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-filtered-with-bools
+  [] +> tests-filtered-with-bools
     eq. > @
       filtered.
         list
@@ -444,7 +444,7 @@
       * false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-head
+  [] +> tests-simple-head
     eq. > @
       head.
         list
@@ -453,7 +453,7 @@
       * 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-head-with-zero-index
+  [] +> tests-list-head-with-zero-index
     is-empty. > @
       head.
         list
@@ -461,7 +461,7 @@
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-list-head-with-length-index
+  [] +> tests-list-head-with-length-index
     eq. > @
       head.
         list
@@ -470,7 +470,7 @@
       * 1 2 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-complex-head
+  [] +> tests-complex-head
     eq. > @
       head.
         list
@@ -479,7 +479,7 @@
       * "foo" 2.2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-head-with-negative
+  [] +> tests-head-with-negative
     eq. > @
       head.
         list
@@ -488,7 +488,7 @@
       * 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-complex-head-with-negative
+  [] +> tests-complex-head-with-negative
     eq. > @
       head.
         list
@@ -497,7 +497,7 @@
       * 2.2 00-01 "bar"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-tail
+  [] +> tests-simple-tail
     eq. > @
       tail.
         list
@@ -506,7 +506,7 @@
       * 4 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-zero-index-in-tail
+  [] +> tests-zero-index-in-tail
     is-empty. > @
       tail.
         list
@@ -514,7 +514,7 @@
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-large-index-in-tail
+  [] +> tests-large-index-in-tail
     eq. > @
       tail.
         list

--- a/tests/org/eolang/structs/map-tests.eo
+++ b/tests/org/eolang/structs/map-tests.eo
@@ -3,15 +3,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > map-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-map-rebuilds-itself
+  [] +> tests-map-rebuilds-itself
     2.eq mp.size > @
     map > mp
       *
@@ -21,7 +21,7 @@
         map.entry 2 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-map-rebuilds-itself-only-once
+  [] +> tests-map-rebuilds-itself-only-once
     eq. > @
       1
       malloc.for
@@ -39,7 +39,7 @@
                 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-list-of-keys
+  [] +> tests-returns-list-of-keys
     eq. > @
       keys.
         map
@@ -50,7 +50,7 @@
       * 1 2 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-list-of-values
+  [] +> tests-returns-list-of-values
     eq. > @
       values.
         map
@@ -61,7 +61,7 @@
       * 2 3 4
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-element-by-key-in-map
+  [] +> tests-finds-element-by-key-in-map
     2.eq found.get > @
     map > mp
       *
@@ -71,7 +71,7 @@
     mp.found "two" > found
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-find-element-by-key-in-hash-map
+  [] +> tests-does-not-find-element-by-key-in-hash-map
     map
       *
         map.entry "one" 1
@@ -81,7 +81,7 @@
     .not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-has-element-with-key-in-hash-map
+  [] +> tests-has-element-with-key-in-hash-map
     map
       *
         map.entry "one" 1
@@ -89,7 +89,7 @@
     .has "two" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-have-element-by-key-in-hash-map
+  [] +> tests-does-not-have-element-by-key-in-hash-map
     map
       *
         map.entry "one" 1
@@ -98,7 +98,7 @@
     .not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-change-map-without-non-existed-element
+  [] +> tests-does-not-change-map-without-non-existed-element
     map
       *
         map.entry "one" 1
@@ -107,7 +107,7 @@
     .eq 1 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-removes-element-from-map-by-key
+  [] +> tests-removes-element-from-map-by-key
     and. > @
       1.eq mp.size
       (mp.has "one").not
@@ -118,7 +118,7 @@
     .without "one" > mp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-adds-new-pair-to-hash-map
+  [] +> tests-adds-new-pair-to-hash-map
     and. > @
       2.eq mp.size
       mp.has "two"
@@ -128,7 +128,7 @@
     .with "two" 2 > mp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-replaces-value-if-pair-with-key-exists-in-map
+  [] +> tests-replaces-value-if-pair-with-key-exists-in-map
     and. > @
       2.eq mp.size
       3.eq (mp.found "two").get

--- a/tests/org/eolang/structs/range-of-ints-tests.eo
+++ b/tests/org/eolang/structs/range-of-ints-tests.eo
@@ -3,43 +3,42 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > range-of-ints-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-range-of-ints-from-one-to-ten
+  [] +> tests-simple-range-of-ints-from-one-to-ten
     eq. > @
       range-of-ints 1 10
       * 1 2 3 4 5 6 7 8 9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-range-of-ints-from-ten-to-ten-is-empty
+  [] +> tests-range-of-ints-from-ten-to-ten-is-empty
     is-empty. > @
       range-of-ints 10 10
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-range-of-descending-ints-is-empty
+  [] +> tests-range-of-descending-ints-is-empty
     is-empty. > @
       range-of-ints 10 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-range-of-negative-ints-works-as-well
+  [] +> tests-range-of-negative-ints-works-as-well
     eq. > @
       range-of-ints -5 0
       * -5 -4 -3 -2 -1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-range-of-ints-with-non-int-start
+  [] +> throws-on-range-of-ints-with-non-int-start
     range-of-ints 1.2 3 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-range-of-ints-with-not-int-end
+  [] +> throws-on-range-of-ints-with-not-int-end
     range-of-ints 1 2.5 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-range-of-not-ints
+  [] +> throws-on-range-of-not-ints
     range-of-ints 1.5 5.2 > @

--- a/tests/org/eolang/structs/range-tests.eo
+++ b/tests/org/eolang/structs/range-tests.eo
@@ -3,14 +3,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > range-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-range-from-one-to-ten
+  [] +> tests-simple-range-from-one-to-ten
     eq. > @
       rng
       * 1 2 3 4 5 6 7 8 9
@@ -23,7 +24,7 @@
       10
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-range-with-floats-from-one-to-five
+  [] +> tests-simple-range-with-floats-from-one-to-five
     eq. > @
       rng
       * 1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5
@@ -36,7 +37,7 @@
       5.0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-range-with-out-of-bounds
+  [] +> tests-range-with-out-of-bounds
     eq. > @
       rng
       * 1 6
@@ -49,7 +50,7 @@
       10
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-range-with-wrong-items-is-an-empty-array
+  [] +> tests-range-with-wrong-items-is-an-empty-array
     rng.is-empty > @
     range > rng
       []

--- a/tests/org/eolang/structs/set-tests.eo
+++ b/tests/org/eolang/structs/set-tests.eo
@@ -3,22 +3,21 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.structs
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > set-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-set-rebuilds-itself
+  [] +> tests-set-rebuilds-itself
     eq. > @
       set
         * 1 2 2
       * 1 2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-append-existed-item-to-set
+  [] +> tests-does-not-append-existed-item-to-set
     set
       * 1 2
     .with 1
@@ -26,14 +25,14 @@
     .eq 2 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-appends-new-item-to-set
+  [] +> tests-appends-new-item-to-set
     set
       * 1 2
     .with 3
     .has 3 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-empty-set-has-size-of-zero
+  [] +> tests-empty-set-has-size-of-zero
     set
       *
     .size

--- a/tests/org/eolang/switch-tests.eo
+++ b/tests/org/eolang/switch-tests.eo
@@ -2,15 +2,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > switch-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-switch-simple-case
+  [] +> tests-switch-simple-case
     eq. > @
       switch
         *
@@ -23,7 +22,7 @@
       "2"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-switch-strings-case
+  [] +> tests-switch-strings-case
     eq. > @
       switch
         *
@@ -40,7 +39,7 @@
     "swordfish" > password
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-switch-with-several-true-cases
+  [] +> tests-switch-with-several-true-cases
     eq. > @
       switch
         *
@@ -56,7 +55,7 @@
       "TRUE1"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-switch-with-all-false-cases
+  [] +> tests-switch-with-all-false-cases
     switch > @
       *
         *
@@ -67,11 +66,11 @@
           "false2"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-empty-switch
+  [] +> throws-on-empty-switch
     switch * > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-switch-complex-case
+  [] +> tests-switch-complex-case
     eq. > @
       switch
         *

--- a/tests/org/eolang/sys/os-tests.eo
+++ b/tests/org/eolang/sys/os-tests.eo
@@ -3,15 +3,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > os-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-os-family
+  [] +> tests-checks-os-family
     or. > @
       or.
         os.is-windows

--- a/tests/org/eolang/sys/posix-tests.eo
+++ b/tests/org/eolang/sys/posix-tests.eo
@@ -4,15 +4,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > posix-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-invokes-getpid-correctly
+  [] +> tests-invokes-getpid-correctly
     or. > @
       os.is-windows
       gt.
@@ -23,7 +23,7 @@
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-opens-posix-tcp-socket
+  [] +> tests-opens-posix-tcp-socket
     or. > @
       os.is-windows
       try
@@ -39,7 +39,7 @@
         * posix.af-inet posix.sock-stream posix.ipproto-tcp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-closes-posix-tcp-socket
+  [] +> tests-closes-posix-tcp-socket
     or. > @
       os.is-windows
       seq
@@ -58,7 +58,7 @@
         * posix.af-inet posix.sock-stream posix.ipproto-tcp
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-posix-inet-addr-for-localhost
+  [] +> tests-returns-valid-posix-inet-addr-for-localhost
     or. > @
       os.is-windows
       addr.eq 16777343

--- a/tests/org/eolang/sys/win32-tests.eo
+++ b/tests/org/eolang/sys/win32-tests.eo
@@ -4,14 +4,14 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.sys
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > win32-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-win32-inet-addr-for-localhost
+  [] +> tests-returns-valid-win32-inet-addr-for-localhost
     or. > @
       os.is-windows.not
       addr.eq 16777343

--- a/tests/org/eolang/try-tests.eo
+++ b/tests/org/eolang/try-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > try-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-catches-simple-exception
+  [] +> tests-catches-simple-exception
     try > @
       slice.
         "some string"
@@ -20,7 +20,7 @@
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-two-nested-try-blocks
+  [] +> tests-two-nested-try-blocks
     try > @
       try
         slice.
@@ -33,7 +33,7 @@
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-try-without-error-block
+  [] +> tests-try-without-error-block
     eq. > @
       try
         30.plus 2
@@ -42,7 +42,7 @@
       32
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-try-malloc-update-catch
+  [] +> tests-try-malloc-update-catch
     eq. > @
       malloc.of
         8

--- a/tests/org/eolang/tuple-tests.eo
+++ b/tests/org/eolang/tuple-tests.eo
@@ -2,34 +2,34 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > tuple-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-makes-tuple-through-special-syntax
+  [] +> tests-makes-tuple-through-special-syntax
     eq. > @
       (* 1 2).length
       2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-gets-lengths-of-empty-tuple-through-special-syntax
+  [] +> tests-gets-lengths-of-empty-tuple-through-special-syntax
     eq. > @
       *.length
       0
 
   # Check that an empty tuples .length equals to zero.
-  [] > tests-empty-tuple-length
+  [] +> tests-empty-tuple-length
     eq. > @
       (arr *).elements.length
       0
     [elements] > arr
 
   # Check that tuple.length works properly for non-empty tuples.
-  [] > tests-non-empty-tuple-length-test
+  [] +> tests-non-empty-tuple-length-test
     eq. > @
       arr
         * "a" "b" "c" "d" "e"
@@ -39,14 +39,14 @@
     [elements] > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-as-a-bound-attribute-size-0
+  [] +> tests-tuple-as-a-bound-attribute-size-0
     eq. > @
       anArray.length
       0
     * > anArray
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-as-a-bound-attribute-size-1
+  [] +> tests-tuple-as-a-bound-attribute-size-1
     eq. > @
       anArray.at 0
       100
@@ -54,7 +54,7 @@
       100
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-as-a-bound-attribute-size-2
+  [] +> tests-tuple-as-a-bound-attribute-size-2
     and. > @
       eq.
         arr.at 0
@@ -67,7 +67,7 @@
       2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-with
+  [] +> tests-tuple-with
     and. > @
       and.
         and.
@@ -88,13 +88,13 @@
       "with"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-wrong-tuple-at
+  [] +> throws-on-wrong-tuple-at
     at. > @
       * 1 2 3 4
       20
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-fluent-with
+  [] +> tests-tuple-fluent-with
     and. > @
       and.
         eq.
@@ -109,7 +109,7 @@
     ((*.with 1).with 2).with 3 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-fluent-with-indented
+  [] +> tests-tuple-fluent-with-indented
     and. > @
       and.
         eq.
@@ -127,41 +127,41 @@
     .with 3 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-gets-lengths-of-empty-tuple
+  [] +> tests-gets-lengths-of-empty-tuple
     eq. > @
       a.length
       0
     tuple.empty > a
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-gets-lengths-of-empty-tuple-without-additional-obj
+  [] +> tests-gets-lengths-of-empty-tuple-without-additional-obj
     eq. > @
       tuple.empty.length
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-creates-empty-tuple-with-number
+  [] +> tests-creates-empty-tuple-with-number
     eq. > @
       a.at 0
       3
     tuple.empty.with 3 > a
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-at-fast-with-first-element
+  [] +> tests-at-fast-with-first-element
     eq. > @
       (arr.at 0).at-fast arr
       100
     * 100 101 102 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-at-fast-with-last-element
+  [] +> tests-at-fast-with-last-element
     eq. > @
       (arr.at 2).at-fast arr
       102
     * 100 101 102 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-empty-fluent-with-indented-keyword
+  [] +> tests-tuple-empty-fluent-with-indented-keyword
     and. > @
       and.
         eq.
@@ -180,20 +180,20 @@
     .with 3 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-with-negative-index-gets-last
+  [] +> tests-tuple-with-negative-index-gets-last
     eq. > @
       arr.at -1
       4
     * 0 1 2 3 4 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-tuple-with-negative-index-gets-first
+  [] +> tests-tuple-with-negative-index-gets-first
     eq. > @
       arr.at -5
       0
     * 0 1 2 3 4 > arr
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-out-of-tuple-bounds-with-negative-index
+  [] +> throws-on-out-of-tuple-bounds-with-negative-index
     arr.at -6 > @
     * 0 1 2 3 4 > arr

--- a/tests/org/eolang/txt/regex-tests.eo
+++ b/tests/org/eolang/txt/regex-tests.eo
@@ -3,23 +3,23 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > regex-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-matches-regex-against-the-pattern
+  [] +> tests-matches-regex-against-the-pattern
     (regex "/[a-z]+/").compiled.matches "hello" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-matches-regex-against-the-pattern
+  [] +> tests-does-not-matches-regex-against-the-pattern
     ((regex "/[a-z]+/").compiled.matches "123").not > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-matched-sequence-has-right-border-indexes
+  [] +> tests-matched-sequence-has-right-border-indexes
     and. > @
       0.eq n.start
       and.
@@ -28,11 +28,11 @@
     ((regex "/[a-z]+/").match "!hello!").next > n
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-returns-valid-matched-string-sequence
+  [] +> tests-regex-returns-valid-matched-string-sequence
     ((regex "/[a-z]+/").match "!hello!").next.text.eq "hello" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-returns-valid-second-matched-block
+  [] +> tests-regex-returns-valid-second-matched-block
     and. > @
       and.
         and.
@@ -45,7 +45,7 @@
     ((regex "/[a-z]+/").match "!hello!world!").next.next > second
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-next-on-not-matched-block
+  [] +> throws-on-getting-next-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.next > @
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/sprintf-tests.eo
+++ b/tests/org/eolang/txt/sprintf-tests.eo
@@ -3,17 +3,16 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 +unlint wrong-sprintf-arguments
 +unlint sprintf-without-formatters
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sprintf-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-prints-simple-string
+  [] +> tests-prints-simple-string
     eq. > @
       "Hello, Jeffrey!"
       sprintf
@@ -21,7 +20,7 @@
         * "Jeffrey"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-prints-complex-string
+  [] +> tests-prints-complex-string
     eq. > @
       "Привет 3.140000 Jeff X!"
       sprintf
@@ -29,7 +28,7 @@
         * 3.14 "Jeff" "X"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-prints-bytes-string
+  [] +> tests-prints-bytes-string
     eq. > @
       "40-45-00-00-00-00-00-00"
       sprintf
@@ -37,7 +36,7 @@
         * 42.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-formats-all-objects
+  [] +> tests-formats-all-objects
     eq. > @
       "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
       sprintf
@@ -45,13 +44,13 @@
         * "Jeff" "Jeff".as-bytes 42.3 14 false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-sprintf-with-arguments-that-does-not-match
+  [] +> throws-on-sprintf-with-arguments-that-does-not-match
     sprintf > @
       "%s%s"
       * "Jeff"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sprintf-does-not-fail-if-arguments-more-than-formats
+  [] +> tests-sprintf-does-not-fail-if-arguments-more-than-formats
     eq. > @
       "Hey"
       sprintf
@@ -59,7 +58,7 @@
         * "Hey" "Jeff"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-sprintf-unsupported-format
+  [] +> throws-on-sprintf-unsupported-format
     sprintf "%o" * > @
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/tests/org/eolang/txt/sscanf-tests.eo
+++ b/tests/org/eolang/txt/sscanf-tests.eo
@@ -5,40 +5,39 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > sscanf-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-string
+  [] +> tests-sscanf-with-string
     eq. > @
       "hello"
       value.
         sscanf "%s" "hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-int
+  [] +> tests-sscanf-with-int
     eq. > @
       33
       value.
         sscanf "%d" "33"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-float
+  [] +> tests-sscanf-with-float
     eq. > @
       0.24
       value.
         sscanf "%f" "0.24"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-sscanf-with-wrong-format
+  [] +> throws-on-sscanf-with-wrong-format
     sscanf "%l" "error" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-string-int-float
+  [] +> tests-sscanf-with-string-int-float
     eq. > @
       list
         sscanf
@@ -47,28 +46,28 @@
       * "hello" 33 0.24
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-string-with-ending
+  [] +> tests-sscanf-with-string-with-ending
     eq. > @
       "hello"
       value.
         sscanf "%s!" "hello!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-complex-string
+  [] +> tests-sscanf-with-complex-string
     eq. > @
       "test"
       value.
         sscanf "some%sstring" "someteststring"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-complex-int
+  [] +> tests-sscanf-with-complex-int
     eq. > @
       734987259
       value.
         sscanf "!%d!" "!734987259!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sscanf-with-complex-float
+  [] +> tests-sscanf-with-complex-float
     eq. > @
       1991.01
       value.

--- a/tests/org/eolang/txt/text-tests.eo
+++ b/tests/org/eolang/txt/text-tests.eo
@@ -5,27 +5,26 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang.txt
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > text-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-slices-the-origin-string
+  [] +> tests-text-slices-the-origin-string
     eq. > @
       (text "Hello, world!").slice 7 5
       "world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-trimmed-left-empty-text
+  [] +> tests-trimmed-left-empty-text
     eq. > @
       (text "").trimmed-left
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-left-one-space
+  [] +> tests-text-trimmed-left-one-space
     eq. > @
       (text " s").trimmed-left
       "s"

--- a/tests/org/eolang/while-tests.eo
+++ b/tests/org/eolang/while-tests.eo
@@ -2,15 +2,15 @@
 +home https://github.com/objectionary/eo
 +tests
 +package org.eolang
-+version 0.56.0
++version 0.56.2
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint sparse-decoration
++unlint duplicate-names-in-diff-context
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > while-tests
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-while-dataizes-only-first-cycle
+  [] +> tests-while-dataizes-only-first-cycle
     eq. > @
       0
       malloc.for
@@ -21,14 +21,14 @@
             m.put i > [i] >>
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-while-with-false-first
+  [] +> tests-simple-while-with-false-first
     not. > @
       while > res
         false > [i]
         true > [i]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-bool-expression-via-malloc-in-while
+  [] +> tests-simple-bool-expression-via-malloc-in-while
     eq. > @
       malloc.for
         true
@@ -39,7 +39,7 @@
       false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-while-dataization-object
+  [] +> tests-last-while-dataization-object
     eq. > @
       malloc.for
         0
@@ -50,14 +50,14 @@
       3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-while-dataization-object-with-false-condition
+  [] +> tests-last-while-dataization-object-with-false-condition
     not. > @
       while
         1.gt 2 > [i]
         true > [i]
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-while-simple-iteration
+  [] +> tests-while-simple-iteration
     eq. > @
       malloc.for
         0
@@ -68,7 +68,7 @@
       9
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterating-tuple-with-while-using-internal-iterator
+  [] +> tests-iterating-tuple-with-while-using-internal-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
     arr.length.plus -1 > max
@@ -95,7 +95,7 @@
                         iter.as-number.plus 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterating-tuple-with-while-using-external-iterator
+  [] +> tests-iterating-tuple-with-while-using-external-iterator
     data.eq arr.length > @
     * 1 1 1 1 > arr
     arr.length.plus -1 > max
@@ -117,7 +117,7 @@
                       iter.as-number.plus 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterating-tuple-with-while-without-body-multiple
+  [] +> tests-iterating-tuple-with-while-without-body-multiple
     data.eq arr.length > @
     * 1 1 1 > arr
     arr.length > max
@@ -147,7 +147,7 @@
                 acc
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-iterating-tuple-with-while-without-body-single
+  [] +> tests-iterating-tuple-with-while-without-body-single
     data.eq arr.length > @
     * 1 > arr
     arr.length > max


### PR DESCRIPTION
A new release `eo-0.56.2` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.