### PR TITLE
New release for eo-0.56.9

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.56.7</eo.version>
+    <eo.version>0.56.9</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The object encapsulates a chain of bytes, adding a few

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,9 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
 
 # Compile Time Instruction (CTI).
 #

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,11 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
-+unlint no-attribute-formation:11
 
 # The object is a FALSE boolean state.
 [] > false

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,10 +3,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Directory in the file system.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,10 +6,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The file object in the filesystem.

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,8 +7,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # A `path` represents a path that is hierarchical and composed of a sequence of

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,8 +5,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Temporary directory.

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Non-conditional forward and backward jumps.

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The 16 bits signed integer.

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The 32 bits signed integer.

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The 64 bits signed integer.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Makes an `input` from bytes.

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,8 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `console` object is basic I/O object that allows to

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Dead input is an input that reads from nowhere and always

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Dead output is an output that writes to nowhere.

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,8 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Reads all the bytes from provided `input` and returns its length.

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Makes an output from allocated block in memory.

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
++version 0.56.9
 +unlint unit-test-missing
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `stdin` object is a convenient wrapper on `console` object

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,8 +2,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `stdout` object is convenient wrapper on `console` object which

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,8 +3,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Tee input is an input that reads from provided `input`,

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `malloc` object is an abstraction of a storage of data in heap

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The angle.

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.5
++version 0.56.9
 +unlint unit-test-missing
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The Euler's number.

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Counts integral from `a` to `b`.

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,10 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 
 # Sequence of numbers.
 # Here `sequence` must be a `tuple` or any `tuple` decorator of `number` objects.

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,8 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Generates a pseudo-random number.

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,10 +3,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Returns a floating point number.

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `not a number` object is an abstraction

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Negative infinity.

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,8 +5,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `number` object is an abstraction of a 64-bit floating-point

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Positive infinity.

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation
 +unlint cti

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Sequence.

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,8 +2,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `string` object is an abstraction of a text string, which

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,8 +3,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Represents sequence of bytes as array.

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Hash code - the pseudo-unique float numeric

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,8 +3,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,8 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Hash-map.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,8 +2,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Range of integers from `start` to `end` (soft border) with step = 1.

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,8 +2,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Range - create a `list` containing a range of elements

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,8 +3,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Set - is an unordered `list` of unique objects.

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The object allows to choose right options according to cases conditions.

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,8 +4,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,8 +2,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Represents the current operating system.

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Makes a Unix syscall by `name` with POSIX interface.

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,10 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:37
 

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,11 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
-+unlint no-attribute-formation:11
 
 # The object is a TRUE boolean state.
 [] > true

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Try, catch and finally. This object helps catch errors created by the

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Tuple.

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Regular expression in Perl format.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,10 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58
 +unlint wrong-sprintf-arguments:66

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,10 +3,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.56.5
++rt jvm org.eolang:eo-runtime:0.56.9
 +rt node eo2js-runtime:0.0.0
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Reads formatted input from a string.

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,8 +6,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Text.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.56.5
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++version 0.56.9
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # The `while` object is very similar to a loop with a pre-condition.


### PR DESCRIPTION
A new release `eo-0.56.9` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.