### PR TITLE
New release for eo-0.57.3

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.57.2</eo.version>
+    <eo.version>0.57.3</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:22

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -63,8 +63,8 @@
         tup.length.eq 0
         true
         seq *
-          tup.value.deleted
-          rec-delete tup.prev
+          tup.head.deleted
+          rec-delete tup.tail
 
   # Creates an empty temporary file in the current directory.
   [] > tmpfile

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:56
@@ -96,8 +96,8 @@
               if.
                 and.
                   accum.length.gt 0
-                  (accum.value.eq "..").not
-                accum.prev
+                  (accum.head.eq "..").not
+                accum.tail
                 if.
                   is-absolute.not
                   accum.with segment
@@ -351,8 +351,8 @@
                 if.
                   and.
                     accum.length.gt 0
-                    (accum.value.eq "..").not
-                  accum.prev
+                    (accum.head.eq "..").not
+                  accum.tail
                   if.
                     and.
                       is-root-relative.not

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:53

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:47

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:82

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.2
++version 0.57.3
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -14,7 +14,7 @@
     true
     if.
       steps.length.eq 1
-      steps.value
+      steps.head
       loop steps
   steps.length.plus -1 > last-index!
 
@@ -26,10 +26,10 @@
     if. > @
       and.
         tup.length.gt 1
-        loop tup.prev
-      tup.value
+        loop tup.tail
+      tup.head
       or.
-        (dataized tup.value).as-bool.eq --
+        (dataized tup.head).as-bool.eq --
         tup.length.eq last-index
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:94

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -28,9 +28,9 @@
   [index item] > withi
     concat. > @
       with.
-        head index
+        front index
         item
-      tail
+      back
         origin.length.minus index
 
   # Reduce with index from "start" using the function "func".
@@ -48,12 +48,12 @@
         tup.length.eq 1
         func
           start
-          tup.value
+          tup.head
           0
         func
-          rec-reducedi tup.prev
-          tup.value
-          tup.prev.length
+          rec-reducedi tup.tail
+          tup.head
+          tup.tail.length
 
   # Reduce from "start" using the function "func".
   # Here "func" must be an abstract object with two free attributes.
@@ -139,8 +139,8 @@
         first.length.eq 0
         true
         and.
-          first.value.eq second.value
-          rec-eq first.prev second.prev
+          first.head.eq second.head
+          rec-eq first.tail second.tail
 
   # Concatenates current list with given one.
   [passed] > concat
@@ -161,11 +161,11 @@
         if.
           next.eq -1
           if.
-            tup.value.eq wanted
-            tup.prev.length
+            tup.head.eq wanted
+            tup.tail.length
             -1
           next
-      rec-index-of tup.prev > next!
+      rec-index-of tup.tail > next!
 
   # Returns index of the last particular item in list.
   # If the list has no this item, returns -1.
@@ -177,9 +177,9 @@
         tup.length.eq 0
         -1
         if.
-          tup.value.eq wanted
-          tup.prev.length
-          rec-last-index-of tup.prev
+          tup.head.eq wanted
+          tup.tail.length
+          rec-last-index-of tup.tail
 
   # Returns `true` if the list contains `element`.
   # Otherwise, `false`.
@@ -204,10 +204,10 @@
         tup.length.eq 0
         *
         if.
-          func tup.value tup.prev.length
-          next.with tup.value
+          func tup.head tup.tail.length
+          next.with tup.head
           next
-      rec-filteredi tup.prev > next
+      rec-filteredi tup.tail > next
 
   # Filter list without index with the function `func`.
   # Here `func` must be an abstract object
@@ -219,13 +219,13 @@
       func item > [item index] >>
 
   # Get the first `index` elements from the start of the list.
-  [index] > head
+  [index] > front
     if. > @
       idx.eq 0
       list *
       if.
         0.gt idx
-        tail (number idx).neg
+        back (number idx).neg
         if.
           (number idx).gte origin.length
           ^
@@ -237,10 +237,10 @@
       if. > @
         tup.length.eq idx
         tup
-        rec-head tup.prev
+        rec-head tup.tail
 
   # Get the last `index` elements from the end of the list.
-  [index] > tail
+  [index] > back
     if. > @
       0.gt start
       ^
@@ -684,79 +684,79 @@
       * false
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-simple-head
+  [] +> tests-simple-front
     eq. > @
-      head.
+      front.
         list
           * 1 2 3 4 5
         1
       * 1
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-list-head-with-zero-index
+  [] +> tests-list-front-with-zero-index
     is-empty. > @
-      head.
+      front.
         list
           * 1 2 3
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-list-head-with-length-index
+  [] +> tests-list-front-with-length-index
     eq. > @
-      head.
+      front.
         list
           * 1 2 3
         3
       * 1 2 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-complex-head
+  [] +> tests-complex-front
     eq. > @
-      head.
+      front.
         list
           * "foo" 2.2 00-01 "bar"
         2
       * "foo" 2.2
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-head-with-negative
+  [] +> tests-front-with-negative
     eq. > @
-      head.
+      front.
         list
           * 1 2 3
         -1
       * 3
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-complex-head-with-negative
+  [] +> tests-complex-front-with-negative
     eq. > @
-      head.
+      front.
         list
           * "foo" 2.2 00-01 "bar"
         -3
       * 2.2 00-01 "bar"
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-simple-tail
+  [] +> tests-simple-back
     eq. > @
-      tail.
+      back.
         list
           * 1 2 3 4 5
         2
       * 4 5
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-zero-index-in-tail
+  [] +> tests-zero-index-in-back
     is-empty. > @
-      tail.
+      back.
         list
           * 1 2 3 4 5
         0
 
   # This unit test is supposed to check the functionality of the corresponding object.
-  [] +> tests-large-index-in-tail
+  [] +> tests-large-index-in-back
     eq. > @
-      tail.
+      back.
         list
           * 1 2 3 4 5
         10

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:40
@@ -49,12 +49,12 @@
             couple
               prev.entries.with
                 [] >>
-                  tup.value.key > key
-                  tup.value.value > value
+                  tup.head.key > key
+                  tup.head.value > value
                   ^.hash > hash
               prev.hashes.with hash
-        hash-code-of tup.value.key > hash!
-        (rec-rebuild tup.prev).this > prev
+        hash-code-of tup.head.key > hash!
+        (rec-rebuild tup.tail).this > prev
 
   # Hash map entry.
   # Here 'key' is an object which is used to find `value` is hash map.
@@ -107,13 +107,13 @@
             prev.exists
             prev
             if.
-              tup.value.hash.eq hash
+              tup.head.hash.eq hash
               [] >>
                 $ > this
                 true > exists
-                tup.value.value > get
+                tup.head.value > get
               not-found
-        (rec-key-search tup.prev).this > prev
+        (rec-key-search tup.tail).this > prev
 
       [] > not-found
         $ > this

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:65

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:26

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:44
@@ -30,7 +30,7 @@
     error "Switch cases are empty"
     if.
       true.eq found.match
-      found.value
+      found.head
       true
   (rec-case cases).self > found
 
@@ -42,9 +42,9 @@
       previous
       [] >>
         $ > self
-        tup.value.prev.value > match!
-        tup.value.value > value
-    (rec-case tup.prev).self > previous
+        tup.head.tail.head > match!
+        tup.head.head > head
+    (rec-case tup.tail).self > previous
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-switch-simple-case

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:23

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:28

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:49

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:16
@@ -12,7 +12,7 @@
 
 # Tuple.
 # An ordered, immutable collection of elements.
-[prev value length] > tuple
+[tail head length] > tuple
   $ > as-tuple
 
   # Empty tuple.
@@ -21,8 +21,8 @@
     $ > empty
     $ > as-tuple
     0 > length
-    error "Can't get prev from the empty tuple" > prev
-    error "Can't get value from the empty tuple" > value
+    error "Can't get tail from the empty tuple" > tail
+    error "Can't get head from the empty tuple" > head
 
     # Take one element from the tuple, at the given position.
     error "Can't get an object from the empty tuple" > [i] > at
@@ -52,8 +52,8 @@
     [tup] > at-fast
       if. > @
         (tup.length.plus -1).eq index
-        tup.value
-        at-fast tup.prev
+        tup.head
+        at-fast tup.tail
 
   # Create a new tuple with this element added to the end of it.
   [x] > with

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.2
++rt jvm org.eolang:eo-runtime:0.57.3
 +rt node eo2js-runtime:0.0.0
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -23,21 +23,21 @@
   [] +> tests-sscanf-with-string
     eq. > @
       "hello"
-      value.
+      head.
         sscanf "%s" "hello"
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-sscanf-with-int
     eq. > @
       33
-      value.
+      head.
         sscanf "%d" "33"
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-sscanf-with-float
     eq. > @
       0.24
-      value.
+      head.
         sscanf "%f" "0.24"
 
   # This unit test is supposed to check the functionality of the corresponding object.
@@ -57,28 +57,28 @@
   [] +> tests-sscanf-with-string-with-ending
     eq. > @
       "hello"
-      value.
+      head.
         sscanf "%s!" "hello!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-sscanf-with-complex-string
     eq. > @
       "test"
-      value.
+      head.
         sscanf "some%sstring" "someteststring"
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-sscanf-with-complex-int
     eq. > @
       734987259
-      value.
+      head.
         sscanf "!%d!" "!734987259!"
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-sscanf-with-complex-float
     eq. > @
       1991.01
-      value.
+      head.
         sscanf "this will be=%f" "this will be=1991.01"
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:24
@@ -99,7 +99,7 @@
     if. > joined-bts!
       items.length.eq 0
       --
-      with-delimiter items.value items.prev
+      with-delimiter items.head items.tail
 
     [acc tup] > with-delimiter
       if. > @
@@ -108,10 +108,10 @@
         with-delimiter
           concat.
             concat.
-              dataized tup.value
+              dataized tup.head
               delimiter
             acc
-          tup.prev
+          tup.tail
 
   # Returns `text` repeated `times` times.
   # If `times` < 0, an error is returned.
@@ -386,7 +386,7 @@
         sprintf
           "Can't convert text %s to number"
           * origin
-      scanned.value
+      scanned.head
     (sscanf "%f" origin).as-tuple > scanned
 
   # Returns a `tuple` of `strings`, separated by a given `delimiter`.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.2
++version 0.57.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.57.3` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.