### PR TITLE
New release for eo-0.56.5

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.56.4</eo.version>
+    <eo.version>0.56.5</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
@@ -23,3 +23,31 @@
   # Or.
   # A logical operation that returns True if at least one of the given conditions is true.
   01-.eq x > [x] > or
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-true-not-is-false
+    eq. > @
+      true.not
+      false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compares-bool-to-string
+    and. > @
+      true.eq "\001"
+      false.eq "\000"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-true-and-false-is-false
+    not. > @
+      and.
+        true
+        false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-forks-on-false-condition
+    eq. > @
+      if.
+        5.eq 8
+        123
+        42
+      42

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.4
++version 0.56.5
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,0 +1,443 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang
++version 0.56.5
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint decorated-formation
++unlint cti
++unlint incorrect-unlint
++unlint unlint-non-existing-defect
+
+# Runtime.
+[] > runtime
+  # This unit test is supposed to check the globals bound objects work as tests.
+  true +> global-test
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-understands-this-correctly
+    eq. > @
+      a 42
+      42
+    [x] > a
+      $.x > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-takes-parent-object
+    eq. > @
+      a 42
+      42
+    [x] > a
+      take > @
+      [] > take
+        ^.x > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-makes-object-a-constant
+    eq. > @
+      f
+      f
+    [] > foo
+      times. > @
+        50
+        50
+    foo.@ > f!
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-takes-parent-through-attribute
+    [] > @
+      [] > @
+        [] > @
+          eq. > @
+            this.x
+            42
+    42 > x
+    $ > this
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> throws-when-applies-to-closed-object
+    closed true > @
+    [x] > a
+      x > @
+    a false > closed
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-makes-deep-object-recursively
+    eq. > @
+      x 5
+      0
+    [i] > x
+      if. > @
+        i.lt 0
+        0
+        x
+          i.minus 1
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-calculates-only-once
+    eq. > @
+      malloc.for
+        0
+        [m] > x
+          seq > @
+            *
+              a.neg.neg.neg.neg.eq 42
+              m
+          [] > a
+            seq > @
+              *
+                ^.m.put (^.m.as-number.plus 1)
+                42
+      1
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-recursion-without-arguments
+    eq. > @
+      malloc.for 4 [m]>>
+        func m > @
+      0
+    [n] > func
+      if. > @
+        n.as-number.gt 0
+        seq
+          *
+            n.put (n.as-number.minus 1)
+            ^.func n
+        n
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-unescapes-slashes
+    eq. > @
+      "x\\b\\f\\u\\r\\t\\n\\'"
+      78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-unescapes-symbols
+    eq. > @
+      "\b\f\n\r\t\u27E6"
+      08-0C-0A-0D-09-E2-9F-A6
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compiles-correctly-with-long-duplicate-names
+    true > @
+    [] > long-object-name
+      [] > long-object-name
+        [] > long-object-name
+          [] > long-object-name
+            [] > long-object-name
+              42 > x
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-named-inner-abstract-object
+    seq > @
+      *
+        [] > b
+          false > @
+        [] > a
+          true > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-app-that-calls-func
+    eq. > @
+      output
+      2
+    [] > app
+      f > @
+        * 1 2 3
+      [args] > f
+        2 > @
+        1 > a
+    app > output
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-directly-accesses-objects-from-root
+    eq. > @
+      Q.org.eolang.malloc.of
+        8
+        [m]
+          seq > @
+            *
+              m.put 42
+              m.put
+                m.as-number.minus 2
+      40
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-directly-accesses-objects-from-standard-root
+    eq. > @
+      QQ.malloc.of
+        8
+        [m]
+          seq > @
+            *
+              m.put 42
+              m.put
+                m.as-number.minus 2
+      40
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-standard-root-and-root
+    eq. > @
+      root
+      stand-root
+    QQ.sys.os > stand-root
+    Q.org.eolang.sys.os > root
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-extract-attribute-from-decoratee
+    eq. > @
+      a.foo
+      43
+    [foo] > return
+    [] > a
+      ^.return > @
+        plus.
+          42
+          1
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-constant-defends-against-side-effects
+    eq. > @
+      malloc.for 7 [m]>>
+        m.put > @
+          times.
+            num
+            num
+        number > num
+          ^.inc m > n!
+      64
+    [x] > inc
+      seq > @
+        *
+          x.put
+            x.as-number.plus 1
+          x.as-number
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-parent-in-vertical-notation
+    eq. > @
+      value
+      5
+    5 > m
+    [] > value
+      [] > @
+        m. > @
+          ^.
+            ^
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-parent-in-horizontal-notation
+    eq. > @
+      value
+      5
+    5 > m
+    [] > value
+      [] > @
+        ^.^.m > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-phi-in-vertical-notation
+    eq. > @
+      @.
+        value
+      100
+    [] > value
+      [] > @
+        100 > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-phi-in-horizontal-notation
+    eq. > @
+      value.@
+      100
+    [] > value
+      [] > @
+        100 > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-right-way-to-use-hierarchy
+    ((pyint 1).add (pyint 3)).eq (pyint 4) > @
+    [value] > pybool
+      value > @
+    [value] > pyint
+      [x] > eq
+        ^.^.pybool (^.value.eq x.value) > @
+      [x] > add
+        ^.^.pyint (^.value.plus x.value) > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-check-triple-quotes
+    eq. > @
+      """
+      Hello
+
+      Hello
+      """
+      "Hello\n\nHello"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-correctly-handles-same-name-attrs-simplified
+    eq. > @
+      calc
+        []
+          build 1 > @
+          [x] > build
+            x > @
+        []
+          build 2 > @
+          [y] > build
+            y > @
+      3
+    [first second] > calc
+      plus. > @
+        first
+        second
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-correctly-handles-same-name-attrs
+    eq. > @
+      calc
+        []
+          build 1 > @
+          [x] > build
+            x.plus 1 > @
+            ^.build > next
+              plus.
+                x
+                1
+        []
+          build 2 > @
+          [y] > build
+            y.plus 2 > @
+            ^.build > next
+              plus.
+                y
+                2
+      9
+    [f s] > calc
+      plus. > @
+        f.next
+        s.next
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-with-void-phi
+    and. > @
+      (five.plus 5).eq 10
+      five.hello.eq "Hello"
+    [@] > x
+      "Hello" > hello
+    x 5 > five
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] (seq (* (five.eq 5) true) > @) (5 > five) +> complex-horizontal
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-vertical-bound-method
+    eq. > @
+      if.
+        true
+        "second":1
+        "first"
+        .as-bytes:0
+      "first"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-methods-by-position
+    and. > @
+      bound.~0.eq 1
+      bound.~1.eq "Hey"
+    [first second] > obj
+    obj 1 "Hey" > bound
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-nesting-blah-test
+    blah0 > @
+    [] > blah0
+      blah1 > @
+      [] > blah1
+        blah2 > @
+        [] > blah2
+          blah3 > @
+          [] > blah3
+            blah4 > @
+            [] > blah4
+              blah5 > @
+              [] > blah5
+                blah6 > @
+                [] > blah6
+                  blah7 > @
+                  [] > blah7
+                    blah8 > @
+                    [] > blah8
+                      blah9 > @
+                      [] > blah9
+                        blah10 > @
+                        [] > blah10
+                          blah11 > @
+                          [] > blah11
+                            blah12 > @
+                            [] > blah12
+                              blah13 > @
+                              [] > blah13
+                                blah14 > @
+                                [] > blah14
+                                  blah15 > @
+                                  [] > blah15
+                                    blah16 > @
+                                    [] > blah16
+                                      blah17 > @
+                                      [] > blah17
+                                        blah18 > @
+                                        [] > blah18
+                                          blah19 > @
+                                          [] > blah19
+                                            blah20 > @
+                                            [] > blah20
+                                              blah21 > @
+                                              [] > blah21
+                                                blah22 > @
+                                                [] > blah22
+                                                  blah23 > @
+                                                  [] > blah23
+                                                    blah24 > @
+                                                    [] > blah24
+                                                      blah25 > @
+                                                      [] > blah25
+                                                        blah26 > @
+                                                        [] > blah26
+                                                          blah27 > @
+                                                          [] > blah27
+                                                            blah28 > @
+                                                            [] > blah28
+                                                              blah29 > @
+                                                              [] > blah29
+                                                                blah30 > @
+                                                                [] > blah30
+                                                                  blah31 > @
+                                                                  [] > blah31
+                                                                    blah32 > @
+                                                                    [] > blah32
+                                                                      blah33 > @
+                                                                      [] > blah33
+                                                                        blah34 > @
+                                                                        [] > blah34
+                                                                          blah35 > @
+                                                                          [] > blah35
+                                                                            blah36 > @
+                                                                            [] > blah36
+                                                                              blah37 > @
+                                                                              [] > blah37
+                                                                                blah38 > @
+                                                                                [] > blah38
+                                                                                  blah39 > @
+                                                                                  [] > blah39
+                                                                                    true > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-tests-just-prints-warning
+    eq. > @
+      cti
+        2.times 2
+        "warning"
+        "This method is deprecated!"
+      4

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -261,7 +261,7 @@
           * 1 2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  (list *).is-empty > [] > list-should-be-empty
+  (list *).is-empty > [] +> list-should-be-empty
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-should-not-be-empty-with-three-objects
@@ -405,7 +405,7 @@
       * 0 2 6 12
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-simple-list-mapping
+  [] +> tests-simple-list-mapping
     eq. > @
       mapped.
         list

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:37

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
@@ -23,3 +23,41 @@
   # Or.
   # A logical operation that returns True if at least one of the given conditions is true.
   ^ > [x] > or
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compares-two-bools
+    eq. > @
+      true
+      true
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-true-as-bool
+    true.as-bool > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compares-two-different-bool-types
+    not. > @
+      eq.
+        true
+        42
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compares-bool-to-bytes
+    and. > @
+      true.eq 01-
+      false.eq 00-
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-compares-bool-to-bytes-reverse
+    and. > @
+      01-.as-bytes.eq true
+      00-.as-bytes.eq false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-forks-on-true-condition
+    eq. > @
+      if.
+        5.eq 5
+        123
+        42
+      123

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -17,3 +17,53 @@
 # its `finally` attribute and returns the result of dataization of `main` or `catch`
 # attribute as `org.eolang.bytes`.
 [main catch finally] > try ?
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-catches-simple-exception
+    try > @
+      slice.
+        "some string"
+        7
+        5
+      true > [e]
+      false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-two-nested-try-blocks
+    try > @
+      try
+        slice.
+          "some string"
+          7
+          5
+        error e > [e]
+        false
+      true > [e]
+      false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-try-without-error-block
+    eq. > @
+      try
+        30.plus 2
+        e > [e]
+        true
+      32
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-try-malloc-update-catch
+    eq. > @
+      malloc.of
+        8
+        [m]
+          seq > @
+            *
+              m.put 1
+              try
+                seq
+                  *
+                    5.div 0
+                    m.put (m.plus 1)
+                e > [e]
+                false
+              m
+      1

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -148,31 +148,31 @@
     ((regex "/[a-z]+/").match "123").next.next > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-from-position-on-not-matched-block
+  [] +> throws-on-getting-from-position-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.from > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-to-position-on-not-matched-block
+  [] +> throws-on-getting-to-position-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.to > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-groups-count-on-not-matched-block
+  [] +> throws-on-getting-groups-count-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.groups-count > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-groups-on-not-matched-block
+  [] +> throws-on-getting-groups-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.groups > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-specified-group-on-not-matched-block
+  [] +> throws-on-getting-specified-group-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.group 1 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-getting-text-on-not-matched-block
+  [] +> throws-on-getting-text-on-not-matched-block
     ((regex "/[a-z]+/").match "123").next.text > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-dotall-option
+  [] +> tests-regex-matches-dotall-option
     regex
       "/(.*)/s"
     .compiled
@@ -180,7 +180,7 @@
       "too \\n many \\n line \\n Feed\\n"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-with-case-insensitive-option
+  [] +> tests-regex-matches-with-case-insensitive-option
     regex
       "/(string)/i"
     .compiled
@@ -188,7 +188,7 @@
       "StRiNg"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-with-multiline-option
+  [] +> tests-regex-matches-with-multiline-option
     regex
       "/(^([0-9]+).*)/m"
     .compiled
@@ -196,7 +196,7 @@
       "1 bottle of water on the wall. \\n1 bottle of water."
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-entire-pattern
+  [] +> tests-regex-matches-entire-pattern
     regex
       "/[0-9]/\\d+/"
     .compiled
@@ -204,7 +204,7 @@
       "2/75"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-with-regex-unix-lines
+  [] +> tests-regex-matches-with-regex-unix-lines
     regex
       "/(.+)/d"
     .compiled
@@ -212,7 +212,7 @@
       "A\\r\\nB\\rC\\nD"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-with-regex-case-insensitive-and-caps
+  [] +> tests-regex-matches-with-regex-case-insensitive-and-caps
     regex
       "/(word)/i"
     .compiled
@@ -220,7 +220,7 @@
       "WORD"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-ignores-comments-in-string
+  [] +> tests-regex-ignores-comments-in-string
     regex
       "/(\\d) #ignore this comment/x"
     .compiled
@@ -228,7 +228,7 @@
       "4"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-matches-with-unicode-case-and-insensitive
+  [] +> tests-regex-matches-with-unicode-case-and-insensitive
     regex
       "/(yildirim)/ui"
     .compiled
@@ -236,11 +236,11 @@
       "Yıldırım"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-missing-first-slash-in-regex
+  [] +> throws-on-missing-first-slash-in-regex
     (regex "(.)+").compiled > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-regex-contains-valid-groups-on-each-matched-block
+  [] +> tests-regex-contains-valid-groups-on-each-matched-block
     and. > @
       and.
         and.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,11 +1,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint wrong-sprintf-arguments:58
++unlint wrong-sprintf-arguments:66
++unlint sprintf-without-formatters:72
 
 # The `sprintf` object allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.
@@ -18,3 +21,77 @@
 # - %x - converts object to `bytes`
 # - %b - converts object to boolean, `true` or `false`.
 [format args] > sprintf ?
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-prints-simple-string
+    eq. > @
+      "Hello, Jeffrey!"
+      sprintf
+        "Hello, %s!"
+        * "Jeffrey"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-prints-complex-string
+    eq. > @
+      "Привет 3.140000 Jeff X!"
+      sprintf
+        "Привет %f %s %s!"
+        * 3.14 "Jeff" "X"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-prints-bytes-string
+    eq. > @
+      "40-45-00-00-00-00-00-00"
+      sprintf
+        "%x"
+        * 42.as-bytes
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-formats-all-objects
+    eq. > @
+      "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
+      sprintf
+        "string %s, bytes %x, float %f, int %d, bool %b"
+        * "Jeff" "Jeff".as-bytes 42.3 14 false
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> throws-on-sprintf-with-arguments-that-does-not-match
+    sprintf > @
+      "%s%s"
+      * "Jeff"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sprintf-does-not-fail-if-arguments-more-than-formats
+    eq. > @
+      "Hey"
+      sprintf
+        "%s"
+        * "Hey" "Jeff"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> throws-on-sprintf-unsupported-format
+    sprintf "%o" * > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sprintf-prints-percents
+    eq. > @
+      "%Jeff"
+      sprintf
+        "%%%s"
+        * "Jeff"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sprintf-does-not-print-i64
+    not. > @
+      eq.
+        sprintf
+          "%d"
+          * 42.as-i64
+        "42"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sprintf-prints-i64-as-number
+    eq. > @
+      "42"
+      sprintf
+        "%d"
+        * 42.as-i64.as-number

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -1,9 +1,11 @@
++alias org.eolang.structs.list
++alias org.eolang.txt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.4
++rt jvm org.eolang:eo-runtime:0.56.5
 +rt node eo2js-runtime:0.0.0
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -17,3 +19,89 @@
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
 [format read] > sscanf ?
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-string
+    eq. > @
+      "hello"
+      value.
+        sscanf "%s" "hello"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-int
+    eq. > @
+      33
+      value.
+        sscanf "%d" "33"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-float
+    eq. > @
+      0.24
+      value.
+        sscanf "%f" "0.24"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> throws-on-sscanf-with-wrong-format
+    sscanf "%l" "error" > @
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-string-int-float
+    eq. > @
+      list
+        sscanf
+          "%s %d %f"
+          "hello 33 0.24"
+      * "hello" 33 0.24
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-string-with-ending
+    eq. > @
+      "hello"
+      value.
+        sscanf "%s!" "hello!"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-complex-string
+    eq. > @
+      "test"
+      value.
+        sscanf "some%sstring" "someteststring"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-complex-int
+    eq. > @
+      734987259
+      value.
+        sscanf "!%d!" "!734987259!"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-complex-float
+    eq. > @
+      1991.01
+      value.
+        sscanf "this will be=%f" "this will be=1991.01"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-with-sprintf
+    eq. > @
+      list
+        sscanf
+          "%s is about %d?"
+          sprintf
+            "%s is about %d?"
+            * "This" 8
+      * "This" 8
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> tests-sscanf-complex-case
+    eq. > @
+      list
+        sscanf
+          "Im%d %s old and this is! Let's calculate %f + %f= %f"
+          "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
+      *
+        18
+        "years"
+        99999999.99
+        0.01
+        100000000.0

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -446,101 +446,101 @@
       "s"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-left-many-spaces
+  [] +> tests-text-trimmed-left-many-spaces
     eq. > @
       (text "     some").trimmed-left
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-left-only-spaces
+  [] +> tests-text-trimmed-left-only-spaces
     eq. > @
       (text "     ").trimmed-left
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-trimmed-right-empty-text
+  [] +> tests-trimmed-right-empty-text
     eq. > @
       (text "").trimmed-right
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-right-one-space
+  [] +> tests-text-trimmed-right-one-space
     eq. > @
       (text "s ").trimmed-right
       "s"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-right-many-spaces
+  [] +> tests-text-trimmed-right-many-spaces
     eq. > @
       (text "some     ").trimmed-right
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-right-only-spaces
+  [] +> tests-text-trimmed-right-only-spaces
     eq. > @
       (text "     ").trimmed-right
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-one-space-left
+  [] +> tests-text-trimmed-one-space-left
     eq. > @
       (text " some").trimmed
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-one-space-right
+  [] +> tests-text-trimmed-one-space-right
     eq. > @
       (text "some ").trimmed
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-one-space-both
+  [] +> tests-text-trimmed-one-space-both
     eq. > @
       (text " some ").trimmed
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-many-spaces
+  [] +> tests-text-trimmed-many-spaces
     eq. > @
       (text "    some     ").trimmed
       "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-empty
+  [] +> tests-text-trimmed-empty
     eq. > @
       (text "").trimmed
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-trimmed-only-spaces
+  [] +> tests-text-trimmed-only-spaces
     eq. > @
       (text "        ").trimmed
       ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-first-char
+  [] +> tests-returns-first-char
     eq. > @
       "s"
       (text "some").at 0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-third-char
+  [] +> tests-returns-third-char
     eq. > @
       "m"
       (text "some").at 2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-char-at-negative-index
+  [] +> tests-returns-char-at-negative-index
     eq. > @
       "m"
       (text "some").at -2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-text-at-index-more-than-length
+  [] +> throws-on-text-at-index-more-than-length
     (text "some").at 10 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-chains-with-other-strings
+  [] +> tests-chains-with-other-strings
     eq. > @
       "Hello, world!"
       chained.
@@ -551,7 +551,7 @@
           "!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-same-text-on-chaining-with-no-strings
+  [] +> tests-returns-same-text-on-chaining-with-no-strings
     eq. > @
       "Some"
       chained.
@@ -559,55 +559,55 @@
         *
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-joined-no-strings
+  [] +> tests-joined-no-strings
     eq. > @
       ""
       (text "-").joined *
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-joined-one-string
+  [] +> tests-joined-one-string
     eq. > @
       "some"
       (text "-").joined
         * "some"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-joined-many-strings
+  [] +> tests-joined-many-strings
     eq. > @
       "hello-world-dear-friend"
       (text "-").joined
         * "hello" "world" "dear" "friend"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-text-repeating-less-than-zero-times
+  [] +> throws-on-text-repeating-less-than-zero-times
     (text "").repeated -1 > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-repeated-zero-times-is-empty
+  [] +> tests-text-repeated-zero-times-is-empty
     eq. > @
       ""
       (text "some").repeated 0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-repeated-five-times
+  [] +> tests-text-repeated-five-times
     eq. > @
       "heyheyheyheyhey"
       (text "hey").repeated 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-index-of-non-existed-substring-with-more-length
+  [] +> tests-index-of-non-existed-substring-with-more-length
     eq. > @
       -1
       (text "Hello").index-of "Somebody"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-index-of-non-existed-substring-with-same-length
+  [] +> tests-index-of-non-existed-substring-with-same-length
     eq. > @
       -1
       (text "Hello").index-of "world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-index-of-non-existed-substring-with-utf
+  [] +> tests-index-of-non-existed-substring-with-utf
     eq. > @
       -1
       index-of.
@@ -615,7 +615,7 @@
         "x"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-index-of-existed-substring-with-utf
+  [] +> tests-index-of-existed-substring-with-utf
     eq. > @
       3
       index-of.
@@ -623,7 +623,7 @@
         "в"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-index-of-substring
+  [] +> tests-returns-valid-index-of-substring
     eq. > @
       6
       index-of.
@@ -631,58 +631,58 @@
         "\n"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-returns-valid-index-of-substring-in-the-end
+  [] +> tests-returns-valid-index-of-substring-in-the-end
     eq. > @
       6
       (text "Hello world").index-of "world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-starts-with-substring
+  [] +> tests-starts-with-substring
     (text "Hello, world").starts-with "Hello" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-start-with-substring
+  [] +> tests-does-not-start-with-substring
     not. > @
       (text "Hello, world").starts-with "world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-ends-with-substring
+  [] +> tests-ends-with-substring
     (text "Hello world!").ends-with "world!" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-end-with-substring
+  [] +> tests-does-not-end-with-substring
     not. > @
       (text "Hello world!").ends-with "Hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-contains-substring
+  [] +> tests-text-contains-substring
     (text "Hello, world!").contains "o, wo" > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-text-does-not-contain-substring
+  [] +> tests-text-does-not-contain-substring
     not. > @
       (text "Hello, world!").contains "Hey"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-last-index-of-substring
+  [] +> tests-finds-last-index-of-substring
     eq. > @
       5
       (text "Hey, Hey, Hey").last-index-of "Hey,"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-finds-last-index-of-the-same-string
+  [] +> tests-finds-last-index-of-the-same-string
     eq. > @
       0
       (text "Hello").last-index-of "Hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-non-existed-substring
+  [] +> tests-last-index-of-non-existed-substring
     eq. > @
       -1
       (text "Hello, world").last-index-of "somebody"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-non-existed-substring-with-utf
+  [] +> tests-last-index-of-non-existed-substring-with-utf
     eq. > @
       -1
       last-index-of.
@@ -690,7 +690,7 @@
         "x"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-last-index-of-existed-substring-with-utf
+  [] +> tests-last-index-of-existed-substring-with-utf
     eq. > @
       3
       last-index-of.
@@ -698,27 +698,27 @@
         "в"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-splits-text-by-dash
+  [] +> tests-splits-text-by-dash
     eq. > @
       list
         (text "a-b-c").split "-"
       * "a" "b" "c"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-splits-text-with-empty-strings
+  [] +> tests-splits-text-with-empty-strings
     eq. > @
       list
         (text "-a-b-").split "-"
       * "" "a" "b" ""
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-text-to-upper-case
+  [] +> tests-converts-text-to-upper-case
     eq. > @
       "HELLO"
       (text "hello").up-cased
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-splits-and-returns-strings
+  [] +> tests-splits-and-returns-strings
     eq. > @
       length.
         at.
@@ -729,99 +729,99 @@
       6
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-text-with-upper-letters-to-upper-case
+  [] +> tests-converts-text-with-upper-letters-to-upper-case
     eq. > @
       "HELLO"
       (text "HeLlO").up-cased
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-text-to-lower-case
+  [] +> tests-converts-text-to-lower-case
     eq. > @
       "hello"
       (text "HELLO").low-cased
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-text-with-low-letters-to-lower-case
+  [] +> tests-converts-text-with-low-letters-to-lower-case
     eq. > @
       "hello"
       (text "HeLlO").low-cased
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-text-to-number
+  [] +> tests-converts-text-to-number
     eq. > @
       5
       (text "5").as-number
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > throws-on-converting-text-to-number
+  [] +> throws-on-converting-text-to-number
     (text "Hello").as-number > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-converts-float-text-to-number
+  [] +> tests-converts-float-text-to-number
     eq. > @
       3.14
       (text "3.14").as-number
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-text-is-ascii
+  [] +> tests-checks-if-text-is-ascii
     is-ascii. > @
       text
         "H311oW"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-emoji-is-not-ascii
+  [] +> tests-checks-if-emoji-is-not-ascii
     not. > @
       is-ascii.
         text
           "🌵"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-string-of-numbers-is-ascii
+  [] +> tests-checks-if-string-of-numbers-is-ascii
     is-ascii. > @
       text
         "123"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-simple-text-is-alphanumeric
+  [] +> tests-checks-if-simple-text-is-alphanumeric
     is-alphanumeric. > @
       text
         "eEo"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-text-with-number-is-alphanumeric
+  [] +> tests-checks-if-text-with-number-is-alphanumeric
     is-alphanumeric. > @
       text
         "ab3d"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-text-with-dashes-is-not-alphanumeric
+  [] +> tests-checks-if-text-with-dashes-is-not-alphanumeric
     not. > @
       is-alphanumeric.
         text
           "-w-"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-simple-text-is-alpha
+  [] +> tests-checks-if-simple-text-is-alpha
     is-alpha. > @
       text
         "eEo"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-text-with-number-is-not-alpha
+  [] +> tests-checks-if-text-with-number-is-not-alpha
     not. > @
       is-alpha.
         text
           "ab3d"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-checks-if-text-with-dashes-is-not-alpha
+  [] +> tests-checks-if-text-with-dashes-is-not-alpha
     not. > @
       is-alpha.
         text
           "-w-"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-does-not-replaces-if-regex-not-found
+  [] +> tests-does-not-replaces-if-regex-not-found
     text
       "Hello, world"
     .replaced
@@ -832,7 +832,7 @@
       "Hello, world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-replaces-digits-with-string
+  [] +> tests-replaces-digits-with-string
     text
       "Hell0, w0rld"
     .replaced
@@ -843,7 +843,7 @@
       "Hello, world"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-replaces-slashes-to-windows-separator
+  [] +> tests-replaces-slashes-to-windows-separator
     text
       "C:\\Windows/foo\\bar/hello.txt"
     .replaced
@@ -854,7 +854,7 @@
       "C:\\Windows\\foo\\bar\\hello.txt"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-replaces-windows-path-with-slash
+  [] +> tests-replaces-windows-path-with-slash
     text
       "C:\\Windows\\Users\\AppLocal\\shrek"
     .replaced
@@ -865,7 +865,7 @@
       "C/Windows/Users/AppLocal/shrek"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] > tests-sanitizes-windows-path-with-regex
+  [] +> tests-sanitizes-windows-path-with-regex
     text
       "foo\\bar<:>?*\"|baz\\asdf"
     .replaced

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.4
++version 0.56.5
 +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.56.5` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.