### PR TITLE
New release for eo-0.57.1

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.57.0</eo.version>
+    <eo.version>0.57.1</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,11 +2,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:27
++unlint redundant-object:46
++unlint redundant-object:56
++unlint redundant-object:66
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,
@@ -385,11 +391,9 @@
   [] +> tests-concat-bools-as-bytes
     eq. > @
       concat.
-        b1
-        b2
+        true.as-bytes
+        false.as-bytes
       01-00
-    true.as-bytes > b1
-    false.as-bytes > b2
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-concat-with-empty
@@ -418,11 +422,11 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-concat-strings
     eq. > @
-      string s-bytes
+      string
+        concat.
+          "hello ".as-bytes
+          "world".as-bytes
       "hello world"
-    concat. > s-bytes
-      "hello ".as-bytes
-      "world".as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
   # (2397719729.xor 4294967295).eq 1897247566.

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,9 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:12
 
 # The object is a FALSE boolean state.
 [] > false

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,11 +3,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
 
 # Directory in the file system.
 # Apparently every directory is a file.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,11 +6,20 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:27
++unlint redundant-object:29
++unlint redundant-object:162
++unlint redundant-object:164
++unlint redundant-object:196
++unlint redundant-object:210
++unlint redundant-object:236
++unlint redundant-object:252
++unlint redundant-object:588
 
 # The file object in the filesystem.
 [path] > file
@@ -137,7 +146,6 @@
     mode > access!
     (access.eq "r").as-bool > read
     (access.eq "w").as-bool > write
-    (access.eq "a").as-bool > append
     (access.eq "r+").as-bool > read-write
     (access.eq "w+").as-bool > write-read
     (access.eq "a+").as-bool > read-append
@@ -150,7 +158,7 @@
         or.
           write.or read-write
           write-read.or read-append
-        append
+        (access.eq "a").as-bool
     as-bool. > must-exists
       read.or read-write
     as-bool. > truncate
@@ -312,12 +320,9 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-moves-a-file
     and. > @
-      (temp.moved dest).exists
+      (temp.moved (sprintf "%s.dest" (* temp.path))).exists
       temp.exists.not
     tmpdir.tmpfile > temp
-    sprintf > dest
-      "%s.dest"
-      * temp.path
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> throws-on-opening-with-wrong-mode
@@ -577,8 +582,7 @@
                   *
                     f.write "Hello, world"
                     ^.m.put i2
-                f.read 7 > i1
-                i1.read 5 > i2
+                (f.read 7).read 5 > i2
             m
     .eq "world" > @
 
@@ -589,7 +593,6 @@
     .open
       "a+"
       [f]
-        o1.write "!" > @
-        f.write "Hello, world" > o1
+        (f.write "Hello, world").write "!" > @
     .size
     .eq 13 > @

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,9 +7,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:56
++unlint redundant-object:58
++unlint redundant-object:59
++unlint redundant-object:268
++unlint redundant-object:270
++unlint redundant-object:271
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
@@ -407,10 +413,10 @@
           validated
             string
               if.
-                other-is-drive-relative
+                (^.is-drive-relative valid-other).as-bool
                 valid-other
                 if.
-                  other-is-root-relative
+                  (^.is-root-relative valid-other).as-bool
                   if.
                     is-drive-relative uri-as-bytes
                     concat.
@@ -424,8 +430,6 @@
                     valid-other
         uri > uri-as-bytes!
         separated-correctly other > valid-other!
-        (^.is-drive-relative valid-other).as-bool > other-is-drive-relative
-        (^.is-root-relative valid-other).as-bool > other-is-root-relative
 
       # Takes the base name from the provided `path`, for example:
       # |------------------------------|---------------|

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,9 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:53
++unlint redundant-object:58
 
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,11 +2,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
 
 # The 16 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,11 +2,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
 
 # The 32 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,11 +2,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
 
 # The 64 bits signed integer.
 # Here `as-bytes` must be a `bytes` object.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,9 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:47
 
 # Makes an `input` from bytes.
 # Here `bts` is sequence of bytes or an object that can be dataized
@@ -78,10 +79,7 @@
           i1.eq 01-02-03-04
           i2.eq 05-06-07-08
         i3.eq F5-F6
-      i4.eq --
-    bytes-as-input > i
-      01-02-03-04-05-06-07-08-F5-F6
-    i.read 4 > i1
+      (i3.read 2).eq --
+    (bytes-as-input 01-02-03-04-05-06-07-08-F5-F6).read 4 > i1
     i1.read 4 > i2
     i2.read 4 > i3
-    i3.read 2 > i4

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,9 +4,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:82
++unlint redundant-object:95
++unlint redundant-object:122
++unlint redundant-object:138
++unlint redundant-object:151
++unlint redundant-object:178
 
 # The `console` object is basic I/O object that allows to
 # interact with operation system console.

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -28,6 +28,5 @@
   [] +> tests-reads-empty-bytes
     and. > @
       i1.eq --
-      i2.eq --
+      (i1.read 10).eq --
     dead-input.read 10 > i1
-    i1.read 10 > i2

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,14 +4,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Reads all the bytes from provided `input` and returns its length.
 [input] > input-length
   rec-read input 0 > @
-  4096 > chunk
 
   [input length] > rec-read
     if. > @
@@ -20,7 +19,7 @@
       rec-read
         read-bytes
         length.plus read-bytes.size
-    (input.read chunk).read.^ > read-bytes
+    (input.read 4096).read.^ > read-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-reads-all-bytes-and-returns-length

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,9 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:43
 
 # Makes an output from allocated block in memory.
 # Here `allocated` is `malloc.of.allocated` object.
@@ -58,11 +59,8 @@
         [mem]
           seq > @
             *
-              o2.write 08-09-A0
+              (((malloc-as-output mem).write 01-02-03).write 04-05-06-07).write 08-09-A0
               mem
-          malloc-as-output mem > out
-          out.write 01-02-03 > o1
-          o1.write 04-05-06-07 > o2
       01-02-03-04-05-06-07-08-09-A0
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,9 +3,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:43
 
 # Tee input is an input that reads from provided `input`,
 # writes to provided `output` and behaves as provided `input`.
@@ -76,13 +77,13 @@
         [m]
           seq > @
             *
-              i2.read 1
+              tee-input
+                bytes-as-input 01-02-03-04-05
+                malloc-as-output m
+              .read 2
+              .read 2
+              .read 1
               m
-          tee-input > tee
-            bytes-as-input 01-02-03-04-05
-            malloc-as-output m
-          tee.read 2 > i1
-          i1.read 2 > i2
       01-02-03-04-05
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -198,14 +198,8 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-writes-into-two-malloc-objects
     and. > @
-      a.eq 10
-      b.eq 20
-    malloc.of > a
-      8
-      m.put 10 > [m]
-    malloc.of > b
-      8
-      m.put 20 > [m]
+      (malloc.of 8 (m.put 10 > [m])).eq 10
+      (malloc.of 8 (m.put 20 > [m])).eq 20
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> throws-on-overflow-boolean-malloc

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,11 +2,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:24
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.0
++version 0.57.1
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,9 +4,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:20
++unlint redundant-object:28
 
 # Generates a pseudo-random number.
 [seed] > random
@@ -36,23 +38,23 @@
 
   # New random with pseudo-random seed.
   [] > pseudo
-    random time-seed > @
-    (posix "gettimeofday" *).output > timeval
-    as-number. > time-seed
-      plus.
-        as-i64.
-          and.
-            time-bytes.left const-1
-            ((one.left const-2).as-i64.minus one).as-bytes
+    random > @
+      as-number.
         plus.
           as-i64.
             and.
-              time-bytes.left const-3
-              ((one.left const-1).as-i64.minus one).as-bytes
-          as-i64.
-            and.
-              time-bytes
-              ((one.left const-3).as-i64.minus one).as-bytes
+              time-bytes.left const-1
+              ((one.left 53).as-i64.minus one).as-bytes
+          plus.
+            as-i64.
+              and.
+                time-bytes.left const-3
+                ((one.left const-1).as-i64.minus one).as-bytes
+            as-i64.
+              and.
+                time-bytes
+                ((one.left const-3).as-i64.minus one).as-bytes
+    (posix "gettimeofday" *).output > timeval
     as-bytes. > time-bytes
       as-i64.
         if.
@@ -63,7 +65,6 @@
             as-number.
               timeval.tv-usec.as-i64.div 1000.as-i64
     35 > const-1
-    53 > const-2
     17 > const-3
     00-00-00-00-00-00-00-01 > one
 

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,11 +3,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:17
 
 # Returns a floating point number.
 [num] > real

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,9 +1,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
 
 # The `not a number` object is an abstraction
 # for representing undefined or unrepresentable numerical results.

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,9 +1,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,10 +5,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
++unlint redundant-object:101
++unlint redundant-object:132
++unlint redundant-object:162
++unlint redundant-object:349
 
 # Socket.
 #
@@ -435,14 +439,13 @@
               closed-socket sd
           error ex > [ex]
           if.
-            cleaned-up.eq win32.socket-error
+            (win32 "WSACleanup" *).code.eq win32.socket-error
             error "Couldn't cleanup Winsock resources"
             true
       code. > started-up
         win32
           "WSAStartup"
           * win32.winsock-version-2-2
-      (win32 "WSACleanup" *).code > cleaned-up
 
     # Initiate a connection on a socket.
     # Here `scope` must be an abstract object with one free attribute which will be

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,11 +1,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:25
++unlint redundant-object:28
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,9 +1,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:19
++unlint redundant-object:20
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Positive infinity.
 # A special floating-point value representing an unbounded quantity greater than all real numbers.

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,13 +1,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation
 +unlint cti
 +unlint incorrect-unlint
 +unlint unlint-non-existing-defect
++unlint redundant-object
 
 # Runtime.
 [] > runtime

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,9 +2,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:94
++unlint redundant-object:110
 
 # The `string` object is an abstraction of a text string, which
 # internally is a chain of bytes.
@@ -211,8 +213,7 @@
   # The smile emoji is F0-9F-98-80 in bytes. Here we check if string.length fails if it faces
   # incomplete 4 byte character.
   [] +> throws-on-taking-length-of-incomplete-n4-byte-character
-    should-be-smile.length > @
-    string F0-9F-98 > should-be-smile
+    (string F0-9F-98).length > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-compares-two-different-string-types

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -31,10 +31,8 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-hash-code-of-bools-is-number
     and. > @
-      true-code.as-bytes.size.eq 8
-      false-code.as-bytes.size.eq 8
-    hash-code-of true > true-code
-    hash-code-of false > false-code
+      (hash-code-of true).as-bytes.size.eq 8
+      (hash-code-of false).as-bytes.size.eq 8
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-hash-code-of-int-is-int

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,9 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:18
++unlint redundant-object:24
 
 # List implements based operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.
@@ -318,8 +320,7 @@
           plus. > @
             x
             a.plus
-              ^.src.at i
-    * 2 2 > src
+              (* 2 2).at i
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-reducedi-long-int-array
@@ -384,7 +385,7 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-complex-objects-list-comparison
-    list > res
+    list
       *
         list (* 0 1)
         list (* 4 0)
@@ -466,10 +467,9 @@
     eq. > @
       withouti.
         list
-          * "smthg" 27 nested
+          * "smthg" 27 (* 3 2 1)
         2
       * "smthg" 27
-    * 3 2 1 > nested
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-list-without
@@ -504,12 +504,10 @@
       eq.
         list3
         * 1 2 3
-    list (* 0 1) > list1
-    list (* 2 3) > list2
     withouti. > list3
       concat.
-        list1
-        list2
+        list (* 0 1)
+        list (* 2 3)
       0
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,9 +4,22 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:40
++unlint redundant-object:53
++unlint redundant-object:68
++unlint redundant-object:69
++unlint redundant-object:72
++unlint redundant-object:77
++unlint redundant-object:120
++unlint redundant-object:121
++unlint redundant-object:122
++unlint redundant-object:127
++unlint redundant-object:128
++unlint redundant-object:129
++unlint redundant-object:146
 
 # Hash-map.
 # Here `pairs` must be a `tuple` of `map.entry` object.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,9 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:27
 
 # Range of integers from `start` to `end` (soft border) with step = 1.
 # Here `start` and `end` must be `int`s. If they're not - an error will

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,9 +2,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:65
++unlint redundant-object:78
++unlint redundant-object:91
++unlint redundant-object:103
 
 # Range - create a `list` containing a range of elements
 # Here `start` must be a abstract object that must have an object `next` to get

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,9 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:26
++unlint redundant-object:27
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,9 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:44
++unlint redundant-object:46
 
 # The object allows to choose right options according to cases conditions.
 # Parameter cases is the array of two dimensional array, which

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,11 +2,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:23
++unlint redundant-object:24
 
 # Represents the current operating system.
 [] > os

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,11 +2,20 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:28
++unlint redundant-object:29
++unlint redundant-object:30
++unlint redundant-object:31
++unlint redundant-object:32
++unlint redundant-object:33
++unlint redundant-object:36
++unlint redundant-object:44
++unlint redundant-object:45
 
 # Makes a Unix syscall by `name` with POSIX interface.
 # Here `args` is a `org.eolang.tuple` of arguments required for
@@ -91,8 +100,4 @@
   [] +> tests-returns-valid-posix-inet-addr-for-localhost
     or. > @
       os.is-windows
-      addr.eq 16777343
-    code. > addr
-      posix
-        "inet_addr"
-        * "127.0.0.1"
+      (code. (posix "inet_addr" (* "127.0.0.1"))).eq 16777343

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,12 +2,24 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint many-void-attributes:37
++unlint many-void-attributes:49
++unlint redundant-object:34
++unlint redundant-object:35
++unlint redundant-object:36
++unlint redundant-object:37
++unlint redundant-object:38
++unlint redundant-object:39
++unlint redundant-object:40
++unlint redundant-object:41
++unlint redundant-object:42
++unlint redundant-object:46
++unlint redundant-object:53
++unlint redundant-object:54
 
 # Makes a kernel32.dll function call by name.
 #
@@ -51,8 +63,4 @@
   [] +> tests-returns-valid-win32-inet-addr-for-localhost
     or. > @
       os.is-windows.not
-      addr.eq 16777343
-    code. > addr
-      win32
-        "inet_addr"
-        * "127.0.0.1"
+      (code. (win32 "inet_addr" (* "127.0.0.1"))).eq 16777343

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,9 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:12
 
 # The object is a TRUE boolean state.
 [] > true

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,9 +1,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:16
++unlint redundant-object:21
++unlint redundant-object:22
++unlint redundant-object:24
++unlint redundant-object:25
 
 # Tuple.
 # An ordered, immutable collection of elements.

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,11 +1,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:55
++unlint redundant-object:63
++unlint redundant-object:89
++unlint redundant-object:90
++unlint redundant-object:92
++unlint redundant-object:99
 
 # Regular expression in Perl format.
 # Here `expression` is a string pattern.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.0
++rt jvm org.eolang:eo-runtime:0.57.1
 +rt node eo2js-runtime:0.0.0
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,9 +6,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-object:24
++unlint redundant-object:27
++unlint redundant-object:29
++unlint redundant-object:31
++unlint redundant-object:292
 
 # Text.
 # A sequence of characters representing words, sentences, or data.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.0
++version 0.57.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -62,7 +62,7 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-simple-while-with-false-first
     not. > @
-      while > res
+      while
         false > [i]
         true > [i]
 


### PR DESCRIPTION
A new release `eo-0.57.1` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.