### PR TITLE
New release for eo-0.62.1

### DIFF
--- a/objects/bool.eo
+++ b/objects/bool.eo
@@ -7,7 +7,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/buffer.eo
+++ b/objects/buffer.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -14,9 +14,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/bytes/array.eo
+++ b/objects/bytes/array.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-bool.eo
+++ b/objects/bytes/as-bool.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-bytes.eo
+++ b/objects/bytes/as-bytes.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-i16.eo
+++ b/objects/bytes/as-i16.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-i32.eo
+++ b/objects/bytes/as-i32.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-i64.eo
+++ b/objects/bytes/as-i64.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-i8.eo
+++ b/objects/bytes/as-i8.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-input.eo
+++ b/objects/bytes/as-input.eo
@@ -24,7 +24,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-number.eo
+++ b/objects/bytes/as-number.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-u16.eo
+++ b/objects/bytes/as-u16.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-u32.eo
+++ b/objects/bytes/as-u32.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-u64.eo
+++ b/objects/bytes/as-u64.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-u8.eo
+++ b/objects/bytes/as-u8.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/hash.eo
+++ b/objects/bytes/hash.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/left.eo
+++ b/objects/bytes/left.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/xor.eo
+++ b/objects/bytes/xor.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/chunk.eo
+++ b/objects/chunk.eo
@@ -21,9 +21,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/chunk/to-output.eo
+++ b/objects/chunk/to-output.eo
@@ -18,7 +18,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package chunk
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/clock.eo
+++ b/objects/clock.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/console.eo
+++ b/objects/console.eo
@@ -58,7 +58,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -31,9 +31,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/directory.eo
+++ b/objects/directory.eo
@@ -3,9 +3,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/directory/deleted.eo
+++ b/objects/directory/deleted.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/directory/made.eo
+++ b/objects/directory/made.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/directory/open.eo
+++ b/objects/directory/open.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/e.eo
+++ b/objects/e.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/eol.eo
+++ b/objects/eol.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/file.eo
+++ b/objects/file.eo
@@ -4,7 +4,7 @@
 +alias string.joined
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -14,30 +14,6 @@
   path > @
   @. > as-path
     Q.path path
-  [] > deleted
-    exists.if > @
-      if.
-        outcome.eq 0
-        ^
-        T
-          "Cant delete the file '%s': %s".printf
-            * path removed.output
-      ^
-    removed.code > outcome
-    called. > removed
-      os.is-windows.if
-        win32 *1
-          win
-          path
-        posix *1
-          unix
-          path
-    is-directory.if > unix
-      "rmdir"
-      "unlink"
-    is-directory.if > win
-      "_rmdir"
-      "_unlink"
   eq. > [] > exists
     code.
       os.is-windows.if
@@ -66,24 +42,6 @@
         posix *1
           "stat"
           path
-  [target] > moved
-    if. > @
-      outcome.eq 0
-      file target
-      T
-        "Cant move the file '%s' to '%s': %s".printf
-          * path target renamed.output
-    renamed.code > outcome
-    called. > renamed
-      os.is-windows.if
-        win32 *1
-          "rename"
-          path
-          target
-        posix *1
-          "rename"
-          path
-          target
   [mode scope cant-open] > open
     known.not.if > @
       T
@@ -200,49 +158,6 @@
     not. > writable
       as-bool.
         access.eq "r"
-  [cant-measure] > size
-    if. > @
-      info.code.eq 0
-      info.output.size
-      cant-measure
-    called. > info
-      os.is-windows.if
-        win32 *1
-          "_stat64"
-          path
-        posix *1
-          "stat"
-          path
-  [] > touched
-    exists.if > @
-      ^
-      if.
-        descriptor.eq -1
-        T
-          "Cant touch the file '%s': %s".printf
-            * path created.output
-        seq *
-          closed
-          ^
-    code. > closed
-      os.is-windows.if
-        win32 *1
-          "_close"
-          descriptor
-        posix *1
-          "close"
-          descriptor
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_creat"
-          path
-          win32.mode
-        posix *1
-          "creat"
-          path
-          posix.mode
-    created.code > descriptor
 
   eq. ++> can-append-data-to-a-file
     size.
@@ -253,20 +168,6 @@
         "a"
         f.write "!" > [f]
     13
-
-  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
-
-  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
-    0
-
-  ++> can-move-a-file
-    and. > @
-      exists.
-        temp.moved
-          "%s.dest".printf
-            * temp.path
-      temp.exists.not
-    mktemp.tmpfile > temp
 
   ++> can-read-from-a-file
     eq. > @
@@ -332,26 +233,12 @@
           "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
 
-  ++> can-return-itself-after-deleting
-    temp.deleted.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  ++> can-return-itself-after-touching
-    temp.deleted.touched.path.eq temp.path > @
-    mktemp.tmpfile > temp
-
-  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
-
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.
       file "absent.txt"
 
   is-directory. ++> can-tell-that-the-current-directory-is-a-directory
     file "."
-
-  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
-
-  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
 
   exists. ++> can-touch-an-absent-file-on-opening-for-appending
     mktemp.tmpfile.deleted.open
@@ -474,10 +361,6 @@
       f > [f]
       "recovered" > [reason]
 
-  eq. ++> rejects-sizing-an-absent-file
-    -1
-    mktemp.tmpfile.deleted.size -1
-
   mktemp.tmpfile.deleted.is-directory --> stops-on-checking-the-directory-of-an-absent-file
 
   seq * --> stops-on-opening-with-a-wrong-mode
@@ -501,8 +384,6 @@
   mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
     "r+"
     f > [f]
-
-  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file
 
   tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
     @.

--- a/objects/file/deleted.eo
+++ b/objects/file/deleted.eo
@@ -1,0 +1,35 @@
+# Deletes the file `f` from the filesystem.
+# Returns the same file, unchanged, if it does not exist.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.62.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > deleted
+  f.exists.if > @
+    if.
+      removed.code.eq 0
+      f
+      T
+        "Cant delete the file '%s': %s".printf
+          * f.path removed.output
+    f
+  called. > removed
+    os.is-windows.if
+      win32 *1
+        f.is-directory.if "_rmdir" "_unlink"
+        f.path
+      posix *1
+        f.is-directory.if "rmdir" "unlink"
+        f.path
+
+  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+
+  ++> can-return-itself-after-deleting
+    temp.deleted.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting

--- a/objects/file/moved.eo
+++ b/objects/file/moved.eo
@@ -1,0 +1,39 @@
+# Moves the file `f` to `target` on the filesystem, returning the file
+# at its new location.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.62.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f target] > moved
+  if. > @
+    renamed.code.eq 0
+    file target
+    T
+      "Cant move the file '%s' to '%s': %s".printf
+        *
+          f.path
+          target
+          renamed.output
+  called. > renamed
+    os.is-windows.if
+      win32 *1
+        "rename"
+        f.path
+        target
+      posix *1
+        "rename"
+        f.path
+        target
+
+  ++> can-move-a-file
+    and. > @
+      exists.
+        temp.moved
+          "%s.dest".printf
+            * temp.path
+      temp.exists.not
+    mktemp.tmpfile > temp

--- a/objects/file/size.eo
+++ b/objects/file/size.eo
@@ -1,0 +1,32 @@
+# Size of the file `f` in bytes, or `cant-measure` if the file
+# does not exist.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.62.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f cant-measure] > size
+  if. > @
+    info.code.eq 0
+    info.output.size
+    cant-measure
+  called. > info
+    os.is-windows.if
+      win32 *1
+        "_stat64"
+        f.path
+      posix *1
+        "stat"
+        f.path
+
+  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
+    0
+
+  eq. ++> rejects-sizing-an-absent-file
+    -1
+    mktemp.tmpfile.deleted.size -1
+
+  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file

--- a/objects/file/touched.eo
+++ b/objects/file/touched.eo
@@ -1,0 +1,47 @@
+# Touches the file `f`, creating it if it does not exist yet.
+# Returns the same file, unchanged, if it already exists.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.62.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[f] > touched
+  f.exists.if > @
+    f
+    if.
+      descriptor.eq -1
+      T
+        "Cant touch the file '%s': %s".printf
+          * f.path created.output
+      seq *
+        code.
+          os.is-windows.if
+            win32 *1
+              "_close"
+              descriptor
+            posix *1
+              "close"
+              descriptor
+        f
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_creat"
+        f.path
+        win32.mode
+      posix *1
+        "creat"
+        f.path
+        posix.mode
+  created.code > descriptor
+
+  ++> can-return-itself-after-touching
+    temp.deleted.touched.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
+
+  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice

--- a/objects/getenv.eo
+++ b/objects/getenv.eo
@@ -5,7 +5,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i64/div.eo
+++ b/objects/i64/div.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package i64
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/i8.eo
+++ b/objects/i8.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/input.eo
+++ b/objects/input.eo
@@ -7,7 +7,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/input/as-bytes.eo
+++ b/objects/input/as-bytes.eo
@@ -11,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/copied.eo
+++ b/objects/input/copied.eo
@@ -14,7 +14,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/dead.eo
+++ b/objects/input/dead.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/length.eo
+++ b/objects/input/length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/tee.eo
+++ b/objects/input/tee.eo
@@ -18,7 +18,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -54,9 +54,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/map.eo
+++ b/objects/map.eo
@@ -14,7 +14,7 @@
 +alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/mktemp.eo
+++ b/objects/mktemp.eo
@@ -9,7 +9,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/ninf.eo
+++ b/objects/ninf.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -14,7 +14,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -3,9 +3,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/number/abs.eo
+++ b/objects/number/abs.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/arc-cosine.eo
+++ b/objects/number/arc-cosine.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/arc-sine.eo
+++ b/objects/number/arc-sine.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/as-i64.eo
+++ b/objects/number/as-i64.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/cosine.eo
+++ b/objects/number/cosine.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/degrees.eo
+++ b/objects/number/degrees.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/eq.eo
+++ b/objects/number/eq.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/exp.eo
+++ b/objects/number/exp.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/floor.eo
+++ b/objects/number/floor.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/gte.eo
+++ b/objects/number/gte.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/integral.eo
+++ b/objects/number/integral.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/is-finite.eo
+++ b/objects/number/is-finite.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/is-integer.eo
+++ b/objects/number/is-integer.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/is-nan.eo
+++ b/objects/number/is-nan.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/ln.eo
+++ b/objects/number/ln.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/lt.eo
+++ b/objects/number/lt.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/lte.eo
+++ b/objects/number/lte.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/minus.eo
+++ b/objects/number/minus.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/mod.eo
+++ b/objects/number/mod.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/neg.eo
+++ b/objects/number/neg.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/power.eo
+++ b/objects/number/power.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/radians.eo
+++ b/objects/number/radians.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/random.eo
+++ b/objects/number/random.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/number/sine.eo
+++ b/objects/number/sine.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/sqrt.eo
+++ b/objects/number/sqrt.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/os.eo
+++ b/objects/os.eo
@@ -3,9 +3,9 @@
 +alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
@@ -36,3 +36,10 @@
   or. ++> can-check-the-os-family
     os.is-windows.or os.is-macos
     os.is-linux
+
+  not. ++> cannot-belong-to-two-os-families-at-once
+    or.
+      or.
+        os.is-linux.and os.is-macos
+        os.is-linux.and os.is-windows
+      os.is-macos.and os.is-windows

--- a/objects/output.eo
+++ b/objects/output.eo
@@ -6,7 +6,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/output/dead.eo
+++ b/objects/output/dead.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package output
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/path.eo
+++ b/objects/path.eo
@@ -9,7 +9,7 @@
 +alias string.split
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/pi.eo
+++ b/objects/pi.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/pinf.eo
+++ b/objects/pinf.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/posix.eo
+++ b/objects/posix.eo
@@ -5,9 +5,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/range.eo
+++ b/objects/range.eo
@@ -23,7 +23,7 @@
 +alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/range/naturals.eo
+++ b/objects/range/naturals.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package range
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/recovered.eo
+++ b/objects/recovered.eo
@@ -5,9 +5,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -13,7 +13,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/set.eo
+++ b/objects/set.eo
@@ -3,7 +3,7 @@
 +alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/socket.eo
+++ b/objects/socket.eo
@@ -44,7 +44,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/stderr.eo
+++ b/objects/stderr.eo
@@ -14,7 +14,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/stdin.eo
+++ b/objects/stdin.eo
@@ -15,7 +15,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/stdout.eo
+++ b/objects/stdout.eo
@@ -10,7 +10,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -14,7 +14,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/string/as-ascii.eo
+++ b/objects/string/as-ascii.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-char.eo
+++ b/objects/string/as-char.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-decimal.eo
+++ b/objects/string/as-decimal.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-fixed.eo
+++ b/objects/string/as-fixed.eo
@@ -8,7 +8,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-hex.eo
+++ b/objects/string/as-hex.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-number.eo
+++ b/objects/string/as-number.eo
@@ -10,7 +10,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/at.eo
+++ b/objects/string/at.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/chained.eo
+++ b/objects/string/chained.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/contains-all.eo
+++ b/objects/string/contains-all.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/contains-any.eo
+++ b/objects/string/contains-any.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/contains.eo
+++ b/objects/string/contains.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/ends-with.eo
+++ b/objects/string/ends-with.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/index-of.eo
+++ b/objects/string/index-of.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/is-alpha.eo
+++ b/objects/string/is-alpha.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/is-alphanumeric.eo
+++ b/objects/string/is-alphanumeric.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/is-ascii.eo
+++ b/objects/string/is-ascii.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/is-digit.eo
+++ b/objects/string/is-digit.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/joined.eo
+++ b/objects/string/joined.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/last-index-of.eo
+++ b/objects/string/last-index-of.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/length.eo
+++ b/objects/string/length.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/low-cased.eo
+++ b/objects/string/low-cased.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/nsplit.eo
+++ b/objects/string/nsplit.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/printf.eo
+++ b/objects/string/printf.eo
@@ -12,9 +12,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/regex.eo
+++ b/objects/string/regex.eo
@@ -17,9 +17,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/string/repeated.eo
+++ b/objects/string/repeated.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/replaced.eo
+++ b/objects/string/replaced.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/scanf.eo
+++ b/objects/string/scanf.eo
@@ -11,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/slice.eo
+++ b/objects/string/slice.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/string/split.eo
+++ b/objects/string/split.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/starts-with.eo
+++ b/objects/string/starts-with.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/trimmed-left.eo
+++ b/objects/string/trimmed-left.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/trimmed-right.eo
+++ b/objects/string/trimmed-right.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/trimmed.eo
+++ b/objects/string/trimmed.eo
@@ -8,7 +8,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/up-cased.eo
+++ b/objects/string/up-cased.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -18,7 +18,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tuple/back.eo
+++ b/objects/tuple/back.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/concat.eo
+++ b/objects/tuple/concat.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -11,9 +11,7 @@
   reducedi > @
     passed
     list
-    with > [accum item index]
-      accum
-      item
+    accum.with item > [accum item index]
 
   ++> can-concat-two-lists
     and. > @

--- a/objects/tuple/contains.eo
+++ b/objects/tuple/contains.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/each.eo
+++ b/objects/tuple/each.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/eachi.eo
+++ b/objects/tuple/eachi.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/filtered.eo
+++ b/objects/tuple/filtered.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/filteredi.eo
+++ b/objects/tuple/filteredi.eo
@@ -8,7 +8,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/front.eo
+++ b/objects/tuple/front.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/index-of.eo
+++ b/objects/tuple/index-of.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/is-empty.eo
+++ b/objects/tuple/is-empty.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/last-index-of.eo
+++ b/objects/tuple/last-index-of.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/mapped.eo
+++ b/objects/tuple/mapped.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/mappedi.eo
+++ b/objects/tuple/mappedi.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/maximum.eo
+++ b/objects/tuple/maximum.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/minimum.eo
+++ b/objects/tuple/minimum.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/reduced.eo
+++ b/objects/tuple/reduced.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/reducedi.eo
+++ b/objects/tuple/reducedi.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/shifted.eo
+++ b/objects/tuple/shifted.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/slice.eo
+++ b/objects/tuple/slice.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/withi.eo
+++ b/objects/tuple/withi.eo
@@ -3,13 +3,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [list index item] > withi
   concat > @
-    with
+    with.
       front list index
       item
     back

--- a/objects/tuple/without.eo
+++ b/objects/tuple/without.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/withouti.eo
+++ b/objects/tuple/withouti.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u16.eo
+++ b/objects/u16.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/u32.eo
+++ b/objects/u32.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/u64.eo
+++ b/objects/u64.eo
@@ -6,7 +6,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/u64/div.eo
+++ b/objects/u64/div.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package u64
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u8.eo
+++ b/objects/u8.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/uri.eo
+++ b/objects/uri.eo
@@ -19,7 +19,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -24,7 +24,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/win32.eo
+++ b/objects/win32.eo
@@ -10,9 +10,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.62.1
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.62.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package


### PR DESCRIPTION
A new release `eo-0.62.1` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.