### PR TITLE
New release for eo-0.58.2

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.58.1</eo.version>
+    <eo.version>0.58.2</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:22
@@ -19,7 +19,7 @@
 # and `float` encapsulate `bytes`.
 [data] > bytes
   data > @
-  $ > as-bytes
+  bytes data > as-bytes
   eq 01- > as-bool
   # Converts this chain of eight bytes into a number.
   # Returns an error if the byte count is not exactly eight.
@@ -34,38 +34,38 @@
         negative-infinity
         if.
           size.eq 8
-          number $
+          number as-bytes
           error
             sprintf
               "Can't convert non 8 length bytes to a number, bytes are %x"
-              * $
+              * as-bytes
   # Converts this chain of eight bytes into an i64 number.
   # Returns an error if the byte count is not exactly eight.
   if. > as-i64
     size.eq 8
-    i64 $
+    i64 as-bytes
     error
       sprintf
         "Can't convert non 8 length bytes to i64, bytes are %x"
-        * $
+        * as-bytes
   # Converts this chain of four bytes into an i32 number.
   # Returns an error if the byte count is not exactly four.
   if. > as-i32
     size.eq 4
-    i32 $
+    i32 as-bytes
     error
       sprintf
         "Can't convert non 4 length bytes to i32, bytes are %x"
-        * $
+        * as-bytes
   # Converts this chain of two bytes into an i16 number.
   # Returns an error if the byte count is not exactly two.
   if. > as-i16
     size.eq 2
-    i16 $
+    i16 as-bytes
     error
       sprintf
         "Can't convert non 2 length bytes to i16, bytes are %x"
-        * $
+        * as-bytes
 
   # Returns `org.eolang.true` if current sequence of bytes equals to another object.
   # Before the actual comparison the object `b` is dataized.

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -14,20 +14,18 @@
 # Directory in the file system.
 # Apparently every directory is a file.
 [file] > dir
-  $.file > @
-  $ > as-dir
+  file > @
   true > is-directory
 
   # Makes a directory together with all required
   # parent directories and returns the created directory.
   [] > made
-    as-dir. > @
-      if.
-        ^.exists
+    if. > @
+      ^.exists
+      ^
+      seq *
+        mkdir
         ^
-        seq *
-          mkdir
-          ^
 
     # Makes a directory together with all required
     # parent directories.
@@ -45,13 +43,12 @@
   # Deletes directory and all files in it, recursively.
   # Returns the deleted directory.
   [] > deleted
-    as-dir. > @
-      if.
-        ^.exists
-        seq *
-          rec-delete (walk "**").@
-          ^
+    if. > @
+      ^.exists
+      seq *
+        rec-delete (walk "**").@
         ^
+      ^
 
     # Deletes files and directories in the current directory recursively.
     # Returns `true`.
@@ -68,15 +65,14 @@
 
   # Creates an empty temporary file in the current directory.
   [] > tmpfile
-    as-file. > @
-      if.
-        ^.exists
-        QQ.fs.file
-          touch.as-bytes
-        error
-          sprintf
-            "Directory %s does not exist, can't create temporary file"
-            * file
+    if. > @
+      ^.exists
+      QQ.fs.file
+        touch.as-bytes
+      error
+        sprintf
+          "Directory %s does not exist, can't create temporary file"
+          * file
 
     # Creates an empty temporary file in the current directory and
     # returns absolute path to it as `org.eolang.string`.

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27
@@ -23,10 +23,9 @@
 
 # The file object in the filesystem.
 [path] > file
-  $.path > @
-  $ > as-file
+  path > @
   # Converts the `file` to a `path`.
-  (QQ.fs.path path).determined > as-path
+  (QQ.fs.path path).@ > as-path
 
   # Returns `org.eolang.true` if current file is a directory, returns `org.eolang.false` otherwise.
   [] > is-directory ?
@@ -38,13 +37,12 @@
   # If current file does not exist - create an empty file
   # in filesystem and returns it.
   [] > touched
-    as-file. > @
-      if.
-        exists
+    if. > @
+      exists
+      ^
+      seq *
+        touch
         ^
-        seq *
-          touch
-          ^
 
     # Creates new empty file and returns `org.eolang.true`.
     #
@@ -55,13 +53,12 @@
   # If current file exists - deletes it and returns it.
   # If current file does not exist - just returns it.
   [] > deleted
-    as-file. > @
-      if.
-        exists
-        seq *
-          delete
-          ^
+    if. > @
+      exists
+      seq *
+        delete
         ^
+      ^
 
     # Deletes the file and returns `org.eolang.true`.
     #
@@ -74,8 +71,8 @@
 
   # Moves the current file to `target`, making and returning a new `file` from it.
   [target] > moved
-    as-file. > @
-      file move
+    file > @
+      move
 
     # Tries to move file from `^.path` to `target`
     # and returns path of moved file as `org.eolang.string`.
@@ -117,32 +114,31 @@
   # When `file.open` is dataized - it opens file stream, dataizes the `scope`,
   # closes the file stream and returns an original file object.
   [mode scope] > open
-    as-file. > @
+    if. > @
+      can-read.not.and can-write.not
+      error "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
-        can-read.not.and can-write.not
-        error "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+        exists.not
         if.
-          exists.not
-          if.
-            must-exists
-            error
-              sprintf
-                "File must exist for given access mod: '%s'"
-                * access
-            seq *
-              touched.touch
-              process-file
-              ^
-          if.
-            truncate
-            seq *
-              deleted.delete
-              touched.touch
-              process-file
-              ^
-            seq *
-              process-file
-              ^
+          must-exists
+          error
+            sprintf
+              "File must exist for given access mod: '%s'"
+              * access
+          seq *
+            touched.touch
+            process-file
+            ^
+        if.
+          truncate
+          seq *
+            deleted.delete
+            touched.touch
+            process-file
+            ^
+          seq *
+            process-file
+            ^
     mode > access!
     (access.eq "r").as-bool > read
     (access.eq "w").as-bool > write
@@ -185,7 +181,8 @@
       # Returns new instance of `input-block` with `buffer` read from file, or
       # returns `org.eolang.error` if access mode does not allow reading operations.
       [size] > read
-        ((input-block --).read size).this > @
+        (input-block --).read > @
+          size
 
         # File input block
         #
@@ -193,24 +190,21 @@
         # don't use the object programmatically outside of `file` object.
         [buffer] > input-block
           buffer > @
-          $ > this
 
           # Read `size` amount of bytes from file input stream.
           # Returns new instance of `input-block` with `buffer` read from file, or
           # returns `org.eolang.error` if provided access mode does not allow reading operations.
           [size] > read
-            this. > @
-              if.
-                can-read.not
-                [] >>
-                  error > @
-                    sprintf
-                      "Can't read from file with provided access mode '%s'"
-                      * access
-                  $ > this
-                seq *
-                  read-bytes
-                  input-block read-bytes
+            if. > @
+              can-read.not
+              [] >>
+                error > @
+                  sprintf
+                    "Can't read from file with provided access mode '%s'"
+                    * access
+              seq *
+                read-bytes
+                input-block read-bytes
             ^.^.read-bytes size > read-bytes!
 
         # Bytes, as `org.eolang.bytes`, read from file input stream.
@@ -225,7 +219,7 @@
       # Returns new instance of `output-block` ready to write again, or
       # returns an error if provided access mode does not allow writing operations.
       [buffer] > write
-        (output-block.write buffer).this > @
+        output-block.write buffer > @
 
         # File output block.
         #
@@ -233,7 +227,6 @@
         # don't use the object programmatically outside of `file` object.
         [] > output-block
           true > @
-          $ > this
 
           # Write given `buffer` to file output stream.
           # Here `buffer` is either a sequence of bytes or an object that can be
@@ -241,18 +234,16 @@
           # Returns new instance of `output-block` ready to write again, or
           # returns an error if provided access mode does not allow writing operations.
           [buffer] > write
-            this. > @
-              if.
-                can-write.not
-                [] >>
-                  error > @
-                    sprintf
-                      "Can't write to file with provided access mode '%s'"
-                      * access
-                  $ > this
-                seq *
-                  written-bytes buffer
-                  output-block
+            if. > @
+              can-write.not
+              [] >>
+                error > @
+                  sprintf
+                    "Can't write to file with provided access mode '%s'"
+                    * access
+              seq *
+                written-bytes buffer
+                output-block
 
         # Writes given `buffer` of bytes to file output stream and returns `org.eolang.true`.
         #
@@ -300,7 +291,7 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> throws-an-error-on-touching-temp-file-in-absent-dir
-    (tmpdir.as-path.resolved "foo").as-dir.tmpfile > @
+    (tmpdir.as-path.resolved "foo").@.tmpfile > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] > tests-resolves-and-touches
@@ -314,7 +305,7 @@
             joined.
               text path.separator
               * "foo" "bar"
-    (tmpdir.as-path.resolved "foo/bar").as-dir > resolved
+    (tmpdir.as-path.resolved "foo/bar").@ > resolved
     resolved.tmpfile > f
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:56
@@ -20,13 +20,12 @@
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
 [uri] > path
-  determined. > @
-    if.
-      os.is-windows
-      win32
-        string uri.as-bytes
-      posix
-        string uri.as-bytes
+  if. > @
+    os.is-windows
+    win32
+      string uri.as-bytes
+    posix
+      string uri.as-bytes
   # The system-dependent default name-separator character.
   # On UNIX systems the value of this field is "/";
   # on Microsoft Windows systems it is "\\".
@@ -53,10 +52,9 @@
   # A standardized way to represent file or directory locations in a Unix-like system.
   [uri] > posix
     uri > @
-    $ > determined
     "/" > separator
-    (file uri).as-file > as-file
-    (dir (QQ.fs.file uri)).as-dir > as-dir
+    file uri > as-file
+    dir (file uri) > as-dir
     # Returns `true` if current path is absolute - starts with '/' char.
     and. > is-absolute
       uri.length.gt 0
@@ -67,12 +65,11 @@
     # - converting multiple slashes into a single slash.
     # - resolving "." (current directory) and ".."  (parent directory) segments.
     [] > normalized
-      determined. > @
-        posix
-          if.
-            normalized.eq "//"
-            "/"
-            string normalized
+      posix > @
+        if.
+          normalized.eq "//"
+          "/"
+          string normalized
       uri > uri-as-bytes!
       ^.is-absolute.as-bool > is-absolute
       and. > has-trailing-slash
@@ -251,12 +248,11 @@
   # The object decorates `win32.validated` with forward slashes replaced with
   # back ones.
   [uri] > win32
-    determined. > @
-      validated
-        string
-          as-bytes.
-            validated.separated-correctly
-              uri
+    validated > @
+      string
+        as-bytes.
+          validated.separated-correctly
+            uri
     "\\" > separator
 
     # Windows validated path with forward slashes replaced with back ones.
@@ -265,10 +261,9 @@
     # don't use the object programmatically outside of `path` object.
     [uri] > validated
       uri > @
-      $ > determined
       ^.separator > separator
-      (file uri).as-file > as-file
-      (dir (file uri)).as-dir > as-dir
+      file uri > as-file
+      dir (file uri) > as-dir
 
       # Returns `true` if given `uri` is drive relative which means it
       # starts with "X:" where 'X' - system drive name.
@@ -315,12 +310,11 @@
       # - resolving "." (current directory) and ".."  (parent directory) segments.
       # - handling of drive letters in Windows.
       [] > normalized
-        determined. > @
-          validated
-            if.
-              normalized.eq "\\\\"
-              separator
-              string normalized
+        validated > @
+          if.
+            normalized.eq "\\\\"
+            separator
+            string normalized
         uri > uri-as-bytes!
         (^.is-drive-relative uri-as-bytes).as-bool > is-drive-relative
         (^.is-root-relative uri-as-bytes).as-bool > is-root-relative

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -18,42 +18,41 @@
 # takes the first environment variable in the list TMP, TEMP, USERPROFILE.
 # If none of these are found, it returns the Windows directory (C:\Windows).
 [] > tmpdir
-  as-dir. > @
-    dir
-      file
-        string
-          [] >>!
-            if. > @
-              os.is-windows
+  dir > @
+    file
+      string
+        [] >>!
+          if. > @
+            os.is-windows
+            if.
+              tmp.eq empty
+              if.
+                temp.eq empty
+                if.
+                  userprofile.eq empty
+                  "C:\\Windows"
+                  userprofile
+                temp
+              tmp
+            if.
+              tmpdir.eq empty
               if.
                 tmp.eq empty
                 if.
                   temp.eq empty
                   if.
-                    userprofile.eq empty
-                    "C:\\Windows"
-                    userprofile
+                    tempdir.eq empty
+                    "/tmp"
+                    tempdir
                   temp
                 tmp
-              if.
-                tmpdir.eq empty
-                if.
-                  tmp.eq empty
-                  if.
-                    temp.eq empty
-                    if.
-                      tempdir.eq empty
-                      "/tmp"
-                      tempdir
-                    temp
-                  tmp
-                tmpdir
-            getenv "TMPDIR" > tmpdir!
-            getenv "TMP" > tmp!
-            getenv "TEMP" > temp!
-            getenv "TEMPDIR" > tempdir!
-            getenv "USERPROFILE" > userprofile!
-            -- > empty
+              tmpdir
+          getenv "TMPDIR" > tmpdir!
+          getenv "TMP" > tmp!
+          getenv "TEMP" > temp!
+          getenv "TEMPDIR" > tempdir!
+          getenv "USERPROFILE" > userprofile!
+          -- > empty
 
   # This unit test is supposed to check the functionality of the corresponding object.
   tmpdir.exists > [] +> global-temp-dir-exists

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:53

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -16,7 +16,6 @@
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i16
   as-bytes > @
-  $ > as-i16
   times -1.as-i64.as-i32.as-i16 > neg
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -15,7 +15,6 @@
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i32
   as-bytes > @
-  $ > as-i32
   times -1.as-i64.as-i32 > neg
   as-i64.as-number > as-number
 

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -15,7 +15,6 @@
 # Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i64
   as-bytes > @
-  $ > as-i64
   times -1.as-i64 > neg
   as-i32.as-i16 > as-i16
 
@@ -193,21 +192,21 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-i64-zero-eq-to-i64-zero
     eq. > @
-      0.as-i64
-      0.as-i64
+      0.@
+      0.@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-i64-eq-true
     eq. > @
-      123.as-i64
-      123.as-i64
+      123.@
+      123.@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-i64-eq-false
     not. > @
       eq.
-        123.as-i64
-        42.as-i64
+        123.@
+        42.@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-i64-one-plus-i64-one

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:47
@@ -33,7 +33,7 @@
   # Returns new instance of `input-block` with set
   # sliced `data` and `buffer`.
   [size] > read
-    ((input-block bts --).read size).self > @
+    ((input-block bts --).read size).@ > @
 
     # Bytes-as-input block.
     #
@@ -44,24 +44,22 @@
     # `buffer` is a sequence of bytes that got from previous reading.
     [data buffer] > input-block
       buffer > @
-      $ > self
 
       # Read `size` amount of bytes from `data`.
       # Returns new instance of `input-block` with set
       # sliced `data` and `buffer`.
       [size] > read
-        self. > @
-          if.
-            available.eq 0
-            input-block -- --
-            input-block
-              as-bytes.
-                data.slice
-                  next
-                  (number available).minus
-                    number next
-              as-bytes.
-                data.slice 0 next
+        if. > @
+          available.eq 0
+          input-block -- --
+          input-block
+            as-bytes.
+              data.slice
+                next
+                (number available).minus
+                  number next
+            as-bytes.
+              data.slice 0 next
         size > to-read!
         data.size > available!
         if. > next!

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:82
@@ -70,21 +70,18 @@
 # ```
 # That why it's better to use it sequentially.
 [] > console
-  platform. > @
-    if.
-      os.is-windows
-      windows-console
-      posix-console
+  if. > @
+    os.is-windows
+    windows-console
+    posix-console
 
   # Posix console.
   # It uses posix system calls to read/write standard inputs/outputs.
   [] > posix-console
-    $ > platform
-
     # Read `size` amount of bytes from operation system console.
     # Returns new instance of `input-block` with `buffer` read from console.
     [size] > read
-      ((input-block --).read size).self > @
+      ((input-block --).read size).@ > @
 
       # Posix console input block.
       #
@@ -92,15 +89,13 @@
       # programmatically outside of `console` object.
       [buffer] > input-block
         buffer > @
-        $ > self
 
         # Read `size` amount of bytes from operation system console.
         # Returns new instance of `input-block` with `buffer` read from console.
         [size] > read
-          self. > @
-            seq *
-              read-bytes
-              input-block read-bytes
+          seq * > @
+            read-bytes
+            input-block read-bytes
           output. > read-bytes!
             posix
               "read"
@@ -111,7 +106,7 @@
     # dataized via `as-bytes` object.
     # Returns new instance of `output-block` ready to write again.
     [buffer] > write
-      (output-block.write buffer).self > @
+      (output-block.write buffer).@ > @
 
       # Posix console output block.
       #
@@ -119,28 +114,24 @@
       # programmatically outside of `console` object.
       [] > output-block
         true > @
-        $ > self
 
         # Writes bytes contained in `buffer` to operation system console.
         # Returns new instance of `output-block` ready to write again.
         [buffer] > write
-          self. > @
-            seq *
-              code.
-                posix
-                  "write"
-                  * posix.stdout-fileno buffer buffer.size
-              output-block
+          seq * > @
+            code.
+              posix
+                "write"
+                * posix.stdout-fileno buffer buffer.size
+            output-block
 
   # Windows console.
   # It uses kernel32.dll system function calls to read/write standard inputs/outputs.
   [] > windows-console
-    $ > platform
-
     # Read `size` amount of bytes from operation system console.
     # Returns new instance of `input-block` with `buffer` read from console.
     [size] > read
-      ((input-block --).read size).self > @
+      ((input-block --).read size).@ > @
 
       # Windows console input block.
       #
@@ -148,15 +139,13 @@
       # programmatically outside of `console` object.
       [buffer] > input-block
         buffer > @
-        $ > self
 
         # Read `size` amount of bytes from operation system console.
         # Returns new instance of `input-block` with `buffer` read from console.
         [size] > read
-          self. > @
-            seq *
-              read-bytes
-              input-block read-bytes
+          seq * > @
+            read-bytes
+            input-block read-bytes
           output. > read-bytes!
             win32
               "ReadFile"
@@ -167,7 +156,7 @@
     # dataized via `as-bytes` object.
     # Returns new instance of `output-block` ready to write again.
     [buffer] > write
-      (output-block.write buffer).self > @
+      (output-block.write buffer).@ > @
 
       # Windows console output block.
       #
@@ -175,18 +164,16 @@
       # programmatically outside of `console` object.
       [] > output-block
         true > @
-        $ > self
 
         # Writes bytes contained in `buffer` to operation system console.
         # Returns new instance of `output-block` ready to write again.
         [buffer] > write
-          self. > @
-            seq *
-              code.
-                win32
-                  "WriteFile"
-                  * win32.std-output-handle buffer buffer.size
-              output-block
+          seq * > @
+            code.
+              win32
+                "WriteFile"
+                * win32.std-output-handle buffer buffer.size
+            output-block
 
   # Prints a simple message to the console. We can't validate
   # the output, so we just run it and see if it crashes.

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43
@@ -29,8 +29,8 @@
   # Writes bytes contained in `buffer` to the operating system console.
   # Returns new instance of `output-block` ready to write again.
   [buffer] > write
-    self. > @
-      (output-block 0).write buffer
+    (output-block 0).write > @
+      buffer
 
     # Malloc output block.
     #
@@ -40,16 +40,14 @@
     # Here `offset` is the offset to write to allocated block in memory with.
     [offset] > output-block
       true > @
-      $ > self
 
       # Writes bytes contained in `buffer` to the operating system console.
       # Returns new instance of `output-block` ready to write again.
       [buffer] > write
-        self. > @
-          seq *
-            allocated.write offset buffer
-            output-block
-              offset.plus buffer.size
+        seq * > @
+          allocated.write offset buffer
+          output-block
+            offset.plus buffer.size
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-makes-an-output-from-malloc-and-writes

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
@@ -54,7 +54,7 @@
       first.as-bytes.size.eq 0
       ""
       rec-read first --
-    (console.read 1).self > first
+    (console.read 1).@ > first
 
     # Recursive reading from console by one byte.
     #
@@ -74,4 +74,4 @@
           next
           buffer.concat char
       input.as-bytes > char
-      (input.read 1).self > next
+      (input.read 1).@ > next

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43
@@ -28,7 +28,8 @@
   # Returns new instance of `input-block` with set
   # `input` ready to be read, `output` ready to be written and bytes `buffer`.
   [size] > read
-    ((input-block input output --).read size).self > @
+    (input-block input output --).read > @
+      size
 
     # Tee-input block.
     #
@@ -40,19 +41,17 @@
     # `buffer` is a sequence of bytes that got from previous reading.
     [input output buffer] > input-block
       buffer > @
-      $ > self
 
       # Read `size` amount of bytes from `input`.
       # Returns new instance of `input-block` with set
       # `input` ready to be read, `output` ready to be written and bytes `buffer`.
       [size] > read
-        self. > @
-          seq *
+        seq * > @
+          written-bytes
+          input-block
+            read-bytes
             written-bytes
-            input-block
-              read-bytes
-              written-bytes
-              read-bytes.as-bytes
+            read-bytes.as-bytes
         (input.read size).read.^ > read-bytes
         (output.write read-bytes).write.^ > written-bytes
 

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -18,12 +18,12 @@
   # Converts this from radians to degrees.
   angle > in-degrees
     div.
-      $.times 180.0
+      times 180.0
       pi
   # Converts this from degrees to radians.
   angle > in-radians
     div.
-      $.times pi
+      times pi
       180.0
 
   # Calculates sine of current angle and returns it as `org.eolang.number`.

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.1
++version 0.58.2
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20
@@ -17,7 +17,6 @@
   div. > @
     seed.as-number
     00-20-00-00-00-00-00-00.as-i64.as-number
-  $ > fixed
   # Next random.
   # Formula is based on linear congruential pseudorandom number generator, as defined by
   # D. H. Lehmer and described by Donald E. Knuth in The Art of Computer Programming, Volume 2,
@@ -25,16 +24,15 @@
   # Magic numbers are taken from Java implementation. 48 lower bits are considered.
   # `next` = (`seed` * 25214903917 + 11) & ((1 << 48) - 1).
   # Here `00-0F-FF-FF-FF-FF-FF-FF` is pre calculated `(1 << 48) - 1`.
-  fixed. > next
-    random
-      as-number.
-        as-i64.
-          and.
-            as-i64.
-              plus.
-                seed.times 25214903917
-                11
-            00-0F-FF-FF-FF-FF-FF-FF
+  random > next
+    as-number.
+      as-i64.
+        and.
+          as-i64.
+            plus.
+              seed.times 25214903917
+              11
+          00-0F-FF-FF-FF-FF-FF-FF
 
   # New random with pseudo-random seed.
   [] > pseudo
@@ -95,7 +93,7 @@
       and.
         rand.next.next.lt 1
         (rand.next.next.lt 0).not
-    (random 123).fixed > rand
+    (random 123).next > rand
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-two-random-numbers-not-equal

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -15,8 +15,6 @@
 # for representing undefined or unrepresentable numerical results.
 [] > nan
   number 7F-F8-00-00-00-00-00-00 > @
-  $ > floor
-  $ > neg
   true > is-nan
   false > is-finite
   false > is-integer
@@ -150,7 +148,7 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-nan-neg-is-nan
     eq. > @
-      nan.neg.as-bytes
+      nan.@.as-bytes
       nan.as-bytes
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -16,7 +16,6 @@
 # When dataized, it signifies an unbounded lower limit or an unreachable minimum value.
 [] > negative-infinity
   number FF-F0-00-00-00-00-00-00 > @
-  $ > floor
   positive-infinity > neg
   false > is-nan
   false > is-finite
@@ -506,7 +505,7 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-negative-infinity-floor-is-equal-to-self
-    negative-infinity.floor.eq negative-infinity > @
+    negative-infinity.@.eq negative-infinity > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-negative-infinity-is-not-nan

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
@@ -90,7 +90,7 @@
     # Read `size` amount of bytes from socket.
     # Returns new instance of `input-block` with `buffer` read from socket.
     [size] > read
-      ((input-block --).read size).self > @
+      ((input-block --).read size).@ > @
 
       # Socket input block.
       #
@@ -98,15 +98,13 @@
       # programmatically outside of `socket` object.
       [buffer] > input-block
         buffer > @
-        $ > self
 
         # Read `size` amount of bytes from socket.
         # Returns new instance of `input-block` with `buffer` read from socket.
         [size] > read
-          self. > @
-            seq *
-              read-bytes
-              input-block read-bytes
+          seq * > @
+            read-bytes
+            input-block read-bytes
           (recv size).as-bytes > read-bytes
 
   # Makes an `output` from posix socket.
@@ -121,7 +119,7 @@
     # dataized via `as-bytes` object.
     # Returns new instance of `output-block` ready to `write` again.
     [buffer] > write
-      (output-block.write buffer).self > @
+      (output-block.write buffer).@ > @
 
       # Socket output block.
       #
@@ -129,15 +127,13 @@
       # programmatically outside of `console` object.
       [] > output-block
         true > @
-        $ > self
 
         # Writes bytes contained in `buffer` to the socket.
         # Returns new instance of `output-block` ready to write again.
         [buffer] > write
-          self. > @
-            seq *
-              send buffer
-              output-block
+          seq * > @
+            send buffer
+            output-block
 
   # Posix platform specified socket.
   #

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20
@@ -17,7 +17,6 @@
 # number that internally is a chain of eight bytes.
 [as-bytes] > number
   as-bytes > @
-  $ > as-number
   times -1 > neg
   as-i64.as-i32 > as-i32
   as-i32.as-i16 > as-i16
@@ -364,9 +363,8 @@
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-to-bytes-and-backwards
     eq. > @
-      as-number.
-        as-bytes.
-          42
+      as-bytes.
+        42
       42
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19
@@ -16,7 +16,6 @@
 # When dataized, it signifies an unbounded upper limit or an unreachable maximum value.
 [] > positive-infinity
   number 7F-F0-00-00-00-00-00-00 > @
-  $ > floor
   negative-infinity > neg
   false > is-nan
   false > is-finite
@@ -519,7 +518,7 @@
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-positive-infinity-floor-is-equal-to-self
-    positive-infinity.floor.eq positive-infinity > @
+    positive-infinity.@.eq positive-infinity > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-positive-infinity-is-not-nan

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation
@@ -25,7 +25,7 @@
       a 42
       42
     [x] > a
-      $.x > @
+      x > @
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-takes-parent-object
@@ -54,10 +54,9 @@
       [] > @
         [] > @
           eq. > @
-            this.x
+            x
             42
     42 > x
-    $ > this
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> throws-when-applies-to-closed-object

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:94

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -17,7 +17,7 @@
   # A check to determine if an object contains no elements or data.
   0.eq origin.length > is-empty
   # Returns a new list sorted via `.lt` method.
-  $ > sorted
+  origin > sorted
 
   # Create a new list with this element added to the end of it.
   [x] > with

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:39
@@ -25,35 +25,33 @@
 # Here `pairs` must be a `tuple` of `map.entry` object.
 # The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
 [pairs] > map
-  this. > @
-    [] >>
-      initialized > @
+  [] > @
+    initialized > @
+      if.
+        pairs.length.eq 0
+        *
+        entries.
+          rec-rebuild
+            pairs
+
+    [entries hashes] > couple
+
+    [tup] > rec-rebuild
+      if. > @
+        tup.length.eq 0
+        couple * (list *)
         if.
-          pairs.length.eq 0
-          *
-          entries.
-            rec-rebuild
-              pairs
-
-      [entries hashes] > couple
-        $ > this
-
-      [tup] > rec-rebuild
-        if. > @
-          tup.length.eq 0
-          couple * (list *)
-          if.
-            prev.hashes.contains hash
-            prev
-            couple
-              prev.entries.with
-                [] >>
-                  tup.head.key > key
-                  tup.head.value > value
-                  ^.hash > hash
-              prev.hashes.with hash
-        hash-code-of tup.head.key > hash!
-        (rec-rebuild tup.tail).this > prev
+          prev.hashes.contains hash
+          prev
+          couple
+            prev.entries.with
+              [] >>
+                tup.head.key > key
+                tup.head.value > value
+                ^.hash > hash
+            prev.hashes.with hash
+      hash-code-of tup.head.key > hash!
+      (rec-rebuild tup.tail).@ > prev
 
   # Hash map entry.
   # Here 'key' is an object which is used to find `value` is hash map.
@@ -64,7 +62,6 @@
 
   # Initialized hash map with rebuilt entries.
   [entries] > initialized
-    $ > this
     entries.length > size
     # Returns `list` of all keys in hash map.
     # Keys order is not guaranteed.
@@ -108,14 +105,12 @@
             if.
               tup.head.hash.eq hash
               [] >>
-                $ > this
                 true > exists
                 tup.head.value > get
               not-found
-        (rec-key-search tup.tail).this > prev
+        (rec-key-search tup.tail).@ > prev
 
       [] > not-found
-        $ > this
         false > exists
         error > get
           sprintf
@@ -125,28 +120,26 @@
     # Returns the new `map` with added object
     # Replaces if there was one before.
     [key value] > with
-      this. > @
-        map.initialized
-          with.
-            origin.
-              filtered.
-                list entries
-                (hash.eq entry.hash).not > [entry] >>
-            [] >>
-              ^.key > key
-              ^.value > value
-              ^.hash > hash
+      map.initialized > @
+        with.
+          origin.
+            filtered.
+              list entries
+              (hash.eq entry.hash).not > [entry] >>
+          [] >>
+            ^.key > key
+            ^.value > value
+            ^.hash > hash
       hash-code-of key > hash!
 
     # Returns a new `map`, without element with the given `key`
     # Returns the `map` itself, if there was no item with this `key`.
     [key] > without
-      this. > @
-        map.initialized
-          origin.
-            filtered.
-              list entries
-              (hash.eq entry.hash).not > [entry] >>
+      map.initialized > @
+        origin.
+          filtered.
+            list entries
+            (hash.eq entry.hash).not > [entry] >>
       hash-code-of key > hash!
 
   # This unit test is supposed to check the functionality of the corresponding object.

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:65

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:26
@@ -11,34 +11,30 @@
 
 # Set - is an unordered `list` of unique objects.
 [lst] > set
-  this. > @
-    initialized
-      map
-        list
-          lst
-        .mapped
-          map.entry item true > [item]
-        .origin
+  initialized > @
+    map
+      list
+        lst
+      .mapped
+        map.entry item true > [item]
+      .origin
 
   # Initialized set with rebuilt unique sequence.
   [mp] > initialized
     mp.keys > @
-    $ > this
     mp.size > size
 
     # Append new `item` to set. It must be possible to get
     # hash code of `item` so `item` must be dataizable.
     [item] > with
-      this. > @
-        set.initialized
-          mp.with item true
+      set.initialized > @
+        mp.with item true
 
     # Remove `item` from `set`. If `item` is not present,
     # the set won't be changed.
     [item] > without
-      this. > @
-        set.initialized
-          mp.without item
+      set.initialized > @
+        mp.without item
 
     # Check if given `item` exists in set.
     mp.has item > [item] > has

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:44
@@ -32,7 +32,7 @@
       true.eq found.match
       found.head
       true
-  (rec-case cases).self > found
+  (rec-case cases).@ > found
 
   [tup] > rec-case
     if. > @
@@ -41,10 +41,9 @@
         previous.match
       previous
       [] >>
-        $ > self
         tup.head.tail.head > match!
         tup.head.head > head
-    (rec-case tup.tail).self > previous
+    (rec-case tup.tail).@ > previous
 
   # This unit test is supposed to check the functionality of the corresponding object.
   [] +> tests-switch-simple-case

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:23

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:28
@@ -33,7 +33,7 @@
   -1 > inaddr-none
   [code output] > return
     output > @
-    $ > called
+    return code output > called
 
   # Timeval structure for "gettimeofday" syscall.
   # Here `tv-sec` is seconds since Jan 1, 1970, and `tv-usec` - microseconds.

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:49
@@ -43,7 +43,7 @@
 
   [code output] > return
     output > @
-    $ > called
+    return code output > called
 
   # Structure for "GetSystemTime" function call.
   [year month day day-of-week hour minute second milliseconds] > system-time

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17
@@ -14,7 +14,6 @@
   # Empty tuple.
   # A tuple with no elements. When dataized, it represents an immutable, empty collection.
   [] > empty
-    $ > empty
     0 > length
     error "Can't get tail from the empty tuple" > tail
     error "Can't get head from the empty tuple" > head

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55
@@ -52,7 +52,7 @@
   # Here `serialized` is `bytes` which represents serialized structure in memory
   # that is built after compilation.
   [serialized] > pattern
-    $ > compiled
+    pattern serialized > compiled
 
     # Returns `true` of given `txt` matches against
     # the provided regular expression pattern.

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.1
++rt jvm org.eolang:eo-runtime:0.58.2
 +rt node eo2js-runtime:0.0.0
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:24
@@ -30,7 +30,7 @@
   # Returns `text` trimmed from both sides.
   if. > trimmed
     0.eq origin.as-bytes.size
-    $
+    text origin
     trimmed-left.trimmed-right
 
   # Takes a piece of a `text` as another `text`.

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.1
++version 0.58.2
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.58.2` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.