### PR TITLE
New release for eo-0.57.2

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.57.1</eo.version>
+    <eo.version>0.57.2</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,17 +2,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:22
 +unlint redundant-object:23
-+unlint redundant-object:27
-+unlint redundant-object:46
-+unlint redundant-object:56
-+unlint redundant-object:66
++unlint redundant-object:26
++unlint redundant-object:44
++unlint redundant-object:53
++unlint redundant-object:62
 
 # The object encapsulates a chain of bytes, adding a few
 # convenient operations to it. Objects like `int`, `string`,
@@ -21,9 +21,8 @@
   data > @
   $ > as-bytes
   eq 01- > as-bool
-  # Turn this chain of eight bytes into a number.
-  # If there are less or more than eight bytes, there will
-  # be an error returned.
+  # Converts this chain of eight bytes into a number.
+  # Returns an error if the byte count is not exactly eight.
   if. > as-number
     eq nan.as-bytes
     nan
@@ -40,9 +39,8 @@
             sprintf
               "Can't convert non 8 length bytes to a number, bytes are %x"
               * $
-  # Turn this chain of eight bytes into a i64 number.
-  # If there are less or more than eight bytes, there will
-  # be an error returned.
+  # Converts this chain of eight bytes into an i64 number.
+  # Returns an error if the byte count is not exactly eight.
   if. > as-i64
     size.eq 8
     i64 $
@@ -50,9 +48,8 @@
       sprintf
         "Can't convert non 8 length bytes to i64, bytes are %x"
         * $
-  # Turn this chain of four bytes into a i32 number.
-  # If there are less or more than four bytes, there will
-  # be an error returned.
+  # Converts this chain of four bytes into an i32 number.
+  # Returns an error if the byte count is not exactly four.
   if. > as-i32
     size.eq 4
     i32 $
@@ -60,9 +57,8 @@
       sprintf
         "Can't convert non 4 length bytes to i32, bytes are %x"
         * $
-  # Turn this chain of two bytes into a i16 number.
-  # If there are less or more than two bytes, there will
-  # be an error returned.
+  # Converts this chain of two bytes into an i16 number.
+  # Returns an error if the byte count is not exactly two.
   if. > as-i16
     size.eq 2
     i16 $

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
@@ -12,6 +12,6 @@
 # other objects. This mechanism is somehow similar to annotations in,
 # for example, Java and C#. For example, the object makes it possible
 # to highlight deprecated methods. EO compiler, when it meets the
-# `cli` object, takes its `message` and prints to the log/console
+# `cti` object, takes its `message` and prints to the log/console
 # with the `level` severity level (use `INFO`, `WARN`, or `ERROR`).
 delegate > [delegate level message] > cti

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,26 +1,27 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# The object dataizes `target`, makes new instance of `bytes` from given data and behaves as result
+# The object dataizes `target`, makes a new instance of `bytes` from given
+# data and behaves as the result
 # `bytes`.
 # The object is used as implementation of caching syntax (`!`).
-# The next two lines of code behaves identically:
+# The next two lines of code behave identically:
 #
 # ```
 # some-object > cached!
 # (dataized some-object).as-bytes > cached
 # ```
 #
-# Dataization is a process of retrieving data (bytes) from an object, by taking its \Delta
-# attribute.
+# Dataization is a process of retrieving data (bytes) from an object
+# by taking its \Delta attribute.
 # An example of usage:
 #
 # ```
-# # Some 64+ characters comment should be here.
+# # Example object with nested structure for dataization demonstration.
 # [] > foo
 #   [] > @
 #     inner.five > @
@@ -31,15 +32,17 @@
 # result.as-number > f             # f is 5
 # ```
 #
-# Here, when `.as-bytes` is taken, the `dataized` dataizes (takes `bytes`) from the object `foo`
-# and returns them. The `.as-bytes` is used to prevent double dataization.
+# Here, when `.as-bytes` is taken, the `dataized` dataizes (takes `bytes`)
+# from the object `foo` and returns them.
+# The `.as-bytes` is used to prevent double dataization.
 [target] > dataized
   try > @
     target
     error ex > [ex]
     01-
 
-  # This unit test is supposed to check the functionality of the corresponding object.
+  # This unit test is supposed to check the functionality of the
+  # corresponding object.
   [] +> tests-dataized-does-not-do-recalculation
     eq. > @
       malloc.for

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,15 +1,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
 # This object must be used in order to terminate the program
-# due to an error. Just make a copy of it with any encapsulated object.
+# with an error. To use it, make a copy with an encapsulated object as the error message.
 # The first attempt to dataize it will lead to runtime error and program
 # termination. The only way to catch such an error is by using
 # the `try` object.

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12
@@ -16,11 +16,11 @@
   right > [left right] > if
 
   # And.
-  # A logical operation that returns True only if all given conditions are true.
+  # A logical operation that returns true only if all given conditions are true.
   ^ > [x] > and
 
   # Or.
-  # A logical operation that returns True if at least one of the given conditions is true.
+  # A logical operation that returns true if at least one of the given conditions is true.
   01-.eq x > [x] > or
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -33,11 +33,11 @@
     # parent directories.
     # Returns `org.eolang.true` object.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use it programmatically outside of `dir` object.
     [] > mkdir ?
 
-  # Goes though all files in the directory, recursively
+  # Goes through all files in the directory, recursively
   # finding them with the `glob` provided.
   # Returns `org.eolang.tuple` of all files in the directory.
   [glob] > walk ?
@@ -53,10 +53,10 @@
           ^
         ^
 
-    # Deletes files and directories in current directory recursively.
+    # Deletes files and directories in the current directory recursively.
     # Returns `true`.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `dir` object.
     [tup] > rec-delete
       if. > @
@@ -81,7 +81,7 @@
     # Creates an empty temporary file in the current directory and
     # returns absolute path to it as `org.eolang.string`.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of the `dir` object.
     [] > touch ?
 

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27
@@ -25,7 +25,7 @@
 [path] > file
   $.path > @
   $ > as-file
-  # Convert the `file` to the `path`.
+  # Converts the `file` to a `path`.
   (QQ.fs.path path).determined > as-path
 
   # Returns `org.eolang.true` if current file is a directory, returns `org.eolang.false` otherwise.
@@ -48,7 +48,7 @@
 
     # Creates new empty file and returns `org.eolang.true`.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
     [] > touch ?
 
@@ -65,14 +65,14 @@
 
     # Deletes the file and returns `org.eolang.true`.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
     [] > delete ?
 
   # Gets the file size in bytes and returns it as `org.eolang.number`.
   [] > size ?
 
-  # Move current file to `target`, making and returning a new `file` from it.
+  # Moves the current file to `target`, making and returning a new `file` from it.
   [target] > moved
     as-file. > @
       file move
@@ -81,7 +81,7 @@
     # and returns path of moved file as `org.eolang.string`.
     # Returns `org.eolang.error` is failed to move the file.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
     [] > move ?
 
@@ -174,7 +174,7 @@
     # The object is stream-safe, which means that stream is closed anyway,
     # even if errors are occurred while `scope` dataization.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of the `file` object.
     [] > process-file ?
 
@@ -189,7 +189,7 @@
 
         # File input block
         #
-        # Attention! The object is for internal usage only, please
+        # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
         [buffer] > input-block
           buffer > @
@@ -215,12 +215,12 @@
 
         # Bytes, as `org.eolang.bytes`, read from file input stream.
         #
-        # Attention! The object is for internal usage only, please
+        # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
         [size] > read-bytes ?
 
       # Write given `buffer` to file output stream.
-      # Here `buffer` is either sequence of bytes or and object that can be
+      # Here `buffer` is either a sequence of bytes or an object that can be
       # dataized via `as-bytes` object.
       # Returns new instance of `output-block` ready to write again, or
       # returns an error if provided access mode does not allow writing operations.
@@ -229,14 +229,14 @@
 
         # File output block.
         #
-        # Attention! The object is for internal usage only, please
+        # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
         [] > output-block
           true > @
           $ > this
 
           # Write given `buffer` to file output stream.
-          # Here `buffer` is either sequence of bytes or and object that can be
+          # Here `buffer` is either a sequence of bytes or an object that can be
           # dataized via `as-bytes` object.
           # Returns new instance of `output-block` ready to write again, or
           # returns an error if provided access mode does not allow writing operations.
@@ -256,7 +256,7 @@
 
         # Writes given `buffer` of bytes to file output stream and returns `org.eolang.true`.
         #
-        # Attention! The object is for internal usage only, please
+        # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
         [buffer] > written-bytes ?
 

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:56
@@ -162,7 +162,7 @@
     # | ""                           | ""            |
     # |------------------------------|---------------|
     #
-    # Unix OS allows to have "\" (backslash) if file name.
+    # Unix OS allows having "\" (backslash) in file names.
     # In such case it'll be included to the base name since separator
     # is "/" (regular slash) in Unix OS:
     # With the `path` "/tmp/var/hello\world" `base-name` returns `hello\world`.
@@ -228,7 +228,7 @@
     # | ""                           | ""                 |
     # |------------------------------|--------------------|
     #
-    # Unix OS allows to have "\" (backslash) if file or directory name.
+    # Unix OS allows having "\" (backslash) in file or directory names.
     # In such case it'll be included to the dir name since separator
     # is "/" (regular slash) in Unix OS:
     # With the `path` "/tmp/v\a\r/hello" `dir-name` returns `/tmp/v\a\r`.
@@ -261,7 +261,7 @@
 
     # Windows validated path with forward slashes replaced with back ones.
     #
-    # Attention! The object is for internal usage only, please
+    # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `path` object.
     [uri] > validated
       uri > @
@@ -442,7 +442,7 @@
       # | ""                           | ""            |
       # |------------------------------|---------------|
       #
-      # Unix OS allows to have "\" (backslash) if file name.
+      # Unix OS allows having "\" (backslash) in file names.
       # In such case it'll be included to the base name since separator
       # is "/" (regular slash) in Unix OS:
       # With the `path` "/tmp/var/hello\world" `base-name` returns `hello\world`.

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:53
@@ -10,7 +10,7 @@
 # Non-conditional forward and backward jumps.
 # Forward jump instantly returns provided object to `g.forward` without touching
 # all the code below.
-# Backward jump instantly returns provided to `go.to` abstract object
+# Backward jump instantly returns the provided object to `go.to`
 #
 # Forward jump may look like this:
 #

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -79,7 +79,7 @@
 
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i16` object.
-  # An `org.eolang.error` is returned if or `x` is equal to `0`.
+  # An `org.eolang.error` is returned if `x` is equal to `0`.
   [x] > div
     if. > @
       x-as-i16.eq zero

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -92,7 +92,7 @@
 
   # Quotient of the division of `$` by `x`.
   # Here `x` must be an `org.eolang.i32` object.
-  # An `error` is returned if or `x` is equal to 0.
+  # An `error` is returned if `x` is equal to 0.
   [x] > div
     if. > @
       x-as-i32.eq zero

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -45,7 +45,7 @@
         i64 value
     x > value!
 
-  # Returns `true` if `$` <= `x`.
+  # Returns `org.eolang.true` if `$` <= `x`.
   # Here `x` must be an `org.eolang.i64` object.
   [x] > lte
     or. > @
@@ -57,7 +57,7 @@
   # Here `x` must be an `org.eolang.i64` object.
   [x] > gt ?
 
-  # Returns `true` if `$` >= `x`.
+  # Returns `org.eolang.true` if `$` >= `x`.
   # Here `x` must be an `org.eolang.i64` object.
   [x] > gte
     or. > @
@@ -69,7 +69,7 @@
   # Here `x` must be an `org.eolang.i64` object.
   [x] > times ?
 
-  # Sum of `$` and `x` as `org.eolang.i64`
+  # Sum of `$` and `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
   [x] > plus ?
 
@@ -81,7 +81,7 @@
 
   # Quotient of the division of `$` by `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
-  # An `org.eolang.error` is returned if or `x` is equal to 0.
+  # An `org.eolang.error` is returned if `x` is equal to 0.
   [x] > div ?
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:47

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:82
@@ -52,7 +52,7 @@
 # ready to `write` again.
 #
 # Console is platform dependent, which means the internal algorithm is different for
-# Posix and Windows. Defining the console is happen every time you "touch" `console` object.
+# Posix and Windows. Defining the console happens every time you "touch" `console` object.
 # If you use it as input/output:
 # ```
 # console.read 2 > i1
@@ -88,7 +88,7 @@
 
       # Posix console input block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use this object
       # programmatically outside of `console` object.
       [buffer] > input-block
         buffer > @
@@ -115,7 +115,7 @@
 
       # Posix console output block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use this object
       # programmatically outside of `console` object.
       [] > output-block
         true > @
@@ -144,7 +144,7 @@
 
       # Windows console input block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use this object
       # programmatically outside of `console` object.
       [buffer] > input-block
         buffer > @
@@ -171,7 +171,7 @@
 
       # Windows console output block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use this object
       # programmatically outside of `console` object.
       [] > output-block
         true > @

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43
@@ -26,7 +26,7 @@
 # Third, you write read bytes to output
 # After the dataization the object `result` contains read bytes.
 [allocated] > malloc-as-output
-  # Writes bytes contained in `buffer` to operation system console.
+  # Writes bytes contained in `buffer` to the operating system console.
   # Returns new instance of `output-block` ready to write again.
   [buffer] > write
     self. > @
@@ -34,7 +34,7 @@
 
     # Malloc output block.
     #
-    # Attention! The object is for internal usage only, please don't use the object
+    # Note: This object is intended for internal use only. Please do not use this object
     # programmatically outside of `malloc-as-output` object.
     #
     # Here `offset` is the offset to write to allocated block in memory with.
@@ -42,7 +42,7 @@
       true > @
       $ > self
 
-      # Writes bytes contained in `buffer` to operation system console.
+      # Writes bytes contained in `buffer` to the operating system console.
       # Returns new instance of `output-block` ready to write again.
       [buffer] > write
         self. > @

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -26,7 +26,7 @@
   all-lines > @
 
   # Consumes all lines from the standard input stream.
-  # There's no line to consume - returns an empty string.
+  # If there's no line to consume, it returns an empty string.
   [] > all-lines
     rec-read next-line -- true > @
     line-separator > separator!
@@ -48,7 +48,7 @@
           false
 
   # Consumes only one line from the standard input stream.
-  # If there's no line to consume - returns an empty string.
+  # If there's no line to consume, it returns an empty string.
   [] > next-line
     if. > @
       first.as-bytes.size.eq 0

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -24,8 +24,8 @@
 #
 # Here, the first argument is a size of allocated block in memory, the second argument
 # is the scope where memory block is available for reading and writing. When `malloc.of` is
-# dataized it dataizes the scope, clears the block and returns the result of scope dataization.
-# So there's no need for end-user to care about clearing memory after allocation.
+# dataized, it processes the scope, clears the block and returns the result of scope dataization.
+# Therefore, users do not need to manage memory cleanup after allocation.
 #
 # Second, when the size is not known upfront, but there exists
 # an object ready to be dataized and placed into the memory block
@@ -41,7 +41,7 @@
 #
 # Here, the first argument is an object which will be dataized, then a block in memory of given data
 # size is allocated and the data is written to the block. The second argument is the same scope as
-# in the p.1.
+# in the first example.
 #
 # Consider the next code:
 # ```
@@ -78,7 +78,7 @@
           scope m
     (dataized object).as-bytes > bts
 
-  # Allocates block in memory of given `size`. After allocation the `size` zero bytes bytes are
+  # Allocates block in memory of given `size`. After allocation, `size` zero bytes are
   # written into memory.
   [size scope] > of
     # Dataizes given `scope` and returns the result of the dataization as `org.eolang.bytes`.
@@ -99,7 +99,7 @@
       # Returns `org.eolang.malloc.of.allocated` object.
       [new-size] > resized ?
 
-      # Reads the data from block in memory with with offset `source` and `length` and writes
+      # Reads the data from block in memory with offset `source` and `length` and writes
       # to the block with offset `target`.
       # Returns `true` on success, or `error` on failure.
       [source target length] > copy

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.1
++version 0.57.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,13 +1,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-# Counts integral from `a` to `b`.
-# Here `func` is integration function, `a` is an upper limit,
-# `b` is bottom limit, `n` is the number of partitions of the integration interval.
+# Calculates the integral from `a` to `b`.
+# Here `func` is the integration function, `a` is the lower limit,
+# `b` is the upper limit, `n` is the number of partitions of the integration interval.
 [fun a b n] > integral
   as-number. > @
     malloc.of

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,7 +15,7 @@
   [] > max
     if. > @
       lst.is-empty
-      error "Can't get max number from empty sequence"
+      error "Can't get the max number from an empty sequence"
       reduced.
         lst
         negative-infinity
@@ -30,7 +30,7 @@
   [] > min
     if. > @
       lst.is-empty
-      error "Can't get min number from empty sequence"
+      error "Can't get the min number from an empty sequence"
       reduced.
         lst
         positive-infinity

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -13,7 +13,7 @@
 
 # Negative infinity.
 # A special floating-point value representing an unbounded quantity less than all real numbers.
-# When dataized, it signifies an unbounded lower limit or an unreachable maximum value.
+# When dataized, it signifies an unbounded lower limit or an unreachable minimum value.
 [] > negative-infinity
   number FF-F0-00-00-00-00-00-00 > @
   $ > floor

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
@@ -71,7 +71,7 @@
   # This conversion is necessary because network protocols like TCP/IP use
   # big-endian byte order, regardless of the host machine's architecture.
   #
-  # Attention! The object is for internal usage only, please don't use
+  # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [port] > htons
     as-i16. > @
@@ -84,7 +84,7 @@
   # The object allows to use `socket` as input stream and `read` from it sequentially.
   # Here `recv` must be an object that receives the data from the socket.
   #
-  # Attention! The object is for internal usage only, please don't use
+  # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [recv] > as-input
     # Read `size` amount of bytes from socket.
@@ -94,7 +94,7 @@
 
       # Socket input block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use the object
       # programmatically outside of `socket` object.
       [buffer] > input-block
         buffer > @
@@ -113,7 +113,7 @@
   # The object allows to use `socket` as output stream and `write` to it sequentially.
   # Here `send` must be an object that sends the data to the socket.
   #
-  # Attention! The object is for internal usage only, please don't use
+  # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [send] > as-output
     # Write given `buffer` to the socket.
@@ -125,7 +125,7 @@
 
       # Socket output block.
       #
-      # Attention! The object is for internal usage only, please don't use the object
+      # Note: This object is intended for internal use only. Please do not use the object
       # programmatically outside of `console` object.
       [] > output-block
         true > @
@@ -141,7 +141,7 @@
 
   # Posix platform specified socket.
   #
-  # Attention! The object is for internal usage only, please don't use
+  # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [address port] > posix-socket
     code. > sd
@@ -214,7 +214,7 @@
     # Close socket by given descriptor `sockfd`.
     # Returns `true` on success, returns `error` otherwise.
     #
-    # Attention! The object is for internal usage only, please don't use
+    # Note: This object is intended for internal use only. Please do not use
     # the object programmatically outside of `socket` object.
     [sockfd] > closed-socket
       if. > @
@@ -231,7 +231,7 @@
 
     # Safe posix socket that ensures that socket is closed even if error is occurred.
     #
-    # Attention! The object is for internal usage only, please don't use
+    # Note: This object is intended for internal use only. Please do not use
     # the object programmatically outside of `socket` object.
     [scope] > safe-socket
       if. > @
@@ -328,7 +328,7 @@
 
   # The win32 platform specified socket.
   #
-  # Attention! The object is for internal usage only, please don't use
+  # Note: This object is intended for internal use only. Please do not use
   # the object programmatically outside of `socket` object.
   [address port] > win-socket
     code. > sd
@@ -399,7 +399,7 @@
     # Close socket by given descriptor `sockfd`.
     # Returns `true` on success, returns `error` otherwise.
     #
-    # Attention! The object is for internal usage only, please don't use
+    # Note: This object is intended for internal use only. Please do not use
     # the object programmatically outside of `socket` object.
     [sockfd] > closed-socket
       if. > @
@@ -417,7 +417,7 @@
     # Safe win32 socket that ensures that socket is closed and Winsock resources are
     # cleaned even if error is occurred.
     #
-    # Attention! The object is for internal usage only, please don't use
+    # Note: This object is intended for internal use only. Please do not use
     # the object programmatically outside of `socket` object.
     [scope] > safe-socket
       if. > @

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20
@@ -82,7 +82,7 @@
   # can be converted to 8 `bytes` via `as-bytes` object.
   [x] > gt ?
 
-  # Returns `true` if `$` > `x`.
+  # Returns `true` if `$` >= `x`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
   [x] > gte

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation
@@ -11,6 +11,10 @@
 +unlint redundant-object
 
 # Runtime.
+#
+# The runtime object provides a collection of test cases that verify
+# core EO language functionality and behavior.
+#
 [] > runtime
   # This unit test is supposed to check the globals bound objects work as tests.
   true +> global-test

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -20,8 +20,8 @@
 
   # Recursive steps dataization.
   #
-  # Attention! The object is for internal usage only, please
-  # don't use the object programmatically outside of `seq` object.
+  # Note: This object is intended for internal use only. Please
+  # do not use this object programmatically outside of the `seq` object.
   [tup] > loop
     if. > @
       and.

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:94
@@ -29,7 +29,7 @@
     pattern-two > result-three
     pattern-three > result-four
 
-    # The object checks if `index` + `char-size` is out of string bounds.
+    # The object checks if `index` + `char-size` is out of the string bounds.
     # If not - the new recursion iteration is started with `index` increased by `char-size` and
     # `accum` increased by 1.
     [index char-size len] > increase-length
@@ -117,7 +117,7 @@
           * (num-start.plus num-len)
       bts-start
 
-    # The object checks if `index` + provided `char-size` is not out of the string bounds.
+    # The object checks if `index` + `char-size` is not out of the string bounds.
     # If not -  the new recursion circle is started with `index` is increased by `char-size` and
     # `accum` is increased by 1.
     [index char-size accum result cause] > increase

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,13 +3,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
 +unlint redundant-object:24
 
-# List implements based operations on collections like reducing, mapping, filtering, etc.
+# List implements basic operations on collections like reducing, mapping, filtering, etc.
 # Decorates and extends `tuple`.
 [origin] > list
   origin > @

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:40

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:65
@@ -42,7 +42,7 @@
 
   # Constructor of range.
   #
-  # Attention! The object is for internal usage only, please
+  # Note: This object is intended for internal use only. Please
   # don't use the object programmatically outside of `range` object.
   [acc current] > appended
     if. > @

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:26

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,14 +1,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:44
 +unlint redundant-object:46
 
-# The object allows to choose right options according to cases conditions.
-# Parameter cases is the array of two dimensional array, which
+# The object allows choosing the right options according to case conditions.
+# Parameter `cases` is an array of two-dimensional arrays, which
 # consist of condition bool value and expected value, if this
 # condition is true. For example:
 #

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:23

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:28

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:49

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12
@@ -16,11 +16,11 @@
   left > [left right] > if
 
   # And.
-  # A logical operation that returns True only if all given conditions are true.
+  # A logical operation that returns true only if all given conditions are true.
   01-.eq x > [x] > and
 
   # Or.
-  # A logical operation that returns True if at least one of the given conditions is true.
+  # A logical operation that returns true if at least one of the given conditions is true.
   ^ > [x] > or
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -12,8 +12,8 @@
 # Decorate them with `try` and errors will be caught by the `catch`
 # abstract object here and the enclosure of the `error` will be passed to it.
 # When object `try` is dataized - it tries to dataize its `main` attribute.
-# If the error is occurred during the dataization - it caches it and tries
-# to dataize its `catch` attribute. After one the attributes is dataized - it just dataizes
+# If an error occurs during the dataization - it caches it and tries
+# to dataize its `catch` attribute. After one of the attributes is dataized - it just dataizes
 # its `finally` attribute and returns the result of dataization of `main` or `catch`
 # attribute as `org.eolang.bytes`.
 [main catch finally] > try ?

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:16

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.1
++rt jvm org.eolang:eo-runtime:0.57.2
 +rt node eo2js-runtime:0.0.0
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:24
@@ -114,8 +114,8 @@
           tup.prev
 
   # Returns `text` repeated `times` times.
-  # If `times` < 0 - an error is returned.
-  # If `times` == 0 - an original text is returned.
+  # If `times` < 0, an error is returned.
+  # If `times` == 0, the original text is returned.
   [times] > repeated
     if. > @
       0.gt amount

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.1
++version 0.57.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -16,7 +16,7 @@
 #       * i
 # ```
 #
-# Here the behaviour of `while` would identical to:
+# Here the behaviour of `while` would be identical to:
 # ```
 # seq > last
 #   *
@@ -37,8 +37,8 @@
 
   # Recursive loop.
   #
-  # Attention! The object is for internal usage only. Please don't use
-  # the object programmatically outside of `while` object.
+  # Note: This object is intended for internal use only. Please do not use
+  # this object programmatically outside of the `while` object.
   [index] > loop
     if. > @
       (condition (index.plus 1)).as-bool


### PR DESCRIPTION
A new release `eo-0.57.2` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.