### PR TITLE
New release for eo-0.63.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.62.1</eo.version>
+    <eo.version>0.63.0</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bool.eo
+++ b/objects/bool.eo
@@ -7,24 +7,21 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint decorated-formation
-+unlint mandatory-package
 
 [if] > bool
   if > @
     01-
     00-
-  if > [x] > and
+  ^.if > [^ x] > and
     01-.eq x
     false
   if > not
     false
     true
-  if > [x] > or
+  ^.if > [^ x] > or
     true
     01-.eq x
 
@@ -50,6 +47,18 @@
       [args] > f
         2 > @
         1 > a
+
+  eq. ++> can-choose-the-left-branch-of-true
+    "yes"
+    true.if
+      "yes"
+      "no"
+
+  eq. ++> can-choose-the-right-branch-of-false
+    "no"
+    false.if
+      "yes"
+      "no"
 
   and. ++> can-compare-a-bool-to-a-string
     true.eq "\u0001"
@@ -82,9 +91,11 @@
 
   true.as-bool ++> can-convert-true-to-a-bool
 
+  true.or false ++> can-disjoin-true-with-false
+
   ++> can-extract-an-attribute-from-a-decoratee
     a.foo.eq 43 > @
-    return > [] > a
+    ^.return > [^] > a
       42.plus 1
     [foo] > return
 
@@ -101,6 +112,12 @@
       123
       42
     123
+
+  false.as-bytes.size.eq 1 ++> can-keep-the-size-of-false-at-one-byte
+
+  true.as-bytes.size.eq 1 ++> can-keep-the-size-of-true-at-one-byte
+
+  false.not ++> can-negate-false
 
   true.not.eq false ++> can-negate-true
 
@@ -193,7 +210,7 @@
                                                                                 blah38 (x.plus 1) > @
                                                                                 [x] > blah38
                                                                                   blah39 (x.plus 1) > @
-                                                                                  x > [x] > blah39
+                                                                                  I > blah39
 
   ++> can-take-a-parent-object
     eq. > @
@@ -201,15 +218,15 @@
       42
     [x] > a
       take > @
-      x > [] > take
+      ^.x > [^] > take
 
-  ++> can-take-a-parent-through-an-attribute
-    [] > @
-      [] > @
-        x.eq 42 > [] > @
-    42 > x
+  not. ++> can-tell-false-does-not-disjoin-with-itself
+    false.or false
+
+  not. ++> can-tell-true-is-not-false
+    true.eq false
 
   --> stops-on-applying-to-a-closed-object
     closed true > @
-    x > [x] > a
+    I > a
     a false > closed

--- a/objects/buffer.eo
+++ b/objects/buffer.eo
@@ -2,16 +2,15 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [buf] > buffer
   buf > @
-  buffer > [str] > with
+  buffer > [^ str] > with
     string
-      buf.as-bytes.concat str.as-bytes
+      ^.buf.as-bytes.concat str.as-bytes
 
   eq. ++> can-build-a-simple-string
     with.

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -1,8 +1,8 @@
 # Object `bytes` encapsulates a chain of bytes, providing the bitwise and
 # structural atoms every data object relies on. Objects like `number`, `string`,
 # and the integer types (`i16`, `i32`, `i64`) use `bytes` as their internal
-# representation, while conversions and derived operations live in the
-# `bytes` package (e.g. `bytes.as-number`, `bytes.xor`).
+# representation, while conversions and derived operations arrive from the
+# `bytes` package as attributes of this object (e.g. `01-02.as-number`).
 #
 # Usage examples:
 # ```
@@ -14,27 +14,34 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [@] > bytes
   [] > and /Q.bytes
+    ? > ^
     ? > b /Q.bytes
   [] > concat /Q.bytes
+    ? > ^
     ? > b
   [] > eq /Q.bool
+    ? > ^
     ? > b
   [] > not /Q.bytes
+    ? > ^
   [] > or /Q.bytes
+    ? > ^
     ? > b /Q.bytes
   [] > right /Q.bytes
+    ? > ^
     ? > x /Q.number
   [] > size /Q.number
+    ? > ^
   [] > slice /Q.bytes
+    ? > ^
     ? > start /Q.number
     ? > len /Q.number
     ? > cant-slice /{Q.string}
@@ -161,6 +168,20 @@
     -11.as-bytes.or 0.as-bytes
     C0-26-00-00-00-00-00-00
 
+  eq. ++> can-recover-from-a-slice-whose-start-plus-length-overflows
+    "recovered"
+    20-1F-EE-B5-90.slice
+      2000000000
+      2000000000
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-out-of-bounds-slice
+    "recovered"
+    20-1F-EE-B5-90.slice
+      3
+      10
+      "recovered" > [message]
+
   eq. ++> can-shift-right-an-even-negative
     -38.as-bytes.right 1
     60-21-80-00-00-00-00-00
@@ -200,20 +221,6 @@
   eq. ++> can-turn-bytes-into-a-string
     "你好, друг!"
     "你好, друг!"
-
-  eq. ++> rejects-a-slice-whose-start-plus-length-overflows
-    "recovered"
-    20-1F-EE-B5-90.slice
-      2000000000
-      2000000000
-      "recovered" > [message]
-
-  eq. ++> rejects-an-out-of-bounds-slice
-    "recovered"
-    20-1F-EE-B5-90.slice
-      3
-      10
-      "recovered" > [message]
 
   slice. --> stops-on-a-slice-offset-exceeding-the-int-range
     20-1F-EE-B5-90

--- a/objects/bytes/array.eo
+++ b/objects/bytes/array.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > array
+[^] > array
+  ^ > b
   size. >> len!
     b >> data!
-  if. > [tup index] >> slice-byte
+  if. > [^ tup index] >> slice-byte
     index.lt len
-    slice-byte
+    ^.slice-byte
       tup.with
-        b.slice index 1
+        ^.b.slice index 1
       as-number.
         index.plus 1
     tup
@@ -25,7 +26,7 @@
     0
 
   eq. ++> can-convert-bytes-to-an-array
-    array 20-1F-EE-B5-FF
+    20-1F-EE-B5-FF.array
     *
       20-
       1F-
@@ -34,9 +35,9 @@
       FF-
 
   eq. ++> can-convert-a-single-byte-to-an-array
-    array 1F-
+    1F-.array
     * 1F-
 
   eq. ++> can-convert-zero-bytes-to-an-array
-    array --
+    --.array
     *

--- a/objects/bytes/as-bool.eo
+++ b/objects/bytes/as-bool.eo
@@ -3,12 +3,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-bool
-  b.eq 01- > @
+[^] > as-bool
+  ^.eq 01- > @
 
   not. ++> can-convert-bytes-to-a-bool
     01-.as-bool.eq 00-.as-bool

--- a/objects/bytes/as-bytes.eo
+++ b/objects/bytes/as-bytes.eo
@@ -5,11 +5,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-bytes
-  b > @
+[^] > as-bytes
+  ^ > @
 
   20-1F-EE.as-bytes.eq 20-1F-EE ++> can-return-itself

--- a/objects/bytes/as-hex.eo
+++ b/objects/bytes/as-hex.eo
@@ -1,0 +1,73 @@
+# Writes the bytes `b` as uppercase hexadecimal pairs joined by a hyphen,
+# so that the two bytes `0x4A 0x65` become `4A-65`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > as-hex
+  ^ > b
+  if. > [h] >> hex-digit
+    h.lt 10
+    as-char.
+      h.plus 48
+    as-char.
+      h.plus 55
+  [^ index acc] >> rec-hex
+    if. > @
+      index.eq ^.b.size
+      acc
+      ^.rec-hex
+        as-number.
+          index.plus 1
+        next
+    as-ascii. > bval
+      string
+        ^.b.slice index 1
+    if. > next!
+      index.eq 0
+      pair
+      concat.
+        acc.concat "-".as-bytes
+        pair
+    concat. > pair
+      hex-digit
+        floor.
+          bval.div 16
+      hex-digit
+        bval.minus
+          times.
+            floor.
+              bval.div 16
+            16
+  | > @
+    0
+    --
+
+  eq. ++> can-write-a-single-byte
+    "41"
+    string "A".as-bytes.as-hex
+
+  eq. ++> can-join-bytes-with-hyphens
+    "4A-65-66-66"
+    string "Jeff".as-bytes.as-hex
+
+  eq. ++> can-write-letter-nibbles
+    "00-00-00-00-00-00-00-FF"
+    string 255.as-i64.as-bytes.as-hex
+
+  eq. ++> can-write-the-bytes-of-a-number
+    "40-45-00-00-00-00-00-00"
+    string 42.as-bytes.as-hex
+
+  eq. ++> can-write-empty-bytes
+    ""
+    string --.as-hex
+
+  eq. ++> can-write-a-64-byte-input-promptly
+    "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00"
+    string
+      00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00.as-hex

--- a/objects/bytes/as-i16.eo
+++ b/objects/bytes/as-i16.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i16
+[^ cant-convert] > as-i16
   if. > @
     b.size.eq 2
     i16 b
     cant-convert
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * b
+  ^ > b
 
   00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
 
-  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size
+  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size-when-converting-to-i16

--- a/objects/bytes/as-i32.eo
+++ b/objects/bytes/as-i32.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i32
+[^ cant-convert] > as-i32
   if. > @
     b.size.eq 4
     i32 b
     cant-convert
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
 
-  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size
+  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size-when-converting-to-i32

--- a/objects/bytes/as-i64.eo
+++ b/objects/bytes/as-i64.eo
@@ -5,17 +5,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i64
+[^ cant-convert] > as-i64
   if. > @
     b.size.eq 8
     i64 b
     cant-convert
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> can-convert-bytes-to-i64
 
@@ -23,12 +24,12 @@
     00-00-00-00-00-00-00-33.as-i64.as-bytes
     00-00-00-00-00-00-00-33
 
-  not. ++> cannot-match-the-bytes-of-the-same-number
-    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
-
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-i64
     "recovered"
     01-01-01-01.as-i64
       "recovered" > [message]
 
-  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size
+  not. ++> can-tell-it-does-not-match-the-bytes-of-the-same-number
+    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+
+  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size-when-converting-to-i64

--- a/objects/bytes/as-i8.eo
+++ b/objects/bytes/as-i8.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i8
+[^ cant-convert] > as-i8
   if. > @
     b.size.eq 1
     i8 b
     cant-convert
       "Can't convert non 1 length bytes to i8, bytes are %x".printf
         * b
+  ^ > b
 
   2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
 
-  01-01.as-i8 --> stops-on-bytes-of-wrong-size
+  01-01.as-i8 --> stops-on-bytes-of-wrong-size-when-converting-to-i8

--- a/objects/bytes/as-input.eo
+++ b/objects/bytes/as-input.eo
@@ -24,37 +24,44 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-input
-  [size] > read
+[^] > as-input
+  ^ > b
+  [^ size] > read
     @. > @
       read.
-        input-block b --
+        input-block ^.b --
         size
-    [data buffer] > input-block
+    [^ data buffer] > input-block
       buffer > @
-      [size] > read
+      [^ size] > read
         if. > @
-          available.eq 0
-          input-block -- --
-          input-block
-            as-bytes.
-              data.slice
-                if. >> next!
-                  gt.
-                    number available
-                    size >> requested!
-                  requested
-                  available
-                minus.
-                  number
-                    data.size >> available!
-                  number next
-            as-bytes.
-              data.slice 0 next
+          size.is-finite.not.or
+            size.is-integer.not.or
+              0.gt size
+          T
+            "Can't read a non-integer, non-finite, or negative byte count"
+          if.
+            available.eq 0
+            ^.^.input-block -- --
+            ^.^.input-block
+              as-bytes.
+                ^.data.slice
+                  if. >> next!
+                    gt.
+                      number available
+                      size >> requested!
+                    requested
+                    available
+                  minus.
+                    number
+                      ^.data.size >> available!
+                    number next
+              as-bytes.
+                ^.data.slice 0 next
 
   ++> can-make-an-input-from-bytes-and-read-it
     and. > @
@@ -66,8 +73,34 @@
       eq.
         i3.read 2
         --
-    read. > i1
-      as-input 01-02-03-04-05-06-07-08-F5-F6
-      4
+    01-02-03-04-05-06-07-08-F5-F6.as-input.read 4 > i1
     i1.read 4 > i2
     i2.read 4 > i3
+
+  01-02-03.as-input.read 3.5 --> stops-on-a-fractional-byte-count-above-available
+
+  01-02-03.as-input.read 0.5 --> stops-on-a-fractional-byte-count-below-available
+
+  read. --> stops-on-a-fractional-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    1.5
+
+  01-02-03.as-input.read nan --> stops-on-a-nan-byte-count
+
+  read. --> stops-on-a-nan-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    nan
+
+  read. --> stops-on-a-negative-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    -5
+
+  01-02-03.as-input.read pinf --> stops-on-an-infinite-byte-count
+
+  read. --> stops-on-an-infinite-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    pinf

--- a/objects/bytes/as-number.eo
+++ b/objects/bytes/as-number.eo
@@ -5,11 +5,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-number
+[^ cant-convert] > as-number
   if. > @
     b.size.eq 8
     if.
@@ -26,13 +26,15 @@
     cant-convert
       "Can't convert non 8 length bytes to a number, bytes are %x".printf
         * b
+  ^ > b
 
-  is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
-    FF-F8-00-00-00-00-00-00.as-number
-
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-a-number
     "recovered"
     01-01-01-01.as-number
       "recovered" > [message]
 
-  01-01-01-01.as-number --> stops-on-bytes-of-wrong-size
+  is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
+    FF-F8-00-00-00-00-00-00.as-number
+
+  as-number. --> stops-on-bytes-of-wrong-size-when-converting-to-a-number
+    01-01-01-01

--- a/objects/bytes/as-u16.eo
+++ b/objects/bytes/as-u16.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u16
+[^ cant-convert] > as-u16
   if. > @
     b.size.eq 2
     u16 b
     cant-convert
       "Can't convert non 2 length bytes to u16, bytes are %x".printf
         * b
+  ^ > b
 
   00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
 
-  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size
+  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size-when-converting-to-u16

--- a/objects/bytes/as-u32.eo
+++ b/objects/bytes/as-u32.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u32
+[^ cant-convert] > as-u32
   if. > @
     b.size.eq 4
     u32 b
     cant-convert
       "Can't convert non 4 length bytes to u32, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
 
-  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size
+  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size-when-converting-to-u32

--- a/objects/bytes/as-u64.eo
+++ b/objects/bytes/as-u64.eo
@@ -5,25 +5,26 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u64
+[^ cant-convert] > as-u64
   if. > @
     b.size.eq 8
     u64 b
     cant-convert
       "Can't convert non 8 length bytes to u64, bytes are %x".printf
         * b
+  ^ > b
 
   eq. ++> can-convert-bytes-to-u64-and-back
     00-00-00-00-00-00-00-33.as-u64.as-bytes
     00-00-00-00-00-00-00-33
 
-  eq. ++> rejects-bytes-of-wrong-size
+  eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-u64
     "recovered"
     01-01-01-01.as-u64
       "recovered" > [message]
 
-  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size
+  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size-when-converting-to-u64

--- a/objects/bytes/as-u8.eo
+++ b/objects/bytes/as-u8.eo
@@ -5,18 +5,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u8
+[^ cant-convert] > as-u8
   if. > @
     b.size.eq 1
     u8 b
     cant-convert
       "Can't convert non 1 length bytes to u8, bytes are %x".printf
         * b
+  ^ > b
 
   2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
 
-  01-01.as-u8 --> stops-on-bytes-of-wrong-size
+  01-01.as-u8 --> stops-on-bytes-of-wrong-size-when-converting-to-u8

--- a/objects/bytes/hash.eo
+++ b/objects/bytes/hash.eo
@@ -7,17 +7,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > hash
-  input.as-bytes >> b!
-  [acc index] >> rec-hash-code
+[^] > hash
+  ^.as-bytes >> b!
+  [^ acc index] >> rec-hash-code
     if. > @
       index.eq b.size!
       acc.as-number
-      rec-hash-code
+      ^.rec-hash-code
         plus.
           31.as-i64.times acc
           as-i64.
@@ -30,115 +30,84 @@
     0
 
   and. ++> can-hash-a-bool-into-a-number
-    eq.
-      size.
-        as-bytes.
-          hash true
-      8
-    eq.
-      size.
-        as-bytes.
-          hash false
-      8
+    true.hash.as-bytes.size.eq 8
+    false.hash.as-bytes.size.eq 8
 
   ++> can-hash-an-integer-into-an-integer
     1.eq > @
       div.
         number
-          hash 42 >> inthash!
+          42.hash >> inthash!
         number inthash
 
   ++> can-hash-equal-numbers-alike
-    eq. > @
-      hash num
-      hash num
+    num.hash.eq num.hash > @
     123456789012345680 > num
 
-  eq. ++> can-hash-equal-integers-alike
-    hash 42
-    hash 42
+  42.hash.eq 42.hash ++> can-hash-equal-integers-alike
 
   not. ++> can-hash-different-integers-apart
-    eq.
-      hash 42
-      hash 24
+    42.hash.eq 24.hash
 
   not. ++> can-hash-integers-of-different-signs-apart
-    eq.
-      hash 42
-      hash -42
+    42.hash.eq -42.hash
 
   ++> can-hash-a-string-into-an-integer
     1.eq > @
       div.
         number
-          hash "hello" >> strhash!
+          "hello".hash >> strhash!
         number strhash
 
-  eq. ++> can-hash-equal-strings-alike
-    hash "Hello"
-    hash "Hello"
+  "Hello".hash.eq "Hello".hash ++> can-hash-equal-strings-alike
 
   not. ++> can-hash-strings-of-the-same-length-apart
-    eq.
-      hash "one"
-      hash "two"
+    "one".hash.eq "two".hash
 
   not. ++> can-hash-different-strings-apart
-    eq.
-      hash "hello"
-      hash "bye!!!"
+    "hello".hash.eq "bye!!!".hash
 
   ++> can-hash-an-abstract-object-into-an-integer
     1.eq > @
       div.
         number
-          hash >> objhash!
+          hash. >> objhash!
             obj 42
         number objhash
-    x > [x] > obj
+    I > obj
 
   ++> can-hash-equal-abstract-objects-alike
-    eq. > @
-      hash value
-      hash value
-    x > [x] > obj
+    value.hash.eq value.hash > @
+    I > obj
     obj 42 > value
 
   ++> can-hash-different-abstract-objects-apart
     not. > @
       eq.
-        hash
+        hash.
           obj 42
-        hash
+        hash.
           obj "42"
-    x > [x] > obj
+    I > obj
 
   ++> can-hash-a-float-into-an-integer
     1.eq > @
       div.
         number
-          hash 42.42 >> flthash!
+          42.42.hash >> flthash!
         number flthash
 
   ++> can-hash-equal-floats-alike
-    eq. > @
-      hash emergency
-      hash emergency
+    emergency.hash.eq emergency.hash > @
     0.911 > emergency
 
   ++> can-hash-equal-big-values-alike
-    eq. > @
-      hash
+    bigval.hash.eq > @
+      hash.
         4.242e43 >> bigval!
-      hash bigval
 
   not. ++> can-hash-different-floats-apart
-    eq.
-      hash 3.14
-      hash 2.72
+    3.14.hash.eq 2.72.hash
 
   not. ++> can-hash-floats-of-different-signs-apart
-    eq.
-      hash 3.22
-      hash -3.22
+    3.22.hash.eq -3.22.hash

--- a/objects/bytes/left.eo
+++ b/objects/bytes/left.eo
@@ -4,12 +4,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b x] > left
-  b.right x.neg > @
+[^ x] > left
+  ^.right x.neg > @
 
   eq. ++> can-shift-left-an-even-negative
     FF-FF-FF-FF-FF-FF-FF-EE.left 2

--- a/objects/bytes/xor.eo
+++ b/objects/bytes/xor.eo
@@ -4,14 +4,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b x] > xor
+[^ x] > xor
   or. > @
     b.and x.not
     b.not.and x
+  ^ > b
 
   eq. ++> can-xor-negative-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00

--- a/objects/chunk.eo
+++ b/objects/chunk.eo
@@ -21,41 +21,60 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [id] > chunk
   get > @
-  write > [source target length] > copy
-    target
-    read
-      source
-      length
+  [^ source target length] > copy
+    seq * > @
+      ^.read source length >> data!
+      if.
+        gt.
+          target.plus length
+          ^.size
+        write.
+          ^.resized
+            target.plus length
+          target
+          data
+        ^.write target data
   read > get
     0
     size
-  if. > [object] > put
+  if. > [^ object] > put
     and.
-      size.gt 0
-      object.size.gt size
+      ^.size.gt 0
+      object.size.gt ^.size
     T
       "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
-        * object.size size
-    seq *
-      write 0 object
-      get
+        * object.size ^.size
+    if.
+      ^.size.eq 0
+      seq *
+        write.
+          ^.resized object.size
+          0
+          object
+        ^.get
+      seq *
+        ^.write 0 object
+        ^.get
   [] > read /Q.bytes
+    ? > ^
     ? > offset /Q.number
     ? > length /Q.number
     ? > cant-read /{Q.string}
   [] > resized /Q.chunk
+    ? > ^
     ? > capacity /Q.number
   [] > size /Q.number
+    ? > ^
   [] > write /Q.bool
+    ? > ^
     ? > offset /Q.number
     ? > data
 

--- a/objects/chunk/to-output.eo
+++ b/objects/chunk/to-output.eo
@@ -1,8 +1,5 @@
-# Makes an output from a `chunk` of memory. Here `allocated` is a `chunk`.
-#
-# Because this object lives in the `chunk` package, it is available on any
-# chunk as `chunk.to-output` (package extension), so there is no need to
-# reference it explicitly:
+# Makes an output from a `chunk` of memory. It is a method of `chunk`, and
+# `allocated` is the chunk it is taken off:
 #
 # ```
 # malloc.of > result
@@ -18,19 +15,29 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package chunk
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[allocated] > to-output
-  [buffer] > write
+[^] > to-output
+  ^ > allocated
+  [^ buffer] > write
     write. > @
-      [offset] >> output-block
+      [^ offset] >> output-block
         true > @
-        seq * > [buffer] > write
-          allocated.write offset buffer
-          output-block
-            offset.plus buffer.size
+        seq * > [^ buffer] > write
+          if.
+            gt.
+              ^.offset.plus buffer.size
+              ^.^.^.allocated.size
+            write.
+              ^.^.^.allocated.resized
+                ^.offset.plus buffer.size
+              ^.offset
+              buffer
+            ^.^.^.allocated.write ^.offset buffer
+          ^.^.output-block
+            ^.offset.plus buffer.size
       | 0
       buffer
 
@@ -40,9 +47,7 @@
       seq * > [mem]
         write.
           write.
-            write.
-              to-output mem
-              01-02-03
+            mem.to-output.write 01-02-03
             04-05-06-07
           08-09-A0
         mem
@@ -60,8 +65,6 @@
     malloc.of
       2
       seq * > [mem]
-        write.
-          to-output mem
-          01-02-03
+        mem.to-output.write 01-02-03
         mem
     01-02-03

--- a/objects/clock.eo
+++ b/objects/clock.eo
@@ -1,13 +1,12 @@
 # Wall-clock time source backed by the operating system.
-# Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime32_s` on Windows.
+# Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime64_s` on Windows.
 # Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > clock
   as-i64. > @
@@ -17,7 +16,7 @@
         millitm.
           output. >> timeb
             win32
-              "_ftime32_s"
+              "_ftime64_s"
               *
       plus.
         times.
@@ -30,4 +29,75 @@
         as-number.
           timeval.micros.as-i64.div 1000.as-i64
 
+  clock.as-bytes.size.eq 8 ++> can-be-eight-bytes-long
+
+  ++> can-be-greater-than-or-equal-to-itself
+    a.gte a > @
+    clock > a
+
+  ++> can-be-less-than-or-equal-to-itself
+    a.lte a > @
+    clock > a
+
+  ++> can-differ-from-a-value-offset-by-one
+    not. > @
+      a.eq
+        a.plus 1.as-i64
+    clock > a
+
+  ++> can-double-in-value-when-multiplied-by-two
+    gt. > @
+      a.times 2.as-i64
+      a
+    clock > a
+
+  ++> can-equal-itself-when-read-once
+    a.eq a > @
+    clock > a
+
+  clock.gt 4294967295.as-i64 ++> can-exceed-a-32-bit-integer-range
+
+  clock.gt 1000000000000.as-i64 ++> can-exceed-the-year-2001-epoch
+
+  ++> can-grow-when-a-positive-offset-is-added
+    gt. > @
+      a.plus 1000.as-i64
+      a
+    clock > a
+
   clock.gt 0 ++> can-read-positive-millis
+
+  gte. ++> can-remain-ahead-when-offset-by-a-large-margin
+    clock.plus 100000.as-i64
+    clock
+
+  ++> can-return-to-itself-after-adding-and-subtracting-the-same-offset
+    eq. > @
+      minus.
+        a.plus 500.as-i64
+        500.as-i64
+      a
+    clock > a
+
+  ++> can-round-trip-through-bytes-and-back
+    a.as-bytes.as-i64.eq a > @
+    clock > a
+
+  ++> can-shrink-when-a-positive-offset-is-subtracted
+    lt. > @
+      a.minus 1000.as-i64
+      a
+    clock > a
+
+  clock.lt 4102444800000.as-i64 ++> can-stay-below-the-year-2100-epoch
+
+  ++> can-stay-close-on-successive-reads
+    and. > @
+      gte.
+        a.plus 60000.as-i64
+        b
+      gte.
+        b.plus 60000.as-i64
+        a
+    clock > a
+    clock > b

--- a/objects/console.eo
+++ b/objects/console.eo
@@ -58,10 +58,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > console
   os.is-windows.if > @
@@ -69,62 +68,115 @@
       [size] > read
         @. > @
           read.
-            [buffer] >> input-block
+            [^ buffer] >> input-block
               buffer > @
-              [size] > read
+              [^ size] > read
                 seq * > @
-                  output. >> chunk!
-                    win32 *1
-                      "_read"
-                      win32.stdin
-                      size
-                  input-block chunk
+                  if. >> chunk!
+                    received.code.eq -1
+                    T
+                      "Failed to read from standard input"
+                    received.output
+                  received
+                  ^.^.input-block chunk
+                called. > received
+                  win32 *1
+                    "_read"
+                    win32.stdin
+                    size
             | --
             size
       [buffer] > write
         @. > @
           write.
-            [] >> output-block
+            [^] >> output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [^ buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard output"
+                    ^.^.output-block
+                  code
+                  remainder
+                code. > code
                   win32 *1
                     "_write"
                     win32.stdout
                     buffer
                     buffer.size
-                output-block
+                if. > remainder
+                  code.lt buffer.size
+                  ^.^.output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  ^.^.output-block
             buffer
     [] >>
       [size] > read
         @. > @
           read.
-            [buffer] >> input-block
+            [^ buffer] >> input-block
               buffer > @
-              [size] > read
+              [^ size] > read
                 seq * > @
-                  output. >> chunk!
-                    posix *1
-                      "read"
-                      posix.stdin
-                      size
-                  input-block chunk
+                  if. >> chunk!
+                    received.code.eq -1
+                    T
+                      "Failed to read from standard input"
+                    received.output
+                  received
+                  ^.^.input-block chunk
+                called. > received
+                  posix *1
+                    "read"
+                    posix.stdin
+                    size
             | --
             size
       [buffer] > write
         @. > @
           write.
-            [] >> output-block
+            [^] >> output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [^ buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard output"
+                    ^.^.output-block
+                  code
+                  remainder
+                code. > code
                   posix *1
                     "write"
                     posix.stdout
                     buffer
                     buffer.size
-                output-block
+                if. > remainder
+                  code.lt buffer.size
+                  ^.^.output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  ^.^.output-block
             buffer
+
+  ++> can-chain-writes-across-output-blocks
+    seq * > @
+      o1
+      o1.write
+        "part two.\n"
+    console.write > o1
+      "part one, "
+
+  console.write ++> can-write-a-non-ascii-string-to-the-console
+    "héllo, wörld! 日本語\n"
+
+  console.write "" ++> can-write-an-empty-string-to-the-console
+
+  console.write 48-65-6C-6C-6F-0A ++> can-write-raw-bytes-to-the-console
 
   console.write ++> can-write-to-the-console
     "Hello, console-test!\n"
+
+  console --> cannot-dataize-console-directly

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -31,14 +31,14 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > dataized /Q.bytes
+  ? > ^
   ? > target
 
   ++> can-avoid-recalculation
@@ -52,8 +52,8 @@
             cached.as-bytes
             cached.as-bool
             m
-          m.put > [] > func
-            m.as-number.plus 1
+          ^.m.put > [^] > func
+            ^.m.as-number.plus 1
       1
 
   ++> can-behave-as-a-const-when-dataized-as-bytes
@@ -71,3 +71,45 @@
         true
         m.put
           m.as-number.plus 1
+
+  ++> can-dataize-a-nested-attribute
+    eq. > @
+      as-number.
+        dataized foo
+      5
+    [] > foo
+      inner.five > @
+      [] > inner
+        5 > five
+
+  ++> can-dataize-a-number-to-the-same-bytes-as-as-bytes
+    eq. > @
+      42 >>!
+      42.as-bytes
+
+  eq. ++> can-dataize-a-plain-number
+    as-number.
+      dataized 42
+    42
+
+  ++> can-dataize-a-string
+    eq. > @
+      "hello" >>!
+      "hello".as-bytes
+
+  ++> can-dataize-a-target-that-is-already-bytes
+    eq. > @
+      42.as-bytes >>!
+      42.as-bytes
+
+  not. ++> can-dataize-false-as-bool
+    as-bool.
+      dataized false
+
+  ++> can-dataize-the-same-target-consistently
+    eq. > @
+      7 >>!
+      7 >>!
+
+  as-bool. ++> can-dataize-true-as-bool
+    dataized true

--- a/objects/directory.eo
+++ b/objects/directory.eo
@@ -1,28 +1,483 @@
 # Directory in the file system.
 # Apparently every directory is a file.
+#
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [file] > directory
   file > @
-  true > is-directory
-  [] > tmpfile
+  [] > listed /Q.tuple
+    ? > ^
+  [dir time process random] > retried
+    [^ index] >> attempted
+      if. > @
+        descriptor.eq -1
+        if.
+          errno.eq
+            os.is-windows.if win32.eexist posix.eexist
+          ^.attempted
+            index.plus 1
+          T
+            "Can't create a unique file in %s, OS error %d".printf
+              * ^.dir errno
+        seq *
+          ^.closed descriptor
+          path
+      ^.opened path > descriptor!
+      code. > errno
+        os.is-windows.if
+          win32
+            "_errno"
+            *
+          posix
+            "errno"
+            *
+      ^.candidate index > path!
+    | 0 > @
+    [^ index] > candidate
+      path.separator.joined > @
+        * ^.dir name
+      "%d-%d-%d-%f".printf > name!
+        *
+          ^.time
+          ^.process
+          index
+          ^.random
+    code. > [descriptor] > closed
+      os.is-windows.if
+        win32 *1
+          "_close"
+          descriptor
+        posix *1
+          "close"
+          descriptor
+    code. > [name] > opened
+      os.is-windows.if
+        win32 *1
+          "_open"
+          name
+          plus.
+            win32.rdonly.plus win32.creat
+            win32.exclusive
+          win32.mode
+        posix *1
+          "open"
+          name
+          plus.
+            posix.rdonly.plus posix.creat
+            posix.exclusive
+          posix.private
+  [^] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
       T
         "Directory %s does not exist, can't create temporary file".printf
-          * file
-    [] > touch /Q.string
-  [] > walk /Q.tuple
-    ? > glob /Q.string
+          * ^.file
+    ^.^.retried > [^] > touch
+      ^.^.path
+      clock.as-number
+      code.
+        os.is-windows.if
+          win32
+            "_getpid"
+            *
+          posix
+            "getpid"
+            *
+      clock.as-number.random
+  [^ glob] > walk
+    [^ accum prefix dir] >> walked
+      [^ rest] >> stepped
+        if. > @
+          rest.length.eq 0
+          if.
+            ^.prefix.length.eq 0
+            ^.accum
+            picked ^.accum ^.prefix
+          if.
+            and.
+              entry.is-directory false
+              not.
+                entry.is-symlink false
+            ^.^.walked earlier sub child.as-dir
+            picked earlier sub
+        ^.dir.as-path.resolved name > child
+        ^.stepped rest.tail > earlier
+        child.as-file > entry
+        rest.head > name
+        if. > sub
+          ^.prefix.length.eq 0
+          name
+          path.separator.joined
+            * ^.prefix name
+      | dir.listed > @
+    | > @
+      *
+      ""
+      ^
+    if. > [^ accum rel] >> picked
+      matched rel
+      accum.with
+        Q.file (base.resolved rel).as-bytes
+      accum
+    ^.as-path >> base
+    if. > [char] >> escaped
+      ".+()|^$[]\\".contains char
+      "".joined
+        * "\\" char
+      char
+    [^ text] >> matched
+      as-bool. > @
+        exists.
+          next.
+            match.
+              compile.
+                regex.
+                  string
+                    as-bytes.
+                      "".joined >>
+                        *
+                          "/^"
+                          translated 0 "" false false
+                          "$/"
+                T > [^ message] >>
+                  "Can't parse '%s' as a glob pattern, %s".printf
+                    * ^.glob message
+              text
+    "".joined >> single
+      *
+        "[^"
+        escaped path.separator >> literal
+        "]"
+    if. > [char] >> classified
+      "\\[&".contains char
+      "".joined
+        * "\\" char
+      char
+    if. > [^ from] >> closes
+      from.gte ^.glob.length
+      false
+      if.
+        eq.
+          ^.glob.at
+            from
+            "" > [absent]
+          "]"
+        true
+        ^.closes
+          from.plus 1
+    [^ index acc braced classed] >> translated
+      if. > @
+        index.gte ^.glob.length
+        acc
+        ^.translated
+          index.plus advance
+          "".joined
+            * acc token
+          classed.if
+            braced
+            if.
+              char.eq "{"
+              true
+              if.
+                char.eq "}"
+                false
+                braced
+          within
+      slashed.if > advance
+        3
+        if.
+          double.or negated
+          2
+          1
+      if. > alternated
+        char.eq "{"
+        "("
+        if.
+          braced.and
+            char.eq "}"
+          ")"
+          if.
+            braced.and
+              char.eq ","
+            "|"
+            escaped char
+      ^.glob.at index > char
+      classed.not.and > double
+        and.
+          char.eq "*"
+          eq.
+            ^.glob.at
+              index.plus 1
+              "" > [message]
+            "*"
+      opening.and > negated
+        eq.
+          ^.glob.at
+            index.plus 1
+            "" > [missing]
+          "!"
+      classed.not.and > opening
+        and.
+          char.eq "["
+          closes
+            index.plus 1
+      double.and > slashed
+        eq.
+          ^.glob.at
+            index.plus 2
+            "" > [space]
+          "/"
+      classed.if > token
+        if.
+          char.eq "]"
+          "]"
+          classified char
+        opening.if
+          negated.if "[^" "["
+          slashed.if
+            "".joined
+              * "(?:.*" literal ")?"
+            double.if
+              ".*"
+              if.
+                char.eq "*"
+                "".joined
+                  * single "*"
+                if.
+                  char.eq "?"
+                  single
+                  if.
+                    char.eq "/"
+                    literal
+                    alternated
+      opening.if > within
+        true
+        if.
+          classed.and
+            char.eq "]"
+          false
+          classed
+
+  ++> can-create-a-regular-tmpfile
+    seq * > @
+      regular
+      temp.deleted
+      regular
+    temp.is-directory.not > regular!
+    mktemp.tmpfile > temp
+
+  ++> can-create-a-tmpfile-only-its-owner-can-read
+    seq * > @
+      owned
+      temp.deleted
+      owned
+    called. > info
+      posix *1
+        "stat"
+        temp.path
+    os.is-windows.or > owned!
+      info.output.mode.eq 33152
+    mktemp.tmpfile > temp
+
+  ++> can-create-an-empty-tmpfile
+    if. > @
+      eq.
+        temp.size -1
+        0
+      seq *
+        temp.deleted
+        true
+      seq *
+        temp.deleted
+        false
+    mktemp.tmpfile > temp
+
+  ++> can-create-unique-tmpfile-paths
+    seq * > @
+      first.exists.and second.exists
+      first.deleted
+      second.deleted
+      valid
+    mktemp.tmpfile > first
+    mktemp.tmpfile > second
+    not. > valid!
+      first.path.eq second.path
+
+  ++> can-delete-a-created-tmpfile
+    seq * > @
+      existed
+      deleted
+      and.
+        existed.and
+          deleted.path.eq temp.path
+        deleted.exists.not
+    temp.deleted > deleted
+    temp.exists > existed
+    mktemp.tmpfile > temp
+
+  ++> can-delete-a-tmpfile-without-orphans
+    seq * > @
+      temp.deleted
+      temp.exists.not
+      next.exists.not
+      parent.deleted
+      true
+    path.separator.joined > candidate
+      *
+        parent.path
+        "%d-%d-%d-%f".printf
+          *
+            42
+            8
+            1
+            0.5
+    parent.retried > created
+      parent.path
+      42
+      8
+      0.5
+    Q.file candidate.as-bytes > next
+    mktemp.tmpfile.deleted.as-path.as-dir.made > parent
+    Q.file created.as-bytes > temp
+
+  ++> can-list-only-the-direct-children-of-a-directory
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "плюшка.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/deep.txt"
+      eq.
+        ",".joined d.as-dir.listed
+        "sub,плюшка.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  is-directory. ++> can-recover-from-checking-an-absent-directory
+    directory mktemp.tmpfile.deleted
+    true
+
+  ++> can-retry-tmpfile-creation-after-a-collision
+    seq * > @
+      collision.touched
+      valid
+      actual.deleted
+      collision.deleted
+      parent.deleted
+      valid
+    Q.file created.as-bytes > actual
+    Q.file occupied.as-bytes > collision
+    parent.retried > created
+      parent.path
+      42
+      7
+      0.5
+    path.separator.joined > expected
+      *
+        parent.path
+        "%d-%d-%d-%f".printf
+          *
+            42
+            7
+            1
+            0.5
+    path.separator.joined > occupied
+      *
+        parent.path
+        "%d-%d-%d-%f".printf
+          *
+            42
+            7
+            0
+            0.5
+    mktemp.tmpfile.deleted.as-path.as-dir.made > parent
+    created.as-bytes.eq expected.as-bytes > valid!
+
+  ++> can-tell-that-a-deleted-directory-is-no-longer-a-directory
+    not. > @
+      d.deleted.is-directory false
+    made. > d
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "gone"
+
+  is-directory. ++> can-tell-that-a-directory-is-a-directory
+    directory
+      Q.file "."
+    false
+
+  not. ++> can-tell-that-a-regular-file-is-not-a-directory
+    is-directory.
+      directory mktemp.tmpfile
+      true
+
+  ++> can-walk-a-directory-before-its-children
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/b.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "**b*"
+        ",".joined
+          *
+            d.resolved "sub"
+            d.resolved "sub/b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-an-empty-directory
+    eq. > @
+      length.
+        d.as-dir.walk "*.txt"
+      0
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-an-empty-directory-with-a-glob-matching-an-empty-path
+    eq. > @
+      length.
+        d.as-dir.walk "*"
+      0
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-past-a-symbolic-link-to-its-own-parent
+    os.is-windows.or > @
+      seq *
+        touched. (d.resolved "щи.txt").as-file
+        code.
+          posix *1
+            "symlink"
+            d
+            d.resolved "ссылка"
+        eq.
+          length.
+            d.as-dir.walk "**"
+          2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
 
   ++> can-walk-recursively
     seq * > @
@@ -46,6 +501,212 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> can-walk-recursively-across-nested-directories
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "**/*.txt"
+        ",".joined
+          *
+            d.resolved "foo/bar/test.txt"
+            d.resolved "x/y/z/a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-recursively-including-direct-children
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "root.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/nested.txt"
+      eq.
+        length.
+          d.as-dir.walk "**/*.txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-recursively-without-including-the-walked-directory
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**"
+        7
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-comma-outside-a-glob-brace-group
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a,b.txt"
+      touched.
+        as-file.
+          d.resolved "ab.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "a,b.txt"
+        d.resolved "a,b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-double-star-immediately-before-a-suffix
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/deep.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**.txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-brace-group
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "привет.txt"
+      touched.
+        as-file.
+          d.resolved "мир.log"
+      touched.
+        as-file.
+          d.resolved "c.md"
+      eq.
+        length.
+          d.as-dir.walk "{привет.txt,мир.log}"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      touched.
+        as-file.
+          d.resolved "c.txt"
+      eq.
+        length.
+          d.as-dir.walk "[ab].txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-containing-a-regex-special-character
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a+b.txt"
+      touched.
+        as-file.
+          d.resolved "ab.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "a+b.txt"
+        d.resolved "a+b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-question-mark
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "ab.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "?.txt"
+        d.resolved "a.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-literal-path-separator-in-the-glob
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/b.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "sub/b.txt"
+        d.resolved "sub/b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-negated-glob-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "[!a].txt"
+        d.resolved "b.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   ++> can-walk-with-a-plain-glob-matching-direct-children-only
     seq * > @
       touched.
@@ -58,19 +719,103 @@
         as-file.
           d.resolved "sub/b.txt"
       eq.
-        length.
+        ",".joined
           d.as-dir.walk "*.txt"
-        1
+        d.resolved "a.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-star-inside-a-glob-character-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "*.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "[*].txt"
+        d.resolved "*.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-an-escaped-character-inside-a-glob-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "&.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "[&].txt"
+        d.resolved "&.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-an-unmatched-glob-bracket
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "[.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "[.txt"
+        d.resolved "[.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-without-including-the-walked-directory
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        length.
+          d.as-dir.walk "*"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  --> stops-on-a-permanent-open-failure
+    parent.retried > @
+      parent.path
+      42
+      9
+      0.5
+    mktemp.tmpfile.deleted.as-path.as-dir > parent
+
+  tmpfile. --> stops-on-a-tmpfile-in-an-absent-directory
+    @.
+      mktemp.tmpfile.deleted.as-path.resolved "child"
+
+  is-directory. --> stops-on-checking-an-absent-directory
+    directory mktemp.tmpfile.deleted
+
+  walk. --> stops-on-walking-a-path-with-a-nul-character
+    directory
+      Q.file "\u0000"
+    "*"
 
   walk. --> stops-on-walking-an-absent-directory
     directory mktemp.tmpfile.deleted
     "**"
 
   --> stops-on-walking-with-a-malformed-glob
-    d.as-dir.walk "[" > @
+    d.as-dir.walk "{" > @
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted

--- a/objects/directory/deleted.eo
+++ b/objects/directory/deleted.eo
@@ -1,24 +1,60 @@
-# Recursively deletes the directory `d` and all of its contents.
+# Recursively deletes a directory and all of its contents. It is a method of
+# `directory`, and `d` is the directory it is taken off. The walk that feeds
+# `entries` reports everything underneath `d` and never `d` itself, so the
+# recursion below empties the directory but leaves it standing. The root is
+# removed by the step after it, once the walk is done and the directory is
+# empty, through `file.deleted`, which reaches for `rmdir` over `unlink`
+# when the path it is given is a directory.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[d] > deleted
-  d.exists.if > @
-    seq *
-      if. > [tup] >> r
-        tup.length.eq 0
-        true
-        seq *
-          tup.head.deleted
-          r tup.tail
-      | (d.walk "**").at.^
-      d
+[^] > deleted
+  seq * > @
+    if. > [^ tup] >> r
+      tup.length.eq 0
+      true
+      seq *
+        tup.head.deleted
+        ^.r tup.tail
+    | entries
+    d.as-path.as-file.deleted
     d
+  ^ > d
+  recovered > [^] > entries
+    ^.d.walk "**"
+    ^.d.exists.if
+      ^.d.walk "**"
+      *
+
+  ++> can-delete-a-directory-containing-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target.as-path
+            dir.as-path.resolved "broken-link"
+        target.deleted
+        dir.deleted.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > target
+
+  ++> can-delete-a-directory-containing-a-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target.as-path
+            dir.as-path.resolved "link"
+        dir.deleted.exists.not.and target.exists
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > target
 
   ++> can-delete-a-directory-with-a-file-and-a-directory
     and. > @
@@ -34,6 +70,24 @@
     dir.tmpfile > f
     as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
 
+  ++> can-delete-a-directory-with-a-nested-file
+    and. > @
+      nested.exists.and dir.deleted.exists.not
+      nested.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
+    inner.tmpfile > nested
+
+  ++> can-delete-a-directory-with-a-unicode-named-entry
+    f.exists.and > @
+      seq *
+        dir.deleted
+        f.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    touched. > f
+      as-file.
+        dir.as-path.resolved "приветствие.txt"
+
   ++> can-delete-a-directory-with-files-recursively
     and. > @
       and.
@@ -46,6 +100,27 @@
     dir.tmpfile > first
     dir.tmpfile > second
 
+  ++> can-delete-a-directory-with-nested-subdirectories
+    f.exists.and dir.deleted.exists.not > @
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    leaf.tmpfile > f
+    as-dir. (directory mid.tmpfile.deleted).made.as-path > leaf
+    as-dir. (directory dir.tmpfile.deleted).made.as-path > mid
+
+  ++> can-delete-an-already-absent-directory
+    d.deleted.deleted.exists.not > @
+    mktemp.tmpfile.deleted.as-path.as-dir > d
+
   not. ++> can-delete-an-empty-directory
     exists.
       deleted. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made
+
+  ++> can-preserve-a-sibling-file-when-deleting-a-directory
+    dir.deleted.exists.not.and sibling.exists > @
+    as-dir. (directory parent.tmpfile.deleted).made.as-path > dir
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > parent
+    parent.tmpfile > sibling
+
+  ++> can-return-itself-after-deleting-a-directory
+    dir.deleted.path.eq dir.path > @
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir

--- a/objects/directory/made.eo
+++ b/objects/directory/made.eo
@@ -1,39 +1,112 @@
-# Creates the directory `d`, making missing parent directories as needed.
+# Creates a directory, making missing parent directories as needed. It is a
+# method of `directory`, and `d` is the directory it is taken off. When the
+# path already exists, it must already be a directory: if a regular file (or
+# any non-directory entry) occupies the path, the computation terminates
+# instead of returning that entry decorated as a directory.
+#
+# The path may be made by somebody else between the question and the answer,
+# so a `mkdir` coming back with `EEXIST` over a directory is taken for the
+# directory it names rather than for a failure. `EOdirectoryEOmadeRaceTest`
+# holds the interleaving that reaches that branch.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[d] > made
+[^] > made
   d.exists.if > @
-    d
+    d.is-directory.if
+      d
+      T
+        "Cant make the directory '%s': a file already occupies that path".printf
+          * d.path
     seq *
       made.
         directory
           file d.as-path.dirname
       if.
-        created.code.eq 0
+        or.
+          created.code.eq 0
+          and.
+            errno.eq eexist
+            d.is-directory
         d
         T
           "Cant make the directory '%s': %s".printf
-            *
-              d.path
-              output.
-                called. >> created
-                  os.is-windows.if
-                    win32 *1
-                      "_mkdir"
-                      d.path
-                    posix *1
-                      "mkdir"
-                      d.path
-                      posix.permissions
+            * d.path created.output
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_mkdir"
+        d.path
+      posix *1
+        "mkdir"
+        d.path
+        posix.permissions
+  ^ > d
+  os.is-windows.if > eexist
+    win32.eexist
+    posix.eexist
+  code. > errno
+    os.is-windows.if
+      win32
+        "_errno"
+        *
+      posix
+        "errno"
+        *
+
+  ++> can-make-a-directory-and-return-the-same-path
+    dir.made.path.eq dir.path > @
+    as-dir. > dir
+      mktemp.tmpfile.deleted.as-path.resolved "foo-same"
+
+  ++> can-make-a-directory-with-a-unicode-name
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "плюшка-目录"
 
   ++> can-make-a-new-directory
     dir.exists.and dir.is-directory > @
     made. > dir
       as-dir.
         mktemp.tmpfile.deleted.as-path.resolved "foo-new"
+
+  ++> can-make-an-already-existing-directory
+    dir.made.exists.and dir.made.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-existing"
+
+  ++> can-make-deeply-nested-directories
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-1/foo-2/foo-3/foo-4"
+
+  ++> can-make-nested-directories-under-an-existing-parent
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        parent.resolved "foo-inner/foo-deepest"
+    made. > parent
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-partial"
+
+  ++> can-make-nested-directories-with-missing-parents
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-parent/foo-child"
+
+  mktemp.tmpfile.as-path.as-dir.made --> rejects-a-path-occupied-by-a-regular-file
+
+  --> rejects-a-path-whose-parent-is-occupied-by-a-regular-file
+    made. > @
+      as-dir.
+        occupied.resolved "foo-child"
+    mktemp.tmpfile.as-path > occupied

--- a/objects/directory/open.eo
+++ b/objects/directory/open.eo
@@ -1,16 +1,18 @@
-# Always fails: a directory cannot be opened for I/O.
+# Always fails: a directory cannot be opened for I/O. It is a method of
+# `directory`, and the directory it is taken off is the one it names in the
+# failure.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[d mode scope] > open
+[^ mode scope] > open
   T > @
     "The file %s is a directory, can't open for I/O operations".printf
-      * d
+      * ^
 
   mktemp.open --> stops-on-opening-a-directory
     "w"

--- a/objects/e.eo
+++ b/objects/e.eo
@@ -4,9 +4,8 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 2.718281828459045 > e

--- a/objects/eol.eo
+++ b/objects/eol.eo
@@ -4,13 +4,26 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
-string > eol
-  as-bytes.
-    os.is-windows.if
-      "\r\n"
-      "\n"
+[] > eol
+  string > @
+    as-bytes.
+      os.is-windows.if "\r\n" "\n"
+
+  eq. ++> can-carry-a-carriage-return-only-on-windows
+    eol.starts-with "\r"
+    os.is-windows
+
+  eol.ends-with "\n" ++> can-end-with-a-line-feed
+
+  eol.length.gt 0 ++> can-hold-at-least-one-character
+
+  eol.length.lt 3 ++> can-hold-fewer-than-three-characters
+
+  contains. ++> can-separate-two-joined-lines
+    eol.joined
+      * "a" "b"
+    eol

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -4,13 +4,34 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
-bool > false
-  []
-    ? >> left
-    ? >> right
-    right > @
+[^] > false
+  bool > @
+    [^]
+      ? >> left
+      ? >> right
+      right > @
+
+  eq. ++> can-avoid-evaluating-the-left-argument
+    false.if
+      1.div 0
+      42
+    42
+
+  eq. ++> can-choose-the-right-argument
+    false.if
+      1
+      2
+    2
+
+  not. ++> can-differ-from-true
+    false.eq true
+
+  false.eq false ++> can-equal-itself
+
+  false.as-bytes.eq 00- ++> can-expose-the-byte-representation-of-false
+
+  false.not.eq true ++> can-negate-to-true

--- a/objects/file.eo
+++ b/objects/file.eo
@@ -1,56 +1,30 @@
 # Represents a file in the filesystem for reading and writing.
 
-+alias string.contains
-+alias string.joined
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [path] > file
   path > @
   @. > as-path
     Q.path path
-  [] > deleted
-    exists.if > @
-      if.
-        outcome.eq 0
-        ^
-        T
-          "Cant delete the file '%s': %s".printf
-            * path removed.output
-      ^
-    removed.code > outcome
-    called. > removed
-      os.is-windows.if
-        win32 *1
-          win
-          path
-        posix *1
-          unix
-          path
-    is-directory.if > unix
-      "rmdir"
-      "unlink"
-    is-directory.if > win
-      "_rmdir"
-      "_unlink"
-  eq. > [] > exists
-    code.
-      os.is-windows.if
-        win32 *1
-          "_access"
-          path
-          0
-        posix *1
-          "access"
-          path
-          0
-    0
-  [cant-check] > is-directory
+  or. > [^] > exists
+    eq.
+      code.
+        os.is-windows.if
+          win32 *1
+            "_access"
+            ^.path
+            0
+          posix *1
+            "access"
+            ^.path
+            0
+      0
+    ^.is-symlink false
+  [^ cant-check] > is-directory
     if. > @
       info.code.eq 0
       eq.
@@ -62,34 +36,40 @@
       os.is-windows.if
         win32 *1
           "_stat64"
-          path
+          ^.path
         posix *1
           "stat"
-          path
-  [target] > moved
-    if. > @
-      outcome.eq 0
-      file target
-      T
-        "Cant move the file '%s' to '%s': %s".printf
-          * path target renamed.output
-    renamed.code > outcome
-    called. > renamed
-      os.is-windows.if
-        win32 *1
-          "rename"
-          path
-          target
-        posix *1
-          "rename"
-          path
-          target
-  [mode scope cant-open] > open
+          ^.path
+  [^ cant-check] > is-symlink
+    os.is-windows.if > @
+      if.
+        attributes.eq win32.invalid
+        cant-check
+        not.
+          eq.
+            attributes.as-i64.as-bytes.and win32.reparse
+            00-00-00-00-00-00-00-00
+      if.
+        info.code.eq 0
+        eq.
+          floor.
+            info.output.mode.div 4096
+          10
+        cant-check
+    code. > attributes
+      win32 *1
+        "GetFileAttributesW"
+        ^.path
+    called. > info
+      posix *1
+        "lstat"
+        ^.path
+  [^ mode scope cant-open] > open
     known.not.if > @
       T
         "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
-        existing.and exists.not
+        existing.and ^.exists.not
         cant-open
           "File must exist for given access mod: '%s'".printf
             *
@@ -110,7 +90,7 @@
     or. > known
       existing.or truncate
       appending
-    [] > open-file
+    [^] > open-file
       os.is-windows.if > @
         open-through
           []
@@ -126,26 +106,38 @@
             posix "open" > open
             posix "read" > read
             posix "write" > write
-      [syscall] > open-through
+      [^ syscall] > open-through
         if. > @
           descriptor.eq -1
-          cant-open
+          ^.^.cant-open
             "Couldn't open file '%s': %s".printf
-              * path opened.output
-          seq *
-            scope
-              stream descriptor
-            code.
-              syscall.close
-                * descriptor
-            true
-        appending.if syscall.append 0 > append
-        existing.not.if syscall.creat 0 > creat
+              * ^.^.^.path opened.output
+          if.
+            recovered
+              seq *
+                ^.^.scope
+                  stream descriptor
+                true
+              false
+            seq *
+              code.
+                syscall.close
+                  * descriptor
+              true
+            seq *
+              code.
+                syscall.close
+                  * descriptor
+              ^.^.cant-open
+                "The scope given to '%s'.open() failed; the descriptor was closed before propagating the failure".printf
+                  * ^.^.^.path
+        ^.^.appending.if syscall.append 0 > append
+        ^.^.existing.not.if syscall.creat 0 > creat
         opened.code > descriptor
         if. > direction
-          readable.and writable
+          ^.^.readable.and ^.^.writable
           syscall.rdwr
-          writable.if syscall.wronly syscall.rdonly
+          ^.^.writable.if syscall.wronly syscall.rdonly
         plus. > flags
           plus.
             direction.plus creat
@@ -153,38 +145,56 @@
           append
         called. > opened
           syscall.open
-            * path flags syscall.mode
-        [descriptor] > stream
-          [size] > read
+            * ^.^.^.path flags syscall.mode
+        [^ descriptor] > stream
+          [^ size] > read
             read. > @
               input-block --
               size
-            [buffer] > input-block
+            [^ buffer] > input-block
               buffer > @
-              [size] > read
-                readable.not.if > @
+              [^ size] > read
+                ^.^.^.^.^.^.readable.not.if > @
                   T
                     "Can't read from file with provided access mode '%s'".printf
                       * access
                   seq *
-                    output. >> chunk!
-                      syscall.read
-                        * descriptor size
-                    input-block chunk
-          [buffer] > write
+                    if. >> chunk!
+                      received.code.eq -1
+                      T
+                        "Failed to read from file"
+                      received.output
+                    received
+                    ^.^.input-block chunk
+                called. > received
+                  ^.^.^.^.syscall.read
+                    * ^.^.^.descriptor size
+          [^ buffer] > write
             output-block.write buffer > @
-            [] > output-block
+            [^] > output-block
               true > @
-              writable.not.if > [buffer] > write
-                T
-                  "Can't write to file with provided access mode '%s'".printf
-                    * access
-                seq *
-                  code.
-                    syscall.write
-                      * descriptor buffer buffer.size
-                  output-block
-        truncate.if syscall.trunc 0 > trunc
+              [^ buffer] > write
+                ^.^.^.^.^.^.writable.not.if > @
+                  T
+                    "Can't write to file with provided access mode '%s'".printf
+                      * access
+                  seq *
+                    if. >>!
+                      code.eq -1
+                      T
+                        "Failed to write to file"
+                      ^.^.output-block
+                    code
+                    remainder
+                code. > code
+                  ^.^.^.^.syscall.write
+                    * ^.^.^.descriptor buffer buffer.size
+                if. > remainder
+                  code.lt buffer.size
+                  ^.^.output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  ^.^.output-block
+        ^.^.truncate.if syscall.trunc 0 > trunc
     and. > readable
       not.
         as-bool.
@@ -200,49 +210,6 @@
     not. > writable
       as-bool.
         access.eq "r"
-  [cant-measure] > size
-    if. > @
-      info.code.eq 0
-      info.output.size
-      cant-measure
-    called. > info
-      os.is-windows.if
-        win32 *1
-          "_stat64"
-          path
-        posix *1
-          "stat"
-          path
-  [] > touched
-    exists.if > @
-      ^
-      if.
-        descriptor.eq -1
-        T
-          "Cant touch the file '%s': %s".printf
-            * path created.output
-        seq *
-          closed
-          ^
-    code. > closed
-      os.is-windows.if
-        win32 *1
-          "_close"
-          descriptor
-        posix *1
-          "close"
-          descriptor
-    called. > created
-      os.is-windows.if
-        win32 *1
-          "_creat"
-          path
-          win32.mode
-        posix *1
-          "creat"
-          path
-          posix.mode
-    created.code > descriptor
 
   eq. ++> can-append-data-to-a-file
     size.
@@ -254,19 +221,70 @@
         f.write "!" > [f]
     13
 
-  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+  ++> can-close-a-descriptor-when-the-scope-fails
+    eq. > @
+      drain 300
+      true
+      drain
+      tmp
+    if. > [^ n] > drain
+      n.lte 0
+      true
+      seq *
+        recovered
+          ^.tmp.open
+            "r"
+            T "boom" > [f]
+          true
+        ^.drain
+          n.minus 1
+    mktemp.tmpfile > tmp
 
-  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
-    0
+  ++> can-create-the-target-of-a-dangling-symlink-on-writing
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.open
+          "w"
+          f.write "created" > [f]
+        target.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "dangling-link" > link
+    d.resolved "absent-target" > target
 
-  ++> can-move-a-file
-    and. > @
-      exists.
-        temp.moved
-          "%s.dest".printf
-            * temp.path
-      temp.exists.not
-    mktemp.tmpfile > temp
+  eq. ++> can-keep-the-size-of-a-file-opened-for-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        true > [f]
+    12
+
+  eq. ++> can-keep-the-size-of-a-file-opened-for-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "r"
+        true > [f]
+    12
+
+  eq. ++> can-keep-the-size-of-a-file-opened-for-reading-or-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a+"
+        true > [f]
+    12
 
   ++> can-read-from-a-file
     eq. > @
@@ -279,7 +297,7 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put > [f] >>
+              ^.m.put > [^ f] >>
                 f.read 12
             m
       "Hello, world"
@@ -295,7 +313,7 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put > [f] >>
+              ^.m.put > [^ f] >>
                 read.
                   f.read 7
                   5
@@ -311,36 +329,63 @@
       "Shrek is love".eq
         malloc.of
           13
-          [m] >>
+          [^ m] >>
             seq * > @
               open.
-                file source
+                file ^.source
                 "r"
-                m.put > [f] >>
+                ^.m.put > [^ f] >>
                   f.read 13
               m
     temp.path > source
     mktemp.tmpfile > temp
 
+  ++> can-recover-from-checking-a-symbolic-link-of-an-absent-file
+    mktemp.tmpfile.deleted.is-symlink true > @
+
+  mktemp.tmpfile.deleted.is-directory ++> can-recover-from-checking-an-absent-file
+    true
+
+  eq. ++> can-recover-from-opening-a-missing-file
+    "recovered"
+    mktemp.tmpfile.deleted.open
+      "r"
+      I
+      "recovered" > [reason]
+
   ++> can-resolve-a-path-and-touch-it
     resolved.as-dir.made.tmpfile.exists.and > @
-      string.contains
-        resolved
-        string.joined *1
-          Q.path.separator
-          "foo"
-          "bar"
+      resolved.contains
+        Q.path.separator.joined
+          * "foo" "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
 
-  ++> can-return-itself-after-deleting
-    temp.deleted.path.eq temp.path > @
-    mktemp.tmpfile > temp
+  ++> can-tell-that-a-directory-beside-a-symbolic-link-is-not-one
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            d.resolved "ссылка"
+        not.
+          d.as-file.is-symlink true
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
 
-  ++> can-return-itself-after-touching
-    temp.deleted.touched.path.eq temp.path > @
-    mktemp.tmpfile > temp
+  not. ++> can-tell-that-a-regular-file-is-not-a-symbolic-link
+    mktemp.tmpfile.is-symlink true
 
-  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
+  ++> can-tell-that-a-symbolic-link-is-one
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        link.as-file.is-symlink false
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "ссылка" > link
 
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.
@@ -348,10 +393,6 @@
 
   is-directory. ++> can-tell-that-the-current-directory-is-a-directory
     file "."
-
-  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
-
-  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
 
   exists. ++> can-touch-an-absent-file-on-opening-for-appending
     mktemp.tmpfile.deleted.open
@@ -423,60 +464,17 @@
       eq.
         malloc.of
           14
-          [m] >>
+          [^ m] >>
             seq * > @
               open.
-                file source
+                file ^.source
                 "r"
-                m.put > [f] >>
+                ^.m.put > [^ f] >>
                   f.read 14
               m
         "Shrek is love!"
     temp.path > source
     mktemp.tmpfile > temp
-
-  eq. ++> cannot-truncate-a-file-opened-for-appending
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a"
-        true > [f]
-    12
-
-  eq. ++> cannot-truncate-a-file-opened-for-reading
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "r"
-        true > [f]
-    12
-
-  eq. ++> cannot-truncate-a-file-opened-for-reading-or-appending
-    size.
-      open.
-        mktemp.tmpfile.open
-          "w"
-          f.write "Hello, world" > [f]
-        "a+"
-        true > [f]
-    12
-
-  mktemp.tmpfile.deleted.is-directory true ++> rejects-checking-an-absent-file
-
-  eq. ++> rejects-opening-a-missing-file
-    "recovered"
-    mktemp.tmpfile.deleted.open
-      "r"
-      f > [f]
-      "recovered" > [reason]
-
-  eq. ++> rejects-sizing-an-absent-file
-    -1
-    mktemp.tmpfile.deleted.size -1
 
   mktemp.tmpfile.deleted.is-directory --> stops-on-checking-the-directory-of-an-absent-file
 
@@ -496,13 +494,11 @@
 
   mktemp.tmpfile.deleted.open --> stops-on-reading-from-a-missing-file
     "r"
-    f > [f]
+    I
 
   mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
     "r+"
-    f > [f]
-
-  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file
+    I
 
   tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
     @.

--- a/objects/file/deleted.eo
+++ b/objects/file/deleted.eo
@@ -1,0 +1,89 @@
+# Deletes a file from the filesystem, returning the same file, unchanged, if it
+# does not exist. It is a method of `file`, and `f` is the file it is taken off.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > deleted
+  f.exists.if > @
+    if.
+      or.
+        removed.code.eq 0
+        f.exists.not
+      f
+      T
+        "Cant delete the file '%s': %s".printf
+          * f.path removed.output
+    f
+  ^ > f
+  called. > removed
+    os.is-windows.if
+      win32 *1
+        f.is-symlink.if
+          "_unlink"
+          f.is-directory.if "_rmdir" "_unlink"
+        f.path
+      posix *1
+        f.is-symlink.if
+          "unlink"
+          f.is-directory.if "rmdir" "unlink"
+        f.path
+
+  ++> can-delete-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        d.as-file.deleted
+        link.as-file.deleted
+        link.as-file.exists.not
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "broken-link" > link
+
+  ++> can-delete-a-directory
+    d.as-file.deleted.exists.not > @
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+
+  ++> can-delete-a-directory-twice
+    d.as-file.deleted.deleted.exists.not > @
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+
+  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+
+  ++> can-delete-a-symlink-to-a-directory
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        link.as-file.deleted
+        link.as-file.exists.not
+        d.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "ссылка" > link
+
+  ++> can-return-itself-after-deleting
+    temp.deleted.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  ++> can-return-itself-after-deleting-a-directory
+    temp.deleted.path.eq temp.path > @
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path.as-file > temp
+
+  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
+
+  --> stops-on-deleting-a-non-empty-directory
+    seq * > @
+      child.as-file.touched
+      d.as-file.deleted
+    d.resolved "child.txt" > child
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d

--- a/objects/file/moved.eo
+++ b/objects/file/moved.eo
@@ -1,0 +1,40 @@
+# Moves a file to `target` on the filesystem, returning the file at its new
+# location. It is a method of `file`, and `f` is the file it is taken off.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ target] > moved
+  if. > @
+    renamed.code.eq 0
+    file target
+    T
+      "Cant move the file '%s' to '%s': %s".printf
+        *
+          f.path
+          target
+          renamed.output
+  ^ > f
+  called. > renamed
+    os.is-windows.if
+      win32 *1
+        "rename"
+        f.path
+        target
+      posix *1
+        "rename"
+        f.path
+        target
+
+  ++> can-move-a-file
+    and. > @
+      exists.
+        temp.moved
+          "%s.dest".printf
+            * temp.path
+      temp.exists.not
+    mktemp.tmpfile > temp

--- a/objects/file/size.eo
+++ b/objects/file/size.eo
@@ -1,0 +1,33 @@
+# Size of a file in bytes, or `cant-measure` if the file does not exist. It is
+# a method of `file`, and `f` is the file it is taken off.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ cant-measure] > size
+  if. > @
+    info.code.eq 0
+    info.output.size
+    cant-measure
+  ^ > f
+  called. > info
+    os.is-windows.if
+      win32 *1
+        "_stat64"
+        f.path
+      posix *1
+        "stat"
+        f.path
+
+  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
+    0
+
+  eq. ++> can-recover-from-sizing-an-absent-file
+    -1
+    mktemp.tmpfile.deleted.size -1
+
+  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file

--- a/objects/file/touched.eo
+++ b/objects/file/touched.eo
@@ -1,0 +1,95 @@
+# Touches a file, creating it if it does not exist yet, and returning the same
+# file, unchanged, if it already does. It is a method of `file`, and `f` is the
+# file it is taken off. `f.exists` counts any symbolic link, dangling or not,
+# as existing, so this checks reachability directly instead: an ordinary
+# absent path or a dangling symlink both get created. On POSIX, opening a
+# symlink is done without the exclusive flag, since POSIX defines
+# `O_CREAT | O_EXCL` on a path naming a symlink as always failing `EEXIST`,
+# whether or not its target exists; the exclusivity that guards the
+# plain-file race stays for every other path, and win32 keeps its exclusive
+# open unconditionally, since its reparse points do not share that rule.
+#
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package file
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > touched
+  reachable.if > @
+    f
+    if.
+      or.
+        descriptor.gte 0
+        linked.not.and
+          errno.eq eexist
+      seq *
+        if.
+          descriptor.gte 0
+          code.
+            os.is-windows.if
+              win32 *1
+                "_close"
+                descriptor
+              posix *1
+                "close"
+                descriptor
+          0
+        f
+      T
+        "Cant touch the file '%s': %s".printf
+          * f.path opened.output
+  code. > accessible
+    os.is-windows.if
+      win32 *1
+        "_access"
+        f.path
+        0
+      posix *1
+        "access"
+        f.path
+        0
+  opened.code > descriptor
+  os.is-windows.if > eexist
+    win32.eexist
+    posix.eexist
+  code. > errno
+    os.is-windows.if
+      win32
+        "_errno"
+        *
+      posix
+        "errno"
+        *
+  linked.not.if > exclusive
+    posix.exclusive
+    0
+  ^ > f
+  f.is-symlink false > linked
+  called. > opened
+    os.is-windows.if
+      win32 *1
+        "_open"
+        f.path
+        plus.
+          win32.creat.plus win32.exclusive
+          win32.wronly
+        win32.mode
+      posix *1
+        "open"
+        f.path
+        plus.
+          posix.creat.plus exclusive
+          posix.wronly
+        posix.mode
+  accessible.eq 0 > reachable
+
+  ++> can-return-itself-after-touching
+    temp.deleted.touched.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
+
+  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice

--- a/objects/getenv.eo
+++ b/objects/getenv.eo
@@ -1,21 +1,111 @@
-# Get environment variable as `string`.
-# If the return `string` is empty - the variable does not exist.
+# Get environment variable as `string`, or `cant-get` if it does not exist.
 #
 # See https://man7.org/linux/man-pages/man3/getenv.3.html.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
-+unlint mandatory-package
 
-output. > [name] > getenv
-  os.is-windows.if
-    win32 *1
-      "getenv"
-      name
-    posix *1
-      "getenv"
-      name
+[name cant-get] > getenv
+  result.code.if > @
+    result.output
+    cant-get
+  called. > result
+    os.is-windows.if
+      win32 *1
+        "getenv"
+        name
+      posix *1
+        "getenv"
+        name
+
+  not. ++> can-distinguish-different-fallbacks-for-different-missing-variables
+    eq.
+      getenv "EO_UNSET_VARIABLE_6142" "first"
+      getenv "EO_UNSET_VARIABLE_7253" "second"
+
+  eq. ++> can-read-a-variable-consistently-across-repeated-calls
+    getenv
+      "PATH"
+      "not found"
+    getenv
+      "PATH"
+      "not found"
+
+  not. ++> can-read-an-existing-variable
+    eq.
+      getenv
+        "PATH"
+        "not found"
+      "not found"
+
+  eq. ++> can-return-fallback-for-a-name-containing-an-equals-sign
+    getenv
+      "EO=UNSET"
+      "not found"
+    "not found"
+
+  eq. ++> can-return-fallback-for-a-name-that-is-only-whitespace
+    getenv
+      "   "
+      "not found"
+    "not found"
+
+  eq. ++> can-return-fallback-for-a-very-long-variable-name
+    getenv
+      "EO_UNSET_VARIABLE_WITH_A_VERY_LONG_NAME_THAT_IS_UNLIKELY_TO_EVER_BE_SET_1234567890"
+      "not found"
+    "not found"
+
+  eq. ++> can-return-the-fallback-object-itself-when-variable-is-absent
+    getenv
+      "EO_UNSET_VARIABLE_6142"
+      42
+    42
+
+  eq. ++> can-treat-an-empty-name-as-a-missing-variable
+    getenv
+      ""
+      "not found"
+    "not found"
+
+  os.is-windows.or ++> can-treat-variable-names-case-sensitively
+    not.
+      eq.
+        getenv
+          "path"
+          "not found"
+        getenv
+          "PATH"
+          "not found"
+
+  eq. ++> can-use-a-boolean-fallback-when-variable-does-not-exist
+    getenv
+      "EO_UNSET_VARIABLE_6142"
+      true
+    true
+
+  eq. ++> can-use-a-tuple-fallback-when-variable-does-not-exist
+    getenv *1
+      "EO_UNSET_VARIABLE_6142"
+      1
+      2
+      3
+    *
+      1
+      2
+      3
+
+  eq. ++> can-use-an-empty-string-fallback-when-variable-does-not-exist
+    getenv
+      "EO_UNSET_VARIABLE_6142"
+      ""
+    ""
+
+  eq. ++> can-use-fallback-when-variable-does-not-exist
+    getenv
+      "EO_UNSET_VARIABLE_6142"
+      "not found"
+    "not found"

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -3,34 +3,32 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i16
   as-bytes > @
-  [] > as-i32
+  [^] > as-i32
     i32 > @
       concat.
         if. >>
           eq.
-            as-bytes.and 80-00
+            ^.as-bytes.and 80-00
             00-00
           00-00
           FF-FF
-        as-bytes
+        ^.as-bytes
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i16 >> other
         00-00
       cant-divide
         "Can't divide %d by i16 zero".printf
-          * as-i32.as-i64.as-number
+          * ^.as-i32.as-i64.as-number
       if.
         or.
           eq.
@@ -40,7 +38,7 @@
         i16
           slice.
             as-bytes. >> b
-              as-i32.div other.as-i32
+              ^.as-i32.div other.as-i32
             2
             2
         plus.
@@ -48,13 +46,13 @@
             b.slice 0 2
           i16
             b.slice 2 2
-  as-i32.gt x.as-i16.as-i32 > [x] > gt
-  as-i32.gte x.as-i16.as-i32 > [x] > gte
-  as-i32.lt x.as-i16.as-i32 > [x] > lt
-  as-i32.lte x.as-i16.as-i32 > [x] > lte
-  plus x.as-i16.neg > [x] > minus
+  ^.as-i32.gt x.as-i16.as-i32 > [^ x] > gt
+  ^.as-i32.gte x.as-i16.as-i32 > [^ x] > gte
+  ^.as-i32.lt x.as-i16.as-i32 > [^ x] > lt
+  ^.as-i32.lte x.as-i16.as-i32 > [^ x] > lte
+  ^.plus x.as-i16.neg > [^ x] > minus
   times -1.as-i64.as-i32.as-i16 > neg
-  [x] > plus
+  [^ x] > plus
     if. > @
       or.
         eq.
@@ -64,7 +62,7 @@
       i16
         slice.
           as-bytes. >> b
-            as-i32.plus x.as-i16.as-i32
+            ^.as-i32.plus x.as-i16.as-i32
           2
           2
       plus.
@@ -72,10 +70,10 @@
           b.slice 0 2
         i16
           b.slice 2 2
-  i16 > [x] > times
+  i16 > [^ x] > times
     slice.
       as-bytes.
-        as-i32.times x.as-i16.as-i32
+        ^.as-i32.times x.as-i16.as-i32
       2
       2
 
@@ -143,6 +141,12 @@
     32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    2.as-i64.as-i32.as-i16.div
+      0.as-i64.as-i32.as-i16
+      "recovered" > [message]
+
   eq. ++> can-subtract-one-from-one
     1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
@@ -150,6 +154,27 @@
   eq. ++> can-subtract-with-overflow
     -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
     32767.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-does-not-equal-a-different-i16
+    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-greater-than-a-larger-i16
+    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-greater-than-an-equal-i16
+    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-i16
+    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-less-than-a-smaller-i16
+    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-i16
+    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
+
+  not. ++> can-tell-it-is-not-less-than-or-equal-to-a-smaller-i16
+    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
 
   eq. ++> can-widen-a-negative-to-i32-with-sign-extension
     -200.as-i64.as-i32.as-i16.as-i32.as-bytes
@@ -166,32 +191,5 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
     256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
     0.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-greater-than-a-larger-i16
-    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-greater-than-an-equal-i16
-    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i16
-    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-less-than-a-smaller-i16
-    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-less-than-an-equal-i16
-    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
-
-  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i16
-    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
-
-  not. ++> cannot-equal-a-different-i16
-    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    2.as-i64.as-i32.as-i16.div
-      0.as-i64.as-i32.as-i16
-      "recovered" > [message]
 
   2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 --> stops-on-division-by-zero

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -3,42 +3,40 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i32
   as-bytes > @
-  [cant-convert] > as-i16
+  [^ cant-convert] > as-i16
     if. > @
       ^.eq left.as-i32
       left
       cant-convert
         "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
-          * as-i64.as-number
+          * ^.as-i64.as-number
     i16 > left
-      as-bytes.slice 2 2
-  [] > as-i64
+      ^.as-bytes.slice 2 2
+  [^] > as-i64
     i64 > @
       concat.
         if. >>
           eq.
-            as-bytes.and 80-00-00-00
+            ^.as-bytes.and 80-00-00-00
             00-00-00-00
           00-00-00-00
           FF-FF-FF-FF
-        as-bytes
+        ^.as-bytes
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i32 >> other
         00-00-00-00
       cant-divide
         "Can't divide %d by i32 zero".printf
-          * as-i64.as-number
+          * ^.as-i64.as-number
       if.
         or.
           eq.
@@ -48,7 +46,7 @@
         i32
           slice.
             as-bytes. >> b
-              as-i64.div other.as-i64
+              ^.as-i64.div other.as-i64
             4
             4
         plus.
@@ -56,13 +54,13 @@
             b.slice 0 4
           i32
             b.slice 4 4
-  as-i64.gt x.as-i32.as-i64 > [x] > gt
-  as-i64.gte x.as-i32.as-i64 > [x] > gte
-  as-i64.lt x.as-i32.as-i64 > [x] > lt
-  as-i64.lte x.as-i32.as-i64 > [x] > lte
-  plus x.as-i32.neg > [x] > minus
+  ^.as-i64.gt x.as-i32.as-i64 > [^ x] > gt
+  ^.as-i64.gte x.as-i32.as-i64 > [^ x] > gte
+  ^.as-i64.lt x.as-i32.as-i64 > [^ x] > lt
+  ^.as-i64.lte x.as-i32.as-i64 > [^ x] > lte
+  ^.plus x.as-i32.neg > [^ x] > minus
   times -1.as-i64.as-i32 > neg
-  [x] > plus
+  [^ x] > plus
     if. > @
       or.
         eq.
@@ -72,7 +70,7 @@
       i32
         slice.
           as-bytes. >> b
-            as-i64.plus x.as-i32.as-i64
+            ^.as-i64.plus x.as-i32.as-i64
           4
           4
       plus.
@@ -80,10 +78,10 @@
           b.slice 0 4
         i32
           b.slice 4 4
-  i32 > [x] > times
+  i32 > [^ x] > times
     slice.
       as-bytes.
-        as-i64.times x.as-i32.as-i64
+        ^.as-i64.times x.as-i32.as-i64
       4
       4
 
@@ -155,6 +153,17 @@
     2147483647.as-i64.as-i32.times 2.as-i64.as-i32
     -2.as-i64.as-i32
 
+  eq. ++> can-recover-from-an-out-of-bounds-conversion-to-i16
+    "recovered"
+    247483647.as-i64.as-i32.as-i16
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    2.as-i64.as-i32.div
+      0.as-i64.as-i32
+      "recovered" > [message]
+
   eq. ++> can-subtract-one-from-one
     1.as-i64.as-i32.minus 1.as-i64.as-i32
     0.as-i64.as-i32
@@ -162,6 +171,27 @@
   eq. ++> can-subtract-with-overflow
     -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
     2147483647.as-i64.as-i32
+
+  not. ++> can-tell-it-does-not-equal-a-different-i32
+    123.as-i64.as-i32.eq 42.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-greater-than-a-larger-i32
+    0.as-i64.as-i32.gt 100.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-greater-than-an-equal-i32
+    0.as-i64.as-i32.gt 0.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-i32
+    0.as-i64.as-i32.gte 10.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-less-than-a-smaller-i32
+    10.as-i64.as-i32.lt -5.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-i32
+    10.as-i64.as-i32.lt 10.as-i64.as-i32
+
+  not. ++> can-tell-it-is-not-less-than-or-equal-to-a-smaller-i32
+    0.as-i64.as-i32.lte -10.as-i64.as-i32
 
   eq. ++> can-widen-a-negative-to-i64-with-sign-extension
     -200.as-i64.as-i32.as-i64.as-bytes
@@ -178,38 +208,6 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
     65536.as-i64.as-i32.times 65536.as-i64.as-i32
     0.as-i64.as-i32
-
-  not. ++> cannot-be-greater-than-a-larger-i32
-    0.as-i64.as-i32.gt 100.as-i64.as-i32
-
-  not. ++> cannot-be-greater-than-an-equal-i32
-    0.as-i64.as-i32.gt 0.as-i64.as-i32
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i32
-    0.as-i64.as-i32.gte 10.as-i64.as-i32
-
-  not. ++> cannot-be-less-than-a-smaller-i32
-    10.as-i64.as-i32.lt -5.as-i64.as-i32
-
-  not. ++> cannot-be-less-than-an-equal-i32
-    10.as-i64.as-i32.lt 10.as-i64.as-i32
-
-  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i32
-    0.as-i64.as-i32.lte -10.as-i64.as-i32
-
-  not. ++> cannot-equal-a-different-i32
-    123.as-i64.as-i32.eq 42.as-i64.as-i32
-
-  eq. ++> rejects-an-out-of-bounds-conversion-to-i16
-    "recovered"
-    247483647.as-i64.as-i32.as-i16
-      "recovered" > [message]
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    2.as-i64.as-i32.div
-      0.as-i64.as-i32
-      "recovered" > [message]
 
   32768.as-i64.as-i32.as-i16 --> stops-on-converting-i16-max-plus-one-to-i16
 

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -1,32 +1,38 @@
 # Signed 64-bit integer.
 # Here `as-bytes` must be a `bytes` object.
+#
+# The out-of-bounds message of `as-i32` names the receiver with `%s` and
+# `as-scientific`, not with `%d`, because `%d` would take a `number` and the
+# `i64` to `number` conversion is lossy at the top of the 64-bit range: the
+# nearest double of `9223372036854775807` is `2^63`, which is one past the
+# `long` range that `printf`'s own `%d` guard accepts, so the message itself
+# used to terminate instead of being printed.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i64
   as-bytes > @
   as-i32.as-i16 > as-i16
-  [cant-convert] > as-i32
+  [^ cant-convert] > as-i32
     if. > @
       ^.eq
         as-i64.
           i32 >> left
-            as-bytes.slice 4 4
+            ^.as-bytes.slice 4 4
       left
       cant-convert
-        "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
-          * as-number
+        "Can't convert i64 number %s to i32 because it's out of i32 bounds".printf
+          *
+            string ^.as-number.as-scientific
     i32 > left
-      as-bytes.slice 4 4
-  [] > as-number
+      ^.as-bytes.slice 4 4
+  [^] > as-number
     if. > @
-      as-bytes.eq 00-00-00-00-00-00-00-00
+      ^.as-bytes.eq 00-00-00-00-00-00-00-00
       0
       number
         sign.or
@@ -57,9 +63,9 @@
       sign.eq 80-00-00-00-00-00-00-00
       as-bytes.
         plus.
-          i64 as-bytes.not
+          i64 ^.as-bytes.not
           i64 00-00-00-00-00-00-00-01
-      as-bytes
+      ^.as-bytes
     if. > mantissa
       highest.lte 52
       and.
@@ -78,11 +84,11 @@
       kept
     guard.and > roundup
       sticky.or odd
-    [m acc step bit] > scan
+    [^ m acc step bit] > scan
       if. > @
         step.lt 1
         acc
-        scan
+        ^.scan
           empty.if m shifted
           empty.if
             acc
@@ -96,60 +102,60 @@
       43-30-00-00-00-00-00-00
       32
       00-00-00-00-00-00-00-20
-    as-bytes.and 80-00-00-00-00-00-00-00 > sign!
+    ^.as-bytes.and 80-00-00-00-00-00-00-00 > sign!
     not. > sticky
       eq.
         magnitude.left
           117.minus highest
         00-00-00-00-00-00-00-00
-  [x] > gt
+  [^ x] > gt
     if. > @
       not.
         eq.
-          as-bytes.and 80-00-00-00-00-00-00-00 >> sign
+          ^.as-bytes.and 80-00-00-00-00-00-00-00 >> sign
           x.as-bytes.and 80-00-00-00-00-00-00-00
       sign.eq 00-00-00-00-00-00-00-00
       and.
         eq.
           and.
             as-bytes.
-              minus x >> difference
+              ^.minus x >> difference
             80-00-00-00-00-00-00-00
           00-00-00-00-00-00-00-00
         not.
           difference.as-bytes.eq 00-00-00-00-00-00-00-00
-  [x] > gte
+  [^ x] > gte
     or. > @
-      gt
+      ^.gt
         x >> value!
       ^.eq value
-  gt. > [x] > lt
+  gt. > [^ x] > lt
     i64 x.as-bytes
     ^
-  [x] > lte
+  [^ x] > lte
     or. > @
-      lt
+      ^.lt
         x >> value!
       ^.eq value
-  plus (i64 x!).neg > [x] > minus
+  ^.plus (i64 x!).neg > [^ x] > minus
   times -1.as-i64 > neg
-  [x] > plus
-    if. > [a b] >> carried
+  [^ x] > plus
+    if. > [^ a b] >> carried
       b.eq 00-00-00-00-00-00-00-00
       i64 a
-      carried
+      ^.carried
         a.xor b
         left.
           a.and b
           1
     | > @
-      as-bytes
+      ^.as-bytes
       x.as-bytes
-  [x] > times
-    if. > [acc a b] > looped
+  [^ x] > times
+    if. > [^ acc a b] > looped
       b.eq 00-00-00-00-00-00-00-00
       i64 acc
-      looped
+      ^.looped
         if.
           eq.
             b.and 00-00-00-00-00-00-00-01
@@ -163,7 +169,7 @@
         b.right 1
     | > @
       00-00-00-00-00-00-00-00
-      as-bytes
+      ^.as-bytes
       x.as-bytes
 
   eq. ++> can-add-mixed-signs
@@ -242,6 +248,18 @@
 
   42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-expose-valid-bytes
 
+  eq. ++> can-format-the-error-message-of-the-maximum-i64-when-converting-to-i32
+    "Can't convert i64 number 9.223372e18 to i32 because it's out of i32 bounds"
+    as-i32.
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+      I
+
+  eq. ++> can-format-the-error-message-of-the-minimum-i64-when-converting-to-i32
+    "Can't convert i64 number -9.223372e18 to i32 because it's out of i32 bounds"
+    as-i32.
+      i64 80-00-00-00-00-00-00-00
+      I
+
   eq. ++> can-keep-the-low-bits-of-a-large-product
     2147483647.as-i64.times 2147483647.as-i64
     i64 3F-FF-FF-FF-00-00-00-01
@@ -257,6 +275,11 @@
   eq. ++> can-multiply-two-negatives
     -7.as-i64.times -6.as-i64
     42.as-i64
+
+  eq. ++> can-recover-from-an-out-of-bounds-conversion-to-i32
+    "recovered"
+    3147483647.as-i64.as-i32
+      "recovered" > [message]
 
   eq. ++> can-round-a-tie-to-even-when-converting-to-a-number
     as-number.
@@ -277,6 +300,37 @@
     1.as-i64.minus 1.as-i64
     0.as-i64
 
+  not. ++> can-tell-it-does-not-equal-a-different-i64
+    123.@.eq 42.@
+
+  not. ++> can-tell-it-does-not-match-the-bytes-of-the-same-number
+    eq.
+      i64 234.as-bytes
+      234.as-i64.as-bytes
+
+  not. ++> can-tell-it-is-not-greater-than-a-larger-i64
+    0.as-i64.gt 100.as-i64
+
+  not. ++> can-tell-it-is-not-greater-than-an-equal-i64
+    0.as-i64.gt 0.as-i64
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-i64
+    0.as-i64.gte 10.as-i64
+
+  not. ++> can-tell-it-is-not-greater-when-min-is-under-max
+    gt.
+      i64 80-00-00-00-00-00-00-00
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+
+  not. ++> can-tell-it-is-not-less-than-a-smaller-i64
+    10.as-i64.lt -5.as-i64
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-i64
+    10.as-i64.lt 10.as-i64
+
+  not. ++> can-tell-it-is-not-less-than-or-equal-to-a-smaller-i64
+    0.as-i64.lte -10.as-i64
+
   eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
     times.
       i64 40-00-00-00-00-00-00-00
@@ -288,42 +342,6 @@
       i64 7F-FF-FF-FF-FF-FF-FF-FF
       1.as-i64
     i64 80-00-00-00-00-00-00-00
-
-  not. ++> cannot-be-greater-than-a-larger-i64
-    0.as-i64.gt 100.as-i64
-
-  not. ++> cannot-be-greater-than-an-equal-i64
-    0.as-i64.gt 0.as-i64
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i64
-    0.as-i64.gte 10.as-i64
-
-  not. ++> cannot-be-greater-when-min-is-under-max
-    gt.
-      i64 80-00-00-00-00-00-00-00
-      i64 7F-FF-FF-FF-FF-FF-FF-FF
-
-  not. ++> cannot-be-less-than-a-smaller-i64
-    10.as-i64.lt -5.as-i64
-
-  not. ++> cannot-be-less-than-an-equal-i64
-    10.as-i64.lt 10.as-i64
-
-  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i64
-    0.as-i64.lte -10.as-i64
-
-  not. ++> cannot-equal-a-different-i64
-    123.@.eq 42.@
-
-  not. ++> cannot-match-the-bytes-of-the-same-number
-    eq.
-      i64 234.as-bytes
-      234.as-i64.as-bytes
-
-  eq. ++> rejects-an-out-of-bounds-conversion-to-i32
-    "recovered"
-    3147483647.as-i64.as-i32
-      "recovered" > [message]
 
   2147483648.as-i64.as-i32 --> stops-on-converting-i32-max-plus-one-to-i32
 

--- a/objects/i64/div.eo
+++ b/objects/i64/div.eo
@@ -6,11 +6,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package i64
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x cant-divide] > div
+[^ x cant-divide] > div
   if. > @
     x.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -29,7 +29,7 @@
           i64 00-00-00-00-00-00-00-01
       i64 quotient
   00-00-00-00-00-00-00-01.left i > [i] >> bit
-  [index remainder quot] >> looped
+  [^ index remainder quot] >> looped
     if. > @
       index.lt 0
       quot
@@ -43,7 +43,7 @@
               shifted-sign.xor divisor-sign >> signs-differ!
               next-rem.xor 80-00-00-00-00-00-00-00 >> trial-nonnegative!
           80-00-00-00-00-00-00-00
-        looped
+        ^.looped
           index.minus 1
           as-bytes. >> next-rem!
             plus.
@@ -51,16 +51,17 @@
               i64 subtrahend
           quot.or >>!
             bit index
-        looped
+        ^.looped
           index.minus 1
           or. >> shifted!
             remainder.left 1
             and.
               right.
-                magnitude n.as-bytes
+                magnitude ^.n.as-bytes
                 index
               00-00-00-00-00-00-00-01
           quot
+  ^ > n
   as-bytes. >> subtrahend
     plus.
       i64
@@ -105,6 +106,12 @@
     13.as-i64.div -5.as-i64
     -2.as-i64
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    2.as-i64.div
+      0.as-i64
+      "recovered" > [message]
+
   eq. ++> can-truncate-toward-zero
     -13.as-i64.div 5.as-i64
     -2.as-i64
@@ -114,11 +121,5 @@
       i64 80-00-00-00-00-00-00-00
       -1.as-i64
     i64 80-00-00-00-00-00-00-00
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    2.as-i64.div
-      0.as-i64
-      "recovered" > [message]
 
   2.as-i64.div 0.as-i64 --> stops-on-division-by-zero

--- a/objects/i8.eo
+++ b/objects/i8.eo
@@ -4,60 +4,58 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > i8
   as-bytes > @
-  [] > as-i16
+  [^] > as-i16
     i16 > @
       concat.
         if. >>
           eq.
-            as-bytes.and 80-
+            ^.as-bytes.and 80-
             00-
           00-
           FF-
-        as-bytes
+        ^.as-bytes
   as-i16.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i8 >> other
         00-
       cant-divide
         "Can't divide %d by i8 zero".printf
-          * as-number
+          * ^.as-number
       i8
         slice.
           as-bytes.
-            as-i16.div other.as-i16
+            ^.as-i16.div other.as-i16
           1
           1
-  as-i16.gt x.as-i8.as-i16 > [x] > gt
-  as-i16.gte x.as-i8.as-i16 > [x] > gte
-  as-i16.lt x.as-i8.as-i16 > [x] > lt
-  as-i16.lte x.as-i8.as-i16 > [x] > lte
-  i8 > [x] > minus
+  ^.as-i16.gt x.as-i8.as-i16 > [^ x] > gt
+  ^.as-i16.gte x.as-i8.as-i16 > [^ x] > gte
+  ^.as-i16.lt x.as-i8.as-i16 > [^ x] > lt
+  ^.as-i16.lte x.as-i8.as-i16 > [^ x] > lte
+  i8 > [^ x] > minus
     slice.
       as-bytes.
-        as-i16.minus x.as-i8.as-i16
+        ^.as-i16.minus x.as-i8.as-i16
       1
       1
   times FF-.as-i8 > neg
-  i8 > [x] > plus
+  i8 > [^ x] > plus
     slice.
       as-bytes.
-        as-i16.plus x.as-i8.as-i16
+        ^.as-i16.plus x.as-i8.as-i16
       1
       1
-  i8 > [x] > times
+  i8 > [^ x] > times
     slice.
       as-bytes.
-        as-i16.times x.as-i8.as-i16
+        ^.as-i16.times x.as-i8.as-i16
       1
       1
 
@@ -109,6 +107,12 @@
 
   C8-.as-i8.as-number.eq -56 ++> can-read-a-high-bit-as-negative
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    02-.as-i8.div
+      00-.as-i8
+      "recovered" > [message]
+
   eq. ++> can-subtract-one-from-one
     01-.as-i8.minus 01-.as-i8
     00-.as-i8
@@ -117,6 +121,12 @@
     80-.as-i8.minus 01-.as-i8
     7F-.as-i8
 
+  not. ++> can-tell-it-does-not-equal-a-different-i8
+    2A-.as-i8.eq 2B-.as-i8
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-i8
+    0A-.as-i8.lt 0A-.as-i8
+
   eq. ++> can-widen-a-negative-to-i16-with-sign-extension
     C8-.as-i8.as-i16.as-bytes
     FF-C8
@@ -124,17 +134,5 @@
   eq. ++> can-widen-a-positive-to-i16-with-a-zero-prefix
     2A-.as-i8.as-i16.as-bytes
     00-2A
-
-  not. ++> cannot-be-less-than-an-equal-i8
-    0A-.as-i8.lt 0A-.as-i8
-
-  not. ++> cannot-equal-a-different-i8
-    2A-.as-i8.eq 2B-.as-i8
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    02-.as-i8.div
-      00-.as-i8
-      "recovered" > [message]
 
   02-.as-i8.div 00-.as-i8 --> stops-on-division-by-zero

--- a/objects/input.eo
+++ b/objects/input.eo
@@ -7,10 +7,13 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint unit-test-missing
 
 [@] > input
+
+  eq. ++> can-decorate-a-source-of-bytes
+    as-bytes.
+      input 01-02-03-04-05.as-input
+    01-02-03-04-05

--- a/objects/input/as-bytes.eo
+++ b/objects/input/as-bytes.eo
@@ -1,34 +1,36 @@
-# Reads all bytes from the provided `input` and returns them as bytes.
+# Reads all bytes from an input and returns them as bytes. It is a method of
+# `input`, and `origin` is the input it is taken off.
 #
 # Example usage:
 # ```
-# as-bytes > b
-#   bytes.as-input 01-02-03-04-05
+# as-bytes. > b
+#   input 01-02-03-04-05.as-input
 # ```
 # After dataization, `b` equals `01-02-03-04-05`.
 
-+alias bytes.as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > as-bytes
+[^] > as-bytes
   malloc.of > @
     0
-    seq * > [m] >>
-      Q.input.copied input m.to-output
+    seq * > [^ m] >>
+      ^.origin.copied m.to-output
       m
+  ^ > origin
 
   ++> can-convert-bytes-to-an-input-and-back
     eq. > @
-      Q.input.as-bytes
-        bytes.as-input b
+      as-bytes.
+        input b.as-input
       b
     01-02-03-04-05-06-07-08 > b
 
   eq. ++> can-return-empty-bytes-from-a-dead-input
-    Q.input.as-bytes dead
+    as-bytes.
+      input input.dead
     --

--- a/objects/input/copied.eo
+++ b/objects/input/copied.eo
@@ -1,42 +1,41 @@
-# Copies all bytes from the provided `input` to the provided `output`
-# and returns the total number of bytes copied.
+# Copies all bytes from an input to the provided `output` and returns the
+# total number of bytes copied. It is a method of `input`, and `input` is the
+# one it is taken off.
 #
 # Example usage:
 # ```
-# copied > total-bytes
-#   bytes.as-input 01-02-03-04-05
+# copied. > total-bytes
+#   input 01-02-03-04-05.as-input
 #   memory.to-output
 # ```
 # After dataization, `total-bytes` equals 5, and all bytes have been
 # copied from input to output.
 
-+alias bytes.as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input output] > copied
-  Q.input.length > @
-    Q.input.tee
-      input
-      output
+[^ output] > copied
+  length. > @
+    input
+      ^.tee output
 
   eq. ++> can-copy-all-bytes-and-return-the-length
     malloc.of
       5
       seq * > [m]
-        Q.input.copied
-          bytes.as-input 01-02-03-04-05
+        copied.
+          input 01-02-03-04-05.as-input
           m.to-output
         m
     01-02-03-04-05
 
   eq. ++> can-handle-a-dead-input
-    Q.input.copied
-      Q.input.dead
+    copied.
+      input input.dead
       Q.output.dead
     0
 
@@ -44,8 +43,8 @@
     malloc.of
       0
       seq * > [m]
-        Q.input.copied
-          bytes.as-input --
+        copied.
+          input --.as-input
           m.to-output
         m
     --
@@ -54,22 +53,22 @@
     20
     malloc.of
       20
-      Q.input.copied > [m]
-        bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+      copied. > [m]
+        input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14.as-input
         m.to-output
 
   eq. ++> can-return-the-byte-count
     malloc.of
       10
-      Q.input.copied > [m]
-        bytes.as-input 01-02-03-04-05-06-07-08-09-10
+      copied. > [m]
+        input 01-02-03-04-05-06-07-08-09-10.as-input
         m.to-output
     10
 
   eq. ++> can-return-zero-for-an-empty-input
     malloc.of
       0
-      Q.input.copied > [m]
-        bytes.as-input --
+      copied. > [m]
+        input --.as-input
         m.to-output
     0

--- a/objects/input/dead.eo
+++ b/objects/input/dead.eo
@@ -1,28 +1,26 @@
 # Dead input is an input that reads from nowhere and always
-# returns empty sequence of bytes (`--`). Here `origin` is the input
-# this one is taken off, as in `i.dead`. It is ignored, because a dead
-# input reads from nowhere anyway.
+# returns empty sequence of bytes (`--`). It is a method of `input`, and the
+# input it is taken off is ignored, because a dead input reads from nowhere
+# anyway.
 
-+alias bytes.as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[origin] > dead
+[] > dead
   [size] > read
-    [] >> input-block
+    [^] >> input-block
       -- > @
-      input-block > [size] > read
+      ^.^.input-block > [^ size] > read
     | > @
 
   eq. ++> can-be-taken-off-any-input
     read.
       dead.
-        input
-          bytes.as-input 01-02-03
+        input 01-02-03.as-input
       10
     --
 

--- a/objects/input/length.eo
+++ b/objects/input/length.eo
@@ -1,40 +1,45 @@
-# Reads all the bytes from provided `input` and returns its length.
+# Reads all the bytes from an input and returns its length. It is a method of
+# `input`, and `origin` is the input it is taken off. Bytes are pulled in
+# 1 MiB chunks: since each chunk costs one level of recursion, a chunk this
+# large keeps an ordinary multi-megabyte or few-gigabyte input well inside
+# the evaluation stack instead of one recursive call per 4 KiB.
 
-+alias bytes.as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > length
-  [input length] >> rec-read
+[^] > length
+  [^ input length] >> rec-read
     if. > @
       chunk.size.eq 0
       length
-      rec-read
+      ^.rec-read
         chunk
         length.plus chunk.size
     ^. > chunk
       read.
-        input.read 4096
+        input.read 1048576
   | > @
-    input
+    origin
     0
+  ^ > origin
 
   eq. ++> can-read-all-bytes-and-return-the-length
-    Q.input.length
-      bytes.as-input 01-02-03-04-05-06-07-08-09-10
+    length.
+      input 01-02-03-04-05-06-07-08-09-10.as-input
     10
 
   eq. ++> can-copy-all-bytes-to-an-output-and-return-the-length
     malloc.of
       10
       seq * > [m]
-        Q.input.length
-          Q.input.tee
-            bytes.as-input 01-02-03-04-05-06-07-08-09-10
-            m.to-output
+        length.
+          input
+            tee.
+              input 01-02-03-04-05-06-07-08-09-10.as-input
+              m.to-output
         m
     01-02-03-04-05-06-07-08-09-10

--- a/objects/input/tee.eo
+++ b/objects/input/tee.eo
@@ -1,50 +1,51 @@
-# Tee input is an input that reads from provided `input`,
-# writes to provided `output` and behaves as provided `input`.
+# Tee input is an input that reads from the input it is taken off, writes to
+# provided `output` and behaves as that same input. It is a method of
+# `input`, and `origin` is the input it is taken off.
 # To copy bytes input to memory you can do:
 # ```
 # malloc.of > copied
 #   5
 #   [m]
 #     read. > @
-#       tee
-#         bytes.as-input 01-02-03-04-05
+#       tee.
+#         input 01-02-03-04-05.as-input
 #         m.to-output
 #       5
 # ```
 # After dataization `copied` is equal to `01-02-03-04-05` which are read
 # from memory.
 
-+alias bytes.as-input
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input output] > tee
-  [size] > read
+[^ output] > tee
+  ^ > origin
+  [^ size] > read
     read. > @
       input-block
-        input
-        output
+        ^.origin
+        ^.output
         --
       size
-    [input output buffer] > input-block
+    [^ input output buffer] > input-block
       buffer > @
-      [size] > read
+      [^ size] > read
         seq * > @
           written
-          input-block chunk written chunk.as-bytes
-        ^. (input.read size).read > chunk
-        ^. (output.write chunk).write > written
+          ^.^.input-block chunk written chunk.as-bytes
+        ^. (^.input.read size).read > chunk
+        ^. (^.output.write chunk).write > written
 
   eq. ++> can-read-from-bytes-and-write-to-memory
     malloc.of
       5
       read. > [mem]
-        Q.input.tee
-          bytes.as-input 01-02-03-04-05
+        tee.
+          input 01-02-03-04-05.as-input
           mem.to-output
         5
     01-02-03-04-05
@@ -56,8 +57,8 @@
         read.
           read.
             read.
-              Q.input.tee
-                bytes.as-input 01-02-03-04-05
+              tee.
+                input 01-02-03-04-05.as-input
                 m.to-output
               2
             2
@@ -72,12 +73,12 @@
         [m1]
           malloc.of > @
             5
-            seq * > [m2] >>
+            seq * > [^ m2] >>
               read.
-                Q.input.tee
-                  Q.input.tee (bytes.as-input 01-02-03-04-05) m2.to-output
-                  m1.to-output
+                tee.
+                  input ((input 01-02-03-04-05.as-input).tee m2.to-output)
+                  ^.m1.to-output
                 5
-              m1.write 5 2A-
-              m1
+              ^.m1.write 5 2A-
+              ^.m1
       01-02-03-04-05-2A

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -54,12 +54,11 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > malloc
   malloc.of > [scope] > empty
@@ -69,10 +68,11 @@
     malloc.of > @
       size.
         object >> bts!
-      seq * > [m] >>
+      seq * > [^ m] >>
         m.write 0 bts
-        scope m
+        ^.scope m
   [] > of /Q.bytes
+    ? > ^
     ? > size /Q.number
     ? > scope /{Q.chunk}
 
@@ -82,7 +82,7 @@
       [b]
         malloc.of > @
           10
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             m.size.eq 10
 
   malloc.empty ++> can-allocate-an-empty-block
@@ -102,9 +102,9 @@
       seq * > @
         a.neg.neg.neg.neg.eq 42
         m
-      seq * > [] > a
-        m.put
-          m.as-number.plus 1
+      seq * > [^] > a
+        ^.m.put
+          ^.m.as-number.plus 1
         42
 
   ++> can-concat-strings-with-an-offset
@@ -113,10 +113,10 @@
       [b]
         malloc.of > @
           3
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write 0 "XXX"
             m.write 1 "Y"
-            b.put
+            ^.b.put
               eq.
                 m.read 0 3
                 "XYX"
@@ -157,8 +157,8 @@
             * second second
           malloc.of > second
             1
-            f.put > [s] >>
-              f.as-number.plus 1
+            ^.f.put > [^ s] >>
+              ^.f.as-number.plus 1
 
   ++> can-decrease-the-block-size
     malloc.of > @
@@ -166,7 +166,7 @@
       [b]
         malloc.for > @
           01-02-03-04-05
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             and.
               eq. (m.resized 3).size 3
               m.get.eq 01-02-03
@@ -175,10 +175,10 @@
     eq. > @
       malloc.for
         7
-        [m] >>
+        [^ m] >>
           m.put > @
             num.times num
-          number (inc m)! > num
+          number (^.inc m)! > num
       64
     seq * > [x] > inc
       x.put
@@ -201,7 +201,7 @@
       [b]
         malloc.for > @
           01-02-03-04
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             and.
               eq. (m.resized 6).size 6
               m.get.eq 01-02-03-04-00-00
@@ -251,25 +251,34 @@
       [b]
         malloc.of > @
           10
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write 2 "Hello"
-            b.put
+            ^.b.put
               eq.
                 m.read 2 5
                 "Hello"
+
+  eq. ++> can-recover-from-reading-over-the-limit
+    01-02
+    malloc.of
+      1
+      m.read > [m]
+        0
+        10
+        01-02 > [ex]
 
   ++> can-recurse-without-arguments
     eq. > @
       malloc.for
         4
-        func m > [m] >>
+        func m > [^ m] >>
       0
-    if. > [n] >> func
+    if. > [^ n] >> func
       n.as-number.gt 0
       seq *
         n.put
           n.as-number.minus 1
-        func n
+        ^.func n
       n
 
   eq. ++> can-return-the-size-from-a-scope
@@ -293,21 +302,15 @@
       [b]
         malloc.of > @
           12
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write
               0
               "Hello, "
             m.write 7 "Jeff!"
-            b.put
+            ^.b.put
               eq.
                 m.read 0 12
                 "Hello, Jeff!"
-
-  malloc.of ++> can-write-beyond-an-offset-and-resize
-    1
-    seq * > [m]
-      m.write 1 true
-      m.size.eq 2
 
   ++> can-write-into-a-block-made-by-of
     mem.eq 10 > @
@@ -332,17 +335,8 @@
   eq. ++> can-write-the-initial-value
     malloc.for
       42
-      m > [m]
+      I
     42
-
-  eq. ++> rejects-reading-over-the-limit
-    01-02
-    malloc.of
-      1
-      m.read > [m]
-        0
-        10
-        01-02 > [ex]
 
   malloc.of --> stops-on-changing-the-size-to-a-fraction
     1
@@ -368,7 +362,7 @@
 
   malloc.for --> stops-on-overflowing-a-bool-block
     false
-    m.put 8.612486788E7 > [m]
+    m.put 8.612486788e7 > [m]
 
   malloc.for --> stops-on-overflowing-a-string-block
     "Hello"
@@ -380,3 +374,9 @@
     m.read > [m]
       0
       100
+
+  malloc.of --> stops-on-writing-beyond-an-offset
+    1
+    m.write > [m]
+      1
+      true

--- a/objects/map.eo
+++ b/objects/map.eo
@@ -9,109 +9,97 @@
 # hash code is derived from those bytes rather than from the key itself,
 # so that keys with side effects are never evaluated more than once.
 
-+alias tuple.filtered
-+alias bytes.hash
-+alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint decorated-formation
-+unlint mandatory-package
 
 [pairs] > map
-  [] > @
-    ctor > @
-      if.
-        pairs.length.eq 0
-        *
-        @.
-          [tup] >> rec-rebuild
-            if. > @
-              tup.length.eq 0
-              *
-              others.with
-                [] >>
-                  ^.hash > hash
-                  ^.kbts > kbts
-                  tup.head.key > key
-                  tup.head.value > value
-            bytes.hash >> hash!
-              tup.head.key.as-bytes >> kbts!
-            tuple.filtered > others
-              prev
-              not. > [ent] >>
-                and.
-                  ent.hash.eq hash
-                  ent.kbts.eq kbts
-            @. > prev
-              rec-rebuild tup.tail
-          | pairs
-  [entries] > ctor
-    [key] > found
-      if. > @
-        size.eq 0
-        not-found
-        [tup] >> rec-key-search
+  ctor > @
+    if.
+      pairs.length.eq 0
+      *
+      @.
+        [^ tup] >> rec-rebuild
           if. > @
             tup.length.eq 0
-            not-found
+            *
+            others.with
+              [^] >>
+                ^.hash > hash
+                ^.kbts > kbts
+                ^.tup.head.key > key
+                ^.tup.head.value > value
+          hash. >> hash!
+            tup.head.key.as-bytes >> kbts!
+          prev.filtered > others
+            not. > [^ ent] >>
+              and.
+                ent.hash.eq hash
+                ent.kbts.eq kbts
+          @. > prev
+            ^.rec-rebuild tup.tail
+        | pairs
+  [entries] > ctor
+    [^ key] > found
+      if. > @
+        ^.size.eq 0
+        not-found
+        [^ tup] >> rec-key-search
+          if. > @
+            tup.length.eq 0
+            ^.not-found
             prev.exists.if
               prev
               if.
                 and.
                   tup.head.hash.eq hash
                   tup.head.kbts.eq kbts
-                [] >>
+                [^] >>
                   true > exists
-                  tup.head.value > [cant-get] > get
-                not-found
+                  ^.^.tup.head.value > [^ cant-get] > get
+                ^.not-found
           @. > prev
-            rec-key-search tup.tail
-        | entries
-      bytes.hash >> hash!
+            ^.rec-key-search tup.tail
+        | ^.entries
+      hash. >> hash!
         key.as-bytes >> kbts!
-      [] > not-found
+      [^] > not-found
         false > exists
-        cant-get > [cant-get] > get
+        cant-get > [^ cant-get] > get
           "Object by hash code %d from given key does not exists".printf
             * hash
-    exists. > [key] > has
-      found key
-    tuple.mapped > keys
-      entries
+    exists. > [^ key] > has
+      ^.found key
+    entries.mapped > keys
       entry.key > [entry]
     entries.length > size
-    tuple.mapped > values
-      entries
+    entries.mapped > values
       entry.value > [entry]
-    [key value] > with
+    [^ key value] > with
       map.ctor > @
         with.
-          tuple.filtered
-            entries
-            not. > [entry] >>
+          ^.entries.filtered
+            not. > [^ entry] >>
               and.
                 hash.eq entry.hash
                 kbts.eq entry.kbts
-          [] >>
+          [^] >>
             ^.hash > hash
             ^.kbts > kbts
             ^.key > key
             ^.value > value
-      bytes.hash >> hash!
+      hash. >> hash!
         key.as-bytes >> kbts!
-    [key] > without
+    [^ key] > without
       map.ctor > @
-        tuple.filtered
-          entries
-          not. > [entry] >>
+        ^.entries.filtered
+          not. > [^ entry] >>
             and.
               hash.eq entry.hash
               kbts.eq entry.kbts
-      bytes.hash >> hash!
+      hash. >> hash!
         key.as-bytes >> kbts!
   [key value] > entry
 
@@ -145,6 +133,14 @@
       map.entry "two" 2
       map.entry "three" 3
 
+  not. ++> can-find-no-element-by-an-absent-key
+    exists.
+      found.
+        map *
+          map.entry "one" 1
+          map.entry "two" 2
+        "three"
+
   ++> can-find-the-value-of-each-key-with-colliding-hashes
     and. > @
       1.eq first.get
@@ -160,6 +156,19 @@
       map.entry "one" 1
       map.entry "two" 2
     "two"
+
+  not. ++> can-have-no-absent-key-colliding-with-a-stored-one
+    has.
+      map *
+        map.entry "Aa" 1
+      "BB"
+
+  not. ++> can-have-no-element-by-an-absent-key
+    has.
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "three"
 
   ++> can-keep-both-keys-with-colliding-hashes
     2.eq mp.size > @
@@ -200,6 +209,23 @@
               m.put
                 m.as-number.plus 1
               1
+
+  eq. ++> can-recover-from-an-absent-key-colliding-with-a-stored-one
+    "recovered"
+    get.
+      found.
+        map *
+          map.entry "Aa" 1
+        "BB"
+      "recovered" > [message]
+
+  ++> can-recover-from-getting-a-missing-key
+    "recovered".eq > @
+      get.
+        mp.found "absent"
+        "recovered" > [message]
+    map * > mp
+      map.entry "one" 1
 
   ++> can-remove-an-element-by-a-key
     and. > @
@@ -258,51 +284,13 @@
       3
       4
 
-  eq. ++> cannot-change-without-an-absent-element
+  eq. ++> can-stay-unchanged-without-an-absent-element
     size.
       without.
         map *
           map.entry "one" 1
         "two"
     1
-
-  not. ++> cannot-find-an-element-by-an-absent-key
-    exists.
-      found.
-        map *
-          map.entry "one" 1
-          map.entry "two" 2
-        "three"
-
-  not. ++> cannot-have-an-absent-key-colliding-with-a-stored-one
-    has.
-      map *
-        map.entry "Aa" 1
-      "BB"
-
-  not. ++> cannot-have-an-element-by-an-absent-key
-    has.
-      map *
-        map.entry "one" 1
-        map.entry "two" 2
-      "three"
-
-  eq. ++> rejects-an-absent-key-colliding-with-a-stored-one
-    "recovered"
-    get.
-      found.
-        map *
-          map.entry "Aa" 1
-        "BB"
-      "recovered" > [message]
-
-  ++> rejects-getting-a-missing-key
-    "recovered".eq > @
-      get.
-        mp.found "absent"
-        "recovered" > [message]
-    map * > mp
-      map.entry "one" 1
 
   --> stops-on-getting-a-missing-key
     get. > @

--- a/objects/mktemp.eo
+++ b/objects/mktemp.eo
@@ -9,10 +9,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > mktemp
   directory > @
@@ -27,9 +26,9 @@
                 if.
                   userprofile.eq empty
                   "C:\\Windows"
-                  getenv "USERPROFILE" >> userprofile!
-                getenv "TEMP" >> temp!
-              getenv "TMP" >> tmp!
+                  getenv "USERPROFILE" empty >> userprofile!
+                getenv "TEMP" empty >> temp!
+              getenv "TMP" empty >> tmp!
             if.
               tmpdir.eq empty
               if.
@@ -39,16 +38,80 @@
                   if.
                     tempdir.eq empty
                     "/tmp"
-                    getenv "TEMPDIR" >> tempdir!
+                    getenv "TEMPDIR" empty >> tempdir!
                   temp
                 tmp
-              getenv "TMPDIR" >> tmpdir!
+              getenv "TMPDIR" empty >> tmpdir!
           -- > empty
 
   mktemp.tmpfile.exists ++> can-create-a-temp-file
+
+  ++> can-create-a-tmpfile-directly-inside-the-temp-directory
+    seq * > @
+      same
+      temp.deleted
+      same
+    temp.as-path.dirname.eq mktemp.path > same!
+    mktemp.tmpfile > temp
+
+  ++> can-create-tmpfiles-with-distinct-paths-across-calls
+    seq * > @
+      first.exists.and second.exists
+      first.deleted
+      second.deleted
+      different
+    not. > different!
+      first.path.eq second.path
+    mktemp.tmpfile > first
+    mktemp.tmpfile > second
+
+  ++> can-keep-the-temp-directory-after-deleting-a-tmpfile
+    seq * > @
+      temp.deleted
+      mktemp.exists
+    mktemp.tmpfile > temp
 
   mktemp.is-directory ++> can-point-at-a-global-temp-directory
 
   mktemp.exists ++> can-point-at-an-existing-global-temp-directory
 
+  ++> can-report-being-a-directory-consistently-across-repeated-calls
+    mktemp.is-directory.eq mktemp.is-directory > @
+
+  mktemp.exists.eq ++> can-report-existing-consistently-across-repeated-calls
+    mktemp.exists
+
+  eq. ++> can-resolve-a-child-path-under-the-temp-directory
+    mktemp.as-path.resolved "eo-mktemp-child"
+    path.joined
+      * mktemp.path "eo-mktemp-child"
+
+  ++> can-return-a-tmpfile-whose-path-differs-from-the-temp-directory-path
+    seq * > @
+      different
+      temp.deleted
+      different
+    not. > different!
+      temp.path.eq mktemp.path
+    mktemp.tmpfile > temp
+
+  ++> can-return-a-tmpfile-with-a-non-empty-basename
+    seq * > @
+      named
+      temp.deleted
+      named
+    temp.as-path.basename.length.gt 0 > named!
+    mktemp.tmpfile > temp
+
+  mktemp.as-path.eq ++> can-return-the-same-path-through-as-path-and-path
+    mktemp.path
+
   mktemp.path.eq mktemp.path ++> can-return-the-same-temp-directory
+
+  ++> can-tell-that-a-fresh-tmpfile-is-not-a-directory
+    seq * > @
+      regular
+      temp.deleted
+      regular
+    temp.is-directory.not > regular!
+    mktemp.tmpfile > temp

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -3,10 +3,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > nan
   7F-F8-00-00-00-00-00-00

--- a/objects/ninf.eo
+++ b/objects/ninf.eo
@@ -4,10 +4,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > ninf
   FF-F0-00-00-00-00-00-00

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -14,10 +14,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [x] > nop
   true > @

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -3,26 +3,27 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > number
   as-bytes > @
   as-i32.as-i16 > as-i16
-  as-i32. > as-i32
-    number.as-i64 $
+  $.as-i64.as-i32 > as-i32
   [] > div /Q.number
+    ? > ^
     ? > x /Q.number
   [] > gt /Q.bool
+    ? > ^
     ? > x /Q.number
   [] > plus /Q.number
+    ? > ^
     ? > x /Q.number
   [] > times /Q.number
+    ? > ^
     ? > x /Q.number
 
   eq. ++> can-add-a-negative-float-to-negative-infinity
@@ -76,11 +77,6 @@
     pinf.plus pinf
     pinf
 
-  lt. ++> can-approximate-a-square-root
-    abs.
-      9.sqrt.minus 3
-    1.0E-9
-
   pinf.gt 42.5 ++> can-be-greater-than-a-float-when-positive-infinity
 
   eq. ++> can-be-greater-than-a-smaller-integer
@@ -99,10 +95,10 @@
       if. > @
         n.lt 3
         small n
-        if. > [n minus1 minus2] >> rec
+        if. > [^ n minus1 minus2] >> rec
           n.eq 3
           minus1.plus minus2
-          rec
+          ^.rec
             n.minus 1
             minus1.plus minus2
             minus1
@@ -116,13 +112,13 @@
     eq. > @
       fibo 4
       3
-    if. > [n] > fibo
+    if. > [^ n] > fibo
       n.lt 3
       1
       plus.
-        fibo
+        ^.fibo
           n.minus 1
-        fibo
+        ^.fibo
           n.minus 2
 
   42.as-bytes.eq 42 ++> can-compare-its-bytes-to-an-integer
@@ -356,61 +352,45 @@
     pinf.times pinf
     pinf
 
-  eq. ++> can-raise-to-a-power
-    2.power 4
-    16
-
-  eq. ++> can-raise-to-a-power-through-the-package
-    number.power
-      2
-      5
-    32
-
-  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative
-
-  eq. ++> can-take-the-modulo-of-two-numbers
-    7.mod 3
-    1
-
-  eq. ++> cannot-be-greater-than-a-float-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-a-float-when-negative-infinity
     ninf.gt 42.5
     false
 
-  eq. ++> cannot-be-greater-than-a-larger-integer
+  eq. ++> can-tell-it-is-not-greater-than-a-larger-integer
     not.
       0.gt 100
     true
 
-  eq. ++> cannot-be-greater-than-a-number-when-nan
+  eq. ++> can-tell-it-is-not-greater-than-a-number-when-nan
     nan.gt 42
     false
 
-  eq. ++> cannot-be-greater-than-an-equal-integer
+  eq. ++> can-tell-it-is-not-greater-than-an-equal-integer
     not.
       0.gt 0
     true
 
-  eq. ++> cannot-be-greater-than-an-integer-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-an-integer-when-negative-infinity
     ninf.gt 42
     false
 
-  not. ++> cannot-be-greater-than-itself-when-negative-infinity
+  not. ++> can-tell-it-is-not-greater-than-itself-when-negative-infinity
     ninf.gt ninf
 
-  not. ++> cannot-be-greater-than-itself-when-positive-infinity
+  not. ++> can-tell-it-is-not-greater-than-itself-when-positive-infinity
     pinf.gt pinf
 
-  eq. ++> cannot-be-greater-than-nan-when-nan
+  eq. ++> can-tell-it-is-not-greater-than-nan-when-nan
     nan.gt nan
     false
 
-  eq. ++> cannot-be-greater-than-nan-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-nan-when-negative-infinity
     ninf.gt nan
     false
 
-  not. ++> cannot-be-greater-than-nan-when-positive-infinity
+  not. ++> can-tell-it-is-not-greater-than-nan-when-positive-infinity
     pinf.gt nan
 
-  eq. ++> cannot-be-greater-than-positive-infinity-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-positive-infinity-when-negative-infinity
     ninf.gt pinf
     false

--- a/objects/number/abs.eo
+++ b/objects/number/abs.eo
@@ -3,39 +3,28 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > abs
+[^] > abs
   if. > @
     gte.
-      number num.as-bytes >> value
+      number ^.as-bytes >> value
       0
     0.plus value
     value.neg
 
   eq. ++> can-normalize-the-sign-of-negative-zero
-    as-bytes.
-      abs -0
+    -0.abs.as-bytes
     00-00-00-00-00-00-00-00
 
-  eq. ++> can-take-the-absolute-value-of-a-negative-float
-    abs -17.9
-    17.9
+  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative-float
 
-  eq. ++> can-take-the-absolute-value-of-a-negative-integer
-    abs -3
-    3
+  -3.abs.eq 3 ++> can-take-the-absolute-value-of-a-negative-integer
 
-  eq. ++> can-take-the-absolute-value-of-a-positive-float
-    abs 13.5
-    13.5
+  13.5.abs.eq 13.5 ++> can-take-the-absolute-value-of-a-positive-float
 
-  eq. ++> can-take-the-absolute-value-of-a-positive-integer
-    abs 3
-    3
+  3.abs.eq 3 ++> can-take-the-absolute-value-of-a-positive-integer
 
-  eq. ++> can-take-the-absolute-value-of-zero
-    abs 0
-    0
+  0.abs.eq 0 ++> can-take-the-absolute-value-of-zero

--- a/objects/number/arc-cosine.eo
+++ b/objects/number/arc-cosine.eo
@@ -6,56 +6,57 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > arc-cosine
+[^] > arc-cosine
   minus. > @
     pi.div 2
-    arc-sine num
+    ^.arc-sine
 
-  eq. ++> can-take-an-arc-cosine-of-minus-one
-    arc-cosine -1
-    pi
+  2.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-above-one
+
+  -2.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-below-minus-one
+
+  nan.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-of-nan
+
+  ninf.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-of-negative-infinity
+
+  pinf.arc-cosine.is-nan ++> can-return-nan-for-an-arc-cosine-of-positive-infinity
+
+  -1.arc-cosine.eq pi ++> can-take-an-arc-cosine-of-minus-one
+
+  lt. ++> can-take-an-arc-cosine-of-minus-zero-point-nine-nine-nine
+    abs.
+      minus.
+        -0.999.arc-cosine.times 1000
+        3096.8675
+    1
 
   lt. ++> can-take-an-arc-cosine-of-minus-zero-point-six
-    abs
+    abs.
       minus.
-        times.
-          arc-cosine -0.6
-          1000
+        -0.6.arc-cosine.times 1000
         2214.297
     1
 
-  eq. ++> can-take-an-arc-cosine-of-one
-    arc-cosine 1
-    0
+  1.arc-cosine.eq 0 ++> can-take-an-arc-cosine-of-one
 
   eq. ++> can-take-an-arc-cosine-of-zero
-    arc-cosine 0
+    0.arc-cosine
     pi.div 2
 
-  lt. ++> can-take-an-arc-cosine-of-zero-point-six
-    abs
+  lt. ++> can-take-an-arc-cosine-of-zero-point-nine-nine-nine
+    abs.
       minus.
-        times.
-          arc-cosine 0.6
-          1000
-        927.295
+        0.999.arc-cosine.times 1000
+        44.7251
     1
 
-  is-nan. ++> cannot-take-an-arc-cosine-above-one
-    arc-cosine 2
-
-  is-nan. ++> cannot-take-an-arc-cosine-below-minus-one
-    arc-cosine -2
-
-  is-nan. ++> cannot-take-an-arc-cosine-of-nan
-    arc-cosine nan
-
-  is-nan. ++> cannot-take-an-arc-cosine-of-negative-infinity
-    arc-cosine ninf
-
-  is-nan. ++> cannot-take-an-arc-cosine-of-positive-infinity
-    arc-cosine pinf
+  lt. ++> can-take-an-arc-cosine-of-zero-point-six
+    abs.
+      minus.
+        0.6.arc-cosine.times 1000
+        927.295
+    1

--- a/objects/number/arc-sine.eo
+++ b/objects/number/arc-sine.eo
@@ -7,72 +7,80 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > arc-sine
+[^] > arc-sine
   if. > @
-    lt.
-      number num.as-bytes >> arg
-      0
-    neg.
-      if. >> base
-        gt.
-          abs arg >> magnitude
-          0.5
-        minus.
-          pi.div 2
-          2.times
-            [point] >> series
-              point.times > @
-                poly 1
-              if. > [depth] > poly
-                depth.gt 30
-                1
-                1.plus
-                  times.
-                    div.
-                      times.
+    arg.as-bytes.eq 80-00-00-00-00-00-00-00
+    arg
+    if.
+      arg.lt 0
+      neg.
+        if. >> base
+          arg.abs.gt 0.5
+          minus.
+            pi.div 2
+            2.times
+              [point] >> series
+                times. > @
+                  number
+                    point >> bts!
+                  poly 1
+                if. > [^ depth] > poly
+                  depth.gt 30
+                  1
+                  1.plus
+                    times.
+                      div.
                         times.
-                          minus. (depth.times 2) 1
-                          minus. (depth.times 2) 1
-                        squared
-                      times.
-                        depth.times 2
-                        plus. (depth.times 2) 1
-                    poly (depth.plus 1)
-              point.times point > squared
-            | (sqrt ((1.minus magnitude).div 2))
-        series magnitude
-    base
+                          times.
+                            minus. (depth.times 2) 1
+                            minus. (depth.times 2) 1
+                          ^.squared
+                        times.
+                          depth.times 2
+                          plus. (depth.times 2) 1
+                      ^.poly (depth.plus 1)
+                times. > squared!
+                  number bts
+                  number bts
+              | ((1.minus arg.abs).div 2).sqrt
+          series arg.abs
+      base
+  number ^.as-bytes > arg
 
-  lt. ++> can-behave-as-an-odd-function
-    abs
+  lt. ++> can-behave-as-an-odd-function-when-taking-arc-sine
+    abs.
       times.
-        plus.
-          arc-sine 0.6
-          arc-sine -0.6
+        0.6.arc-sine.plus -0.6.arc-sine
         1000
     1
 
+  2.arc-sine.is-nan ++> can-return-nan-for-an-arc-sine-above-one
+
+  -2.arc-sine.is-nan ++> can-return-nan-for-an-arc-sine-below-minus-one
+
+  nan.arc-sine.is-nan ++> can-return-nan-for-an-arc-sine-of-nan
+
+  ninf.arc-sine.is-nan ++> can-return-nan-for-an-arc-sine-of-negative-infinity
+
+  pinf.arc-sine.is-nan ++> can-return-nan-for-an-arc-sine-of-positive-infinity
+
   lt. ++> can-take-an-arc-sine-of-a-half
-    abs
+    abs.
       minus.
-        times.
-          arc-sine 0.5
-          1000
+        0.5.arc-sine.times 1000
         times.
           pi.div 6
           1000
     1
 
   lt. ++> can-take-an-arc-sine-of-minus-a-half
-    abs
+    abs.
       minus.
-        times.
-          arc-sine -0.5
-          1000
+        -0.5.arc-sine.times 1000
         times.
           neg.
             pi.div 6
@@ -80,52 +88,54 @@
     1
 
   lt. ++> can-take-an-arc-sine-of-minus-one
-    abs
+    abs.
       minus.
-        times.
-          arc-sine -1
-          1000
+        -1.arc-sine.times 1000
         times.
           neg.
             pi.div 2
           1000
     1
 
-  lt. ++> can-take-an-arc-sine-of-one
-    abs
+  lt. ++> can-take-an-arc-sine-of-minus-zero-point-nine
+    abs.
       minus.
-        times.
-          arc-sine 1
-          1000
+        -0.9.arc-sine.times 1000
+        -1119.7695
+    1
+
+  eq. ++> can-take-an-arc-sine-of-negative-zero-preserving-sign
+    0.neg.arc-sine.as-bytes
+    80-00-00-00-00-00-00-00
+
+  lt. ++> can-take-an-arc-sine-of-one
+    abs.
+      minus.
+        1.arc-sine.times 1000
         times.
           pi.div 2
           1000
     1
 
-  eq. ++> can-take-an-arc-sine-of-zero
-    arc-sine 0
-    0
+  0.arc-sine.eq 0 ++> can-take-an-arc-sine-of-zero
 
-  lt. ++> can-take-an-arc-sine-of-zero-point-six
-    abs
+  lt. ++> can-take-an-arc-sine-of-zero-point-nine
+    abs.
       minus.
-        times.
-          arc-sine 0.6
-          1000
-        643.5
+        0.9.arc-sine.times 1000
+        1119.7695
     1
 
-  is-nan. ++> cannot-take-an-arc-sine-above-one
-    arc-sine 2
+  lt. ++> can-take-an-arc-sine-of-zero-point-nine-nine-nine
+    abs.
+      minus.
+        0.999.arc-sine.times 1000
+        1526.0712
+    1
 
-  is-nan. ++> cannot-take-an-arc-sine-below-minus-one
-    arc-sine -2
-
-  is-nan. ++> cannot-take-an-arc-sine-of-nan
-    arc-sine nan
-
-  is-nan. ++> cannot-take-an-arc-sine-of-negative-infinity
-    arc-sine ninf
-
-  is-nan. ++> cannot-take-an-arc-sine-of-positive-infinity
-    arc-sine pinf
+  lt. ++> can-take-an-arc-sine-of-zero-point-six
+    abs.
+      minus.
+        0.6.arc-sine.times 1000
+        643.5
+    1

--- a/objects/number/as-char.eo
+++ b/objects/number/as-char.eo
@@ -1,0 +1,58 @@
+# Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
+# The receiver must be an integer within the range [0, 255]; any other value
+# (negative, above 255, or fractional) terminates the computation instead of
+# being silently truncated to its least-significant byte.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > as-char
+  if. > @
+    or.
+      or.
+        0.gt ^
+        ^.gt 255
+      ^.is-integer.not
+    T
+      "The receiver of as-char must be an integer within the range [0, 255]"
+    ^.as-i64.as-bytes.slice
+      7
+      1
+
+  eq. ++> can-round-trip-through-as-ascii
+    "!"
+    string "!".as-ascii.as-char
+
+  eq. ++> can-write-the-byte-of-a-lowercase-letter
+    "z"
+    string 122.as-char
+
+  eq. ++> can-write-the-byte-of-a-space
+    " "
+    string 32.as-char
+
+  eq. ++> can-write-the-byte-of-an-uppercase-letter
+    "A"
+    string 65.as-char
+
+  eq. ++> can-write-the-byte-of-the-last-printable-character
+    "~"
+    string 126.as-char
+
+  eq. ++> can-write-the-byte-of-the-last-uppercase-letter
+    "Z"
+    string 90.as-char
+
+  eq. ++> can-write-the-byte-of-the-zero-digit
+    "0"
+    string 48.as-char
+
+  256.as-char --> stops-on-a-code-past-the-byte-range
+
+  3.5.as-char --> stops-on-a-fractional-code
+
+  -1.as-char --> stops-on-a-negative-code

--- a/objects/number/as-decimal.eo
+++ b/objects/number/as-decimal.eo
@@ -1,0 +1,140 @@
+# Writes the number `n` as signed decimal digits, truncating its fraction
+# towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
+#
+# The digits are peeled off an `i64`, where division by ten is exact, so every
+# magnitude below `2^63` is written exactly, and not only the magnitudes below
+# `2^53` that a double divides without losing a digit.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > as-decimal
+  n.is-finite.not.if > @
+    T
+      "Can't write a non-finite number as decimal"
+    if.
+      n.eq -9.223372036854776e18
+      "-9223372036854775808".as-bytes
+      if.
+        n.abs.gte 9.223372036854776e18
+        T
+          "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"
+        if.
+          n.abs.lt 9007199254740992
+          if.
+            and.
+              n.lt 0
+              not.
+                truncated.eq 0
+            "-".as-bytes.concat
+              [^ m] >> quick
+                if. > @
+                  m.lt 10
+                  as-char.
+                    m.plus 48
+                  concat.
+                    ^.quick head
+                    as-char.
+                      plus.
+                        m.minus (head.times 10)
+                        48
+                floor. > head
+                  m.div 10
+              | truncated
+            quick truncated
+          if.
+            n.lt 0
+            if. > [^ m] >> negative
+              m.as-number.eq 0
+              digits m
+              "-".as-bytes.concat
+                digits m
+            |
+              as-i64.
+                n.times -1
+                T message > [message] >> failure
+            [^ n] >> digits
+              if. > @
+                n.lt ^.ten
+                as-char.
+                  n.as-number.plus 48
+                concat.
+                  ^.digits q
+                  as-char.
+                    plus. (n.minus (q.times ^.ten)).as-number 48
+              n.div ^.ten failure > bits!
+              i64 bits > q
+            | (n.as-i64 failure)
+  ^ > n
+  10.as-i64 failure > ten!
+  n.abs.floor > truncated
+
+  eq. ++> can-drop-the-sign-of-a-negative-below-one
+    "0"
+    string -0.9.as-decimal
+
+  eq. ++> can-drop-the-sign-of-a-negative-truncating-to-zero
+    "0"
+    string -0.5.as-decimal
+
+  eq. ++> can-truncate-a-negative-fraction
+    "-7"
+    string -7.89.as-decimal
+
+  eq. ++> can-truncate-a-positive-fraction
+    "42"
+    string 42.987.as-decimal
+
+  eq. ++> can-write-a-large-negative-magnitude
+    "-9007199254740992"
+    string -9007199254740992.as-decimal
+
+  eq. ++> can-write-a-magnitude-above-two-to-the-53rd
+    "9007199254740992"
+    string 9007199254740992.as-decimal
+
+  eq. ++> can-write-a-multi-digit-number
+    "31415"
+    string 31415.as-decimal
+
+  eq. ++> can-write-a-negative-number
+    "-42"
+    string -42.as-decimal
+
+  eq. ++> can-write-a-number-with-an-inner-zero
+    "105"
+    string 105.as-decimal
+
+  eq. ++> can-write-a-single-digit
+    "7"
+    string 7.as-decimal
+
+  eq. ++> can-write-the-largest-exactly-representable-magnitude
+    "9007199254740991"
+    string 9007199254740991.as-decimal
+
+  eq. ++> can-write-the-largest-magnitude-below-two-to-the-63rd
+    "9223372036854774784"
+    string 9223372036854774784.as-decimal
+
+  eq. ++> can-write-the-minimum-signed-64-bit-value
+    "-9223372036854775808"
+    string 80-00-00-00-00-00-00-00.as-i64.as-number.as-decimal
+
+  eq. ++> can-write-zero
+    "0"
+    string 0.as-decimal
+
+  1.0e30.as-decimal --> stops-on-a-magnitude-far-past-the-long-range
+
+  9.223372036854776e18.as-decimal --> stops-on-a-magnitude-of-two-to-the-63rd
+
+  nan.as-decimal --> stops-on-nan
+
+  ninf.as-decimal --> stops-on-negative-infinity
+
+  pinf.as-decimal --> stops-on-positive-infinity

--- a/objects/number/as-fixed.eo
+++ b/objects/number/as-fixed.eo
@@ -1,0 +1,313 @@
+# Writes the number `n` as fixed-point decimal with exactly `places` fraction
+# digits, rounding to the nearest unit in the last place, so that `2.5` with
+# four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
+# If `places` is not a finite non-negative integer below 2^53 (negative,
+# fractional, nan, infinite, or too large to reach zero by repeated
+# subtraction of one), the `cant-print` fallback is returned, or the
+# terminator when unbound.
+#
+# The value is split into its integer and fraction parts before scaling, so
+# only the fraction is multiplied by a power of ten and every magnitude that
+# `as-decimal` writes exactly is written exactly here too. A magnitude of
+# 2^63 or larger is past what `as-decimal` can write, so it returns the
+# `cant-print` fallback as well, instead of terminating.
+#
+# The fraction is scaled by at most 10^15, the largest power of ten that
+# keeps the scaled value an exact integer below 2^53, and never by 10^places
+# directly. Only that many digits are peeled off; any place beyond them is a
+# trailing zero. This keeps the digits shared by two calls with different
+# `places` in agreement, instead of drifting as an unfloored accumulator was
+# carried through more divisions the larger `places` was.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ places cant-print] > as-fixed
+  if. > @
+    n.is-finite.not.or
+      huge.or
+        or.
+          0.gt places
+          places.is-integer.not.or
+            places.gt 9007199254740991
+    cant-print
+      n.is-finite.not.if
+        "Can't write a non-finite number as a fixed-point decimal"
+        huge.if
+          "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
+          places.is-finite.if
+            "Can't write a fixed-point decimal with %f fraction places".printf
+              * places
+            "Can't write a fixed-point decimal with a non-finite number of fraction places"
+    if.
+      n.as-bytes.eq 80-00-00-00-00-00-00-00
+      "-".as-bytes.concat
+        [^ a] >> positive
+          if. > @
+            digits.eq scale
+            if. > [^ unit rest] >> written
+              ^.^.places.eq 0
+              unit.as-decimal
+              concat.
+                unit.as-decimal.concat ".".as-bytes
+                concat.
+                  rec-pad rest ^.k --
+                  zeros (^.^.places.minus ^.k) --
+            | (whole.plus 1) 0
+            written whole digits
+          floor. > digits
+            plus.
+              times.
+                a.minus whole
+                scale
+              0.5
+          if. > k
+            ^.places.gt 15
+            15
+            ^.places
+          pow10 k > scale
+          a.floor > whole
+        | 0
+      if.
+        n.lt 0
+        if. > [^ a] >> signed
+          eq.
+            floor.
+              plus.
+                a.times
+                  pow10 ^.places
+                0.5
+            0
+          positive a
+          "-".as-bytes.concat
+            positive a
+        | (n.times -1)
+        positive n
+  n.abs.gte 9.223372036854776e18 > huge
+  ^ > n
+  if. > [^ p] >> pow10
+    p.eq 0
+    1
+    times.
+      ^.pow10
+        as-number.
+          p.minus 1
+      10
+  if. > [^ value count acc] >> rec-pad
+    count.eq 0
+    acc
+    ^.rec-pad
+      floor.
+        value.div 10
+      as-number.
+        count.minus 1
+      concat.
+        as-char.
+          plus.
+            floor.
+              value.minus
+                times. (value.div 10).floor 10
+            48
+        acc
+  if. > [^ count acc] >> zeros
+    count.eq 0
+    acc
+    ^.zeros
+      as-number.
+        count.minus 1
+      acc.concat "0".as-bytes
+
+  eq. ++> can-agree-with-fewer-places-on-their-shared-digits
+    "1.1000000000000000000"
+    string
+      1.1.as-fixed 19
+
+  eq. ++> can-agree-with-more-places-on-their-shared-digits
+    "1.100000000000000000000"
+    string
+      1.1.as-fixed 21
+
+  eq. ++> can-carry-rounding-into-the-integer-part
+    "1.000000"
+    string
+      0.9999999.as-fixed 6
+
+  eq. ++> can-carry-rounding-into-the-integer-part-with-zero-places
+    "1"
+    string
+      0.9999999.as-fixed 0
+
+  eq. ++> can-drop-the-sign-of-a-negative-rounding-to-zero
+    "0.00"
+    string
+      -1.0e-4.as-fixed 2
+
+  eq. ++> can-drop-the-sign-of-a-tiny-negative-rounding-to-zero
+    "0.00"
+    string
+      -0.001.as-fixed 2
+
+  eq. ++> can-format-the-error-message-of-a-magnitude-past-the-decimal-range
+    "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
+    9.223372036854776e18.as-fixed
+      0
+      I
+
+  eq. ++> can-format-the-error-message-of-a-non-decrementable-precision
+    "Can't write a fixed-point decimal with 9007199254740992.000000 fraction places"
+    1.25.as-fixed
+      9007199254740992
+      I
+
+  eq. ++> can-format-the-error-message-of-infinite-places
+    "Can't write a fixed-point decimal with a non-finite number of fraction places"
+    3.14159.as-fixed
+      pinf
+      I
+
+  eq. ++> can-format-the-error-message-of-negative-places
+    "Can't write a fixed-point decimal with -2.000000 fraction places"
+    3.14159.as-fixed
+      -2
+      I
+
+  eq. ++> can-honour-custom-places
+    "3.14"
+    string
+      3.14159.as-fixed 2
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places
+    "3"
+    string
+      2.5.as-fixed 0
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places-when-negative
+    "-3"
+    string
+      -2.5.as-fixed 0
+
+  eq. ++> can-pad-the-fraction-with-trailing-zeros
+    "1.250000"
+    string
+      1.25.as-fixed 6
+
+  eq. ++> can-preserve-the-sign-of-an-exact-negative-zero
+    "-0.00"
+    string
+      0.neg.as-fixed 2
+
+  eq. ++> can-recover-from-a-magnitude-past-the-decimal-range
+    "recovered"
+    9.223372036854776e18.as-fixed
+      2
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-negative-number-with-a-non-decrementable-precision
+    "recovered"
+    -1.25.as-fixed
+      9007199254740992
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-non-finite-number
+    "recovered"
+    nan.as-fixed
+      2
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-precision-far-above-the-non-decrementable-bound
+    "recovered"
+    1.25.as-fixed
+      18014398509481984
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-precision-just-above-the-non-decrementable-bound
+    "recovered"
+    1.25.as-fixed
+      9007199254740994
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-precision-that-cannot-be-decremented
+    "recovered"
+    1.25.as-fixed
+      9007199254740992
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-number
+    "recovered"
+    pinf.as-fixed
+      2
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-infinite-places
+    "recovered"
+    1.25.as-fixed
+      pinf
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-negative-places
+    "recovered"
+    3.14159.as-fixed
+      -2
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-non-integer-places
+    "recovered"
+    3.14159.as-fixed
+      2.5
+      "recovered" > [message]
+
+  eq. ++> can-round-to-the-last-place
+    "0.123457"
+    string
+      0.123456789.as-fixed 6
+
+  eq. ++> can-scale-a-magnitude-above-two-to-the-53rd
+    "100000000000000000.000000"
+    string
+      100000000000000000.as-fixed 6
+
+  eq. ++> can-scale-a-negative-magnitude-above-two-to-the-53rd
+    "-100000000000000000.000000"
+    string
+      -100000000000000000.as-fixed 6
+
+  eq. ++> can-tell-positive-zero-from-negative-zero
+    "0.00"
+    string
+      0.as-fixed 2
+
+  eq. ++> can-write-a-fraction-of-places-past-the-double-accumulator-range
+    "123.45600000000000300000"
+    string
+      123.456.as-fixed 20
+
+  eq. ++> can-write-a-negative-value
+    "-2.500000"
+    string
+      -2.5.as-fixed 6
+
+  eq. ++> can-write-a-single-place
+    "2.5"
+    string
+      2.5.as-fixed 1
+
+  eq. ++> can-write-a-whole-number-far-past-the-double-accumulator-range
+    "2.0000000000000000000000000000000000000000"
+    string
+      2.as-fixed 40
+
+  eq. ++> can-write-places-past-the-double-accumulator-range
+    "1.5000000000000000000000000"
+    string
+      1.5.as-fixed 25
+
+  eq. ++> can-write-zero-with-places
+    "0.000000"
+    string
+      0.as-fixed 6
+
+  3.14159.as-fixed -2 --> stops-on-negative-places

--- a/objects/number/as-i64.eo
+++ b/objects/number/as-i64.eo
@@ -7,11 +7,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n cant-convert] > as-i64
+[^ cant-convert] > as-i64
   if. > @
     or.
       eq.
@@ -36,8 +36,9 @@
                   00-10-00-00-00-00-00-00
                 00-10-00-00-00-00-00-00
     cant-convert
-      "Can't convert number %f to i64 because it's out of i64 bounds".printf
-        * n
+      "Can't convert number %s to i64 because it's out of i64 bounds".printf
+        *
+          string n.as-scientific
     if.
       exp.lt 1023
       00-00-00-00-00-00-00-00.as-i64
@@ -53,6 +54,7 @@
                 exp.minus 1075
               mantissa.right
                 1075.minus exp
+  ^ > n
 
   eq. ++> can-convert-a-fraction-below-one-to-zero
     0.5.as-i64.as-bytes
@@ -70,10 +72,16 @@
     -9.223372036854776e18.as-i64.as-bytes
     80-00-00-00-00-00-00-00
 
-  eq. ++> can-convert-the-origin-number
-    as-bytes.
-      as-i64 42
-    00-00-00-00-00-00-00-2A
+  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-convert-the-origin-number
+
+  eq. ++> can-format-the-error-message-of-an-out-of-range-number
+    "Can't convert number 1.000000e30 to i64 because it's out of i64 bounds"
+    1.0e30.as-i64 I
+
+  eq. ++> can-recover-from-an-out-of-range-number
+    "recovered"
+    1.0e30.as-i64
+      "recovered" > [message]
 
   eq. ++> can-truncate-a-negative-toward-zero
     -3.7.as-i64.as-bytes
@@ -82,11 +90,6 @@
   eq. ++> can-truncate-a-positive-toward-zero
     3.7.as-i64.as-bytes
     00-00-00-00-00-00-00-03
-
-  eq. ++> rejects-an-out-of-range-number
-    "recovered"
-    1.0e30.as-i64
-      "recovered" > [message]
 
   1.0e30.as-i64 --> stops-on-converting-a-huge-number
 

--- a/objects/number/as-scientific.eo
+++ b/objects/number/as-scientific.eo
@@ -1,0 +1,142 @@
+# Writes the number `n` in scientific notation, as a mantissa with six fraction
+# digits, the letter `e`, and the power of ten that scales the mantissa back to
+# `n`, so that `1.0e19` becomes `1.000000e19`, and `1e-7` becomes
+# `1.000000e-7`. A magnitude past the range of a signed 64-bit integer is
+# named this way, since `as-decimal` writes only what it spells out digit by
+# digit, and a non-finite number becomes `nan`, `infinity` or `-infinity`,
+# having no digits at all. The mantissa is always normalized to `[1, 10)`, so
+# a magnitude below one carries a negative power, as `5.000000e-1` for `0.5`.
+# A magnitude below the normal range of a `double` is brought up into that range
+# before the mantissa is taken, since the power of ten that would scale it in
+# one step is itself subnormal and carries too few bits to divide by.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > as-scientific
+  n.is-finite.not.if > @
+    n.is-nan.if
+      "nan".as-bytes
+      if.
+        n.lt 0
+        "-infinity".as-bytes
+        "infinity".as-bytes
+    if.
+      or.
+        mantissa.eq "10.000000".as-bytes
+        carried
+      concat.
+        normalized.concat "e".as-bytes
+        as-decimal.
+          plus.
+            number exponent
+            1
+      concat.
+        mantissa.concat "e".as-bytes
+        as-decimal.
+          number exponent
+  10.power 300 > boost!
+  mantissa.eq "-10.000000".as-bytes > carried!
+  minus. > exponent!
+    number raw
+    number shift
+  as-fixed. > mantissa
+    scaled.div
+      10.power
+        number raw
+    6
+  ^ > n
+  carried.as-bool.if > normalized!
+    "-1.000000".as-bytes
+    "1.000000".as-bytes
+  rec-exponent > raw!
+    scaled.abs
+    0
+  if. > [^ m count] >> rec-exponent
+    or.
+      m.eq 0
+      and.
+        m.gte 1
+        m.lt 10
+    count
+    if.
+      m.lt 1
+      ^.rec-exponent
+        m.times 10
+        as-number.
+          count.minus 1
+      ^.rec-exponent
+        m.div 10
+        as-number.
+          count.plus 1
+  tiny.as-bool.if > scaled
+    n.times boost
+    n
+  tiny.as-bool.if > shift!
+    300
+    0
+  and. > tiny!
+    n.abs.lt
+      1.div boost
+    not.
+      n.eq 0
+
+  eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
+    "1.000000e1"
+    string 9.9999996.as-scientific
+
+  eq. ++> can-carry-a-rounded-mantissa-past-the-long-range
+    "1.000000e20"
+    string 9.9999996e19.as-scientific
+
+  eq. ++> can-carry-a-rounded-negative-mantissa-into-the-next-power-of-ten
+    "-1.000000e1"
+    string -9.9999996.as-scientific
+
+  eq. ++> can-carry-a-rounded-negative-mantissa-past-the-long-range
+    "-1.000000e20"
+    string -9.9999996e19.as-scientific
+
+  eq. ++> can-name-a-magnitude-at-the-bottom-of-the-subnormal-range
+    "4.940656e-324"
+    string 4.9e-324.as-scientific
+
+  eq. ++> can-name-a-magnitude-past-the-long-range
+    "1.000000e19"
+    string 1.0e19.as-scientific
+
+  eq. ++> can-name-a-negative-magnitude
+    "-9.223372e18"
+    string -9.223372036854776e18.as-scientific
+
+  eq. ++> can-name-a-negative-small-magnitude-with-a-negative-power
+    "-1.000000e-7"
+    string -1.0e-7.as-scientific
+
+  eq. ++> can-name-a-small-magnitude-with-a-negative-power
+    "1.000000e-7"
+    string 1.0e-7.as-scientific
+
+  eq. ++> can-name-a-subnormal-magnitude
+    "9.999889e-321"
+    string 1.0e-320.as-scientific
+
+  eq. ++> can-name-a-subnormal-magnitude-with-few-significant-bits
+    "9.980126e-322"
+    string 1.0e-321.as-scientific
+
+  eq. ++> can-name-nan
+    "nan"
+    string nan.as-scientific
+
+  eq. ++> can-name-negative-infinity
+    "-infinity"
+    string ninf.as-scientific
+
+  eq. ++> can-name-positive-infinity
+    "infinity"
+    string pinf.as-scientific

--- a/objects/number/cosine.eo
+++ b/objects/number/cosine.eo
@@ -1,33 +1,39 @@
 # Cosine of `num` radians as `org.eolang.number`, taken from the sine of the
-# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2).
+# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2). The
+# finite approximation of `pi` used in that shift misses the exact extremum
+# at zero, so zero is special-cased to return the exact unit value.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > cosine
-  sine > @
-    num.plus
-      pi.div 2
+[^] > cosine
+  if. > @
+    num.eq 0
+    1
+    sine.
+      num.plus
+        pi.div 2
+  ^ > num
 
   lt. ++> can-behave-as-an-even-function
-    abs
+    abs.
       times.
         minus.
-          cosine
+          cosine.
             pi.div 3
-          cosine (pi.div 3).neg
+          cosine. (pi.div 3).neg
         1000
     1
 
-  lt. ++> can-reduce-a-large-angle
-    abs
+  lt. ++> can-reduce-a-large-angle-when-taking-cosine
+    abs.
       minus.
         times.
-          cosine
+          cosine.
             plus.
               pi.times 10
               pi.div 3
@@ -35,56 +41,49 @@
         500
     1
 
+  nan.cosine.is-nan ++> can-return-nan-for-a-cosine-of-nan
+
+  ninf.cosine.is-nan ++> can-return-nan-for-a-cosine-of-negative-infinity
+
+  pinf.cosine.is-nan ++> can-return-nan-for-a-cosine-of-positive-infinity
+
   lt. ++> can-take-a-cosine-of-pi
-    abs
+    abs.
       minus.
-        times.
-          cosine pi
-          1000
+        pi.cosine.times 1000
         -1000
     1
 
   lt. ++> can-take-a-cosine-of-pi-halves
-    abs
+    abs.
       times.
-        cosine
+        cosine.
           pi.div 2
         1000
     1
 
   lt. ++> can-take-a-cosine-of-pi-thirds
-    abs
+    abs.
       minus.
         times.
-          cosine
+          cosine.
             pi.div 3
           1000
         500
     1
 
   lt. ++> can-take-a-cosine-of-seventeen-radians
-    abs
+    abs.
       minus.
-        times.
-          cosine 17
-          1000
+        17.cosine.times 1000
         -275
     1
 
   lt. ++> can-take-a-cosine-of-zero
-    abs
+    abs.
       minus.
-        times.
-          cosine 0
-          1000
+        0.cosine.times 1000
         1000
     1
 
-  is-nan. ++> cannot-take-a-cosine-of-nan
-    cosine nan
-
-  is-nan. ++> cannot-take-a-cosine-of-negative-infinity
-    cosine ninf
-
-  is-nan. ++> cannot-take-a-cosine-of-positive-infinity
-    cosine pinf
+  1.eq 0.cosine ++> can-take-an-exact-cosine-of-zero

--- a/objects/number/degrees.eo
+++ b/objects/number/degrees.eo
@@ -4,50 +4,48 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > degrees
-  div. > @
-    times.
-      number num.as-bytes
-      180
-    pi
+[^] > degrees
+  times. > @
+    div.
+      number ^.as-bytes
+      pi
+    180
+
+  lt. ++> can-convert-a-large-value-to-degrees-without-overflow
+    abs.
+      1.0e306.degrees.minus 5.729577951308232e307
+    1.0e294
 
   lt. ++> can-convert-minus-pi-to-degrees
-    abs
-      minus.
-        degrees pi.neg
-        -180
-    1.0E-4
+    abs.
+      pi.neg.degrees.minus -180
+    1.0e-4
 
   lt. ++> can-convert-pi-halves-to-degrees
-    abs
+    abs.
       minus.
-        degrees
+        degrees.
           pi.div 2
         90
-    1.0E-4
+    1.0e-4
 
   lt. ++> can-convert-pi-to-degrees
-    abs
-      minus.
-        degrees pi
-        180
-    1.0E-4
+    abs.
+      pi.degrees.minus 180
+    1.0e-4
 
   lt. ++> can-convert-two-pi-to-degrees
-    abs
+    abs.
       minus.
-        degrees
+        degrees.
           pi.times 2
         360
-    1.0E-4
+    1.0e-4
 
-  eq. ++> can-convert-zero-to-degrees
-    degrees 0
-    0
+  0.degrees.eq 0 ++> can-convert-zero-to-degrees
 
-  is-nan. ++> cannot-convert-nan-to-degrees
-    degrees nan
+  nan.degrees.is-nan ++> can-return-nan-when-converting-nan-to-degrees

--- a/objects/number/eq.eo
+++ b/objects/number/eq.eo
@@ -6,11 +6,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > eq
+[^ x] > eq
   if. > @
     n.is-nan.or
       is-nan.
@@ -30,15 +30,14 @@
             pzero
           b.eq nzero
       b.eq xbts
+  ^ > n
 
   eq. ++> can-compare-two-different-number-types
     68.eq "12345678"
     false
 
   eq. ++> can-compare-two-numbers-through-the-package
-    eq
-      42
-      42
+    42.eq 42
     true
 
   42.eq 42.as-bytes ++> can-equal-an-integer-through-bytes
@@ -59,27 +58,27 @@
     0.eq 0
     true
 
-  eq. ++> cannot-equal-a-different-integer
+  eq. ++> can-tell-it-does-not-equal-a-different-integer
     not.
       123.eq 42
     true
 
-  not. ++> cannot-equal-a-float-when-negative-infinity
+  not. ++> can-tell-it-does-not-equal-a-float-when-negative-infinity
     ninf.eq 42.5
 
-  not. ++> cannot-equal-a-float-when-positive-infinity
+  not. ++> can-tell-it-does-not-equal-a-float-when-positive-infinity
     pinf.eq 42.5
 
-  not. ++> cannot-equal-a-number-when-nan
+  not. ++> can-tell-it-does-not-equal-a-number-when-nan
     nan.eq 42
 
-  not. ++> cannot-equal-an-integer-when-negative-infinity
+  not. ++> can-tell-it-does-not-equal-an-integer-when-negative-infinity
     ninf.eq 42
 
-  not. ++> cannot-equal-an-integer-when-positive-infinity
+  not. ++> can-tell-it-does-not-equal-an-integer-when-positive-infinity
     pinf.eq 42
 
-  eq. ++> cannot-equal-nan-or-infinities-when-a-float-under-load
+  eq. ++> can-tell-it-does-not-equal-nan-or-infinities-when-a-float-under-load
     and.
       and.
         and.
@@ -117,7 +116,7 @@
         false
     true
 
-  eq. ++> cannot-equal-nan-or-infinities-when-an-integer
+  eq. ++> can-tell-it-does-not-equal-nan-or-infinities-when-an-integer
     and.
       and.
         and.
@@ -143,17 +142,17 @@
         false
     true
 
-  not. ++> cannot-equal-nan-when-nan
+  not. ++> can-tell-it-does-not-equal-nan-when-nan
     nan.eq nan
 
-  not. ++> cannot-equal-nan-when-negative-infinity
+  not. ++> can-tell-it-does-not-equal-nan-when-negative-infinity
     ninf.eq nan
 
-  not. ++> cannot-equal-nan-when-positive-infinity
+  not. ++> can-tell-it-does-not-equal-nan-when-positive-infinity
     pinf.eq nan
 
-  not. ++> cannot-equal-negative-infinity-when-positive-infinity
+  not. ++> can-tell-it-does-not-equal-negative-infinity-when-positive-infinity
     pinf.eq ninf
 
-  not. ++> cannot-equal-positive-infinity-when-negative-infinity
+  not. ++> can-tell-it-does-not-equal-positive-infinity-when-negative-infinity
     ninf.eq pinf

--- a/objects/number/exp.eo
+++ b/objects/number/exp.eo
@@ -3,49 +3,41 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > exp
-  power > @
-    e
-    num
+[^] > exp
+  e.power ^ > @
 
   lt. ++> can-exponentiate-five
-    abs
+    abs.
       minus.
-        power e 5
-        exp 5
-    1.0E-7
+        e.power 5
+        5.exp
+    1.0e-7
 
   lt. ++> can-exponentiate-minus-one
-    abs
+    abs.
       minus.
         1.div e
-        exp -1
-    1.0E-8
+        -1.exp
+    1.0e-8
 
   lt. ++> can-exponentiate-minus-ten
-    abs
+    abs.
       minus.
-        power e -10
-        exp -10
-    1.0E-12
+        e.power -10
+        -10.exp
+    1.0e-12
 
-  eq. ++> can-exponentiate-negative-infinity
-    exp ninf
-    0
+  ninf.exp.eq 0 ++> can-exponentiate-negative-infinity
 
   lt. ++> can-exponentiate-one
-    abs
-      e.minus
-        exp 1
-    1.0E-8
+    abs.
+      e.minus 1.exp
+    1.0e-8
 
-  eq. ++> can-exponentiate-positive-infinity
-    exp pinf
-    pinf
+  pinf.exp.eq pinf ++> can-exponentiate-positive-infinity
 
-  is-nan. ++> cannot-exponentiate-nan
-    exp nan
+  nan.exp.is-nan ++> can-return-nan-when-exponentiating-nan

--- a/objects/number/floor.eo
+++ b/objects/number/floor.eo
@@ -4,23 +4,27 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n] > floor
+[^] > floor
   if. > @
-    n.is-finite.not.or
-      or.
-        n.gte 4503599627370496
-        n.lte -4503599627370496
+    n.as-bytes.eq 80-00-00-00-00-00-00-00
     n
     if.
-      gt.
-        n.as-i64.as-number >> trunc
-        n
-      trunc.minus 1
-      n.as-i64.as-number
+      n.is-finite.not.or
+        or.
+          n.gte 4503599627370496
+          n.lte -4503599627370496
+      n
+      if.
+        gt.
+          n.as-i64.as-number >> trunc
+          n
+        trunc.minus 1
+        n.as-i64.as-number
+  ^ > n
 
   -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
 
@@ -37,6 +41,10 @@
   42.floor.eq 42 ++> can-floor-an-integer
 
   ninf.floor.eq ninf ++> can-floor-negative-infinity
+
+  eq. ++> can-floor-negative-zero-preserving-sign
+    0.neg.floor.as-bytes
+    80-00-00-00-00-00-00-00
 
   pinf.floor.eq pinf ++> can-floor-positive-infinity
 

--- a/objects/number/gte.eo
+++ b/objects/number/gte.eo
@@ -3,15 +3,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > gte
+[^ x] > gte
   or. > @
     n.gt
       x >> value!
     n.eq value
+  ^ > n
 
   eq. ++> can-be-greater-than-or-equal-to-a-float-when-positive-infinity
     pinf.gte 42.5
@@ -41,35 +42,35 @@
     pinf.gte pinf
     true
 
-  eq. ++> cannot-be-greater-than-or-equal-to-a-float-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-a-float-when-negative-infinity
     ninf.gte 42.5
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-a-larger-integer
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-integer
     not.
       0.gte 10
     true
 
-  eq. ++> cannot-be-greater-than-or-equal-to-a-number-when-nan
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-a-number-when-nan
     nan.gte 42
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-an-integer-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-an-integer-when-negative-infinity
     ninf.gte 42
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-nan
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-nan-when-nan
     nan.gte nan
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-nan-when-negative-infinity
     ninf.gte nan
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-positive-infinity
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-nan-when-positive-infinity
     pinf.gte nan
     false
 
-  eq. ++> cannot-be-greater-than-or-equal-to-positive-infinity-when-negative-infinity
+  eq. ++> can-tell-it-is-not-greater-than-or-equal-to-positive-infinity-when-negative-infinity
     ninf.gte pinf
     false

--- a/objects/number/integral.eo
+++ b/objects/number/integral.eo
@@ -1,55 +1,60 @@
 # Calculates the integral from `a` to `b`.
 # Here `func` is the integration function, `a` is the lower limit,
 # `b` is the upper limit, `n` is the number of partitions of the integration interval.
+# `n` must be smaller than 2^53, because the loop advances its counter by one
+# and larger IEEE-754 integers cannot advance by that amount.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [fun a b n] > integral
   if. > @
-    n.is-finite.and
-      n.is-integer.and
-        n.gt 0
+    and.
+      n.is-finite.and
+        n.is-integer.and
+          n.gt 0
+      n.lt safe
     as-number.
       malloc.of
         8
-        [sum] >>
+        [^ sum] >>
           seq * > @
             while
-              if. > [i] >>
-                i.lt n
+              if. > [^ i] >>
+                i.lt ^.^.n
                 seq *
-                  sum.put
-                    sum.as-number.plus
+                  ^.sum.put
+                    ^.sum.as-number.plus
                       subsection
-                        a.plus (i.times step)
-                        a.plus ((i.plus 1).times step)
+                        ^.^.a.plus (i.times ^.step)
+                        ^.^.a.plus ((i.plus 1).times ^.step)
                   true
                 false
               true > [i]
             sum
-          as-number. > step
+          as-number. > step!
             div.
-              b.minus a
-              n
+              ^.b.minus ^.a
+              ^.n
     T
-      "the number of partitions must be a finite positive integer"
-  times. > [a b] >> subsection
+      "the number of partitions must be a finite positive integer smaller than 2^53"
+  9007199254740992 > safe
+  times. > [^ a b] >> subsection
     div.
       b.minus a
       6
     plus.
-      fun a
+      ^.fun a
       plus.
         4.times
-          fun
+          ^.fun
             0.5.times
               a.plus b
-        fun b
+        ^.fun b
 
   ++> can-integrate-a-cubic-function
     close-to > @
@@ -62,11 +67,11 @@
           10
           100
       2499.75
-      1.0E-7
+      1.0e-7
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -79,16 +84,16 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           1
           10
           15
       49.5
-      1.0E-7
+      1.0e-7
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -106,11 +111,11 @@
           10
           100
       333
-      1.0E-7
+      1.0e-7
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -123,16 +128,16 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           0
           1
           1
       0.5
-      1.0E-7
+      1.0e-7
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -145,16 +150,16 @@
     close-to > @
       as-number.
         integral
-          x > [x]
+          I
           0
           10
           10
       50
-      1.0E-7
+      1.0e-7
     [value operand err] > close-to
       lte. > @
         minus.
-          abs
+          abs.
             value.minus operand
           err
         0
@@ -163,38 +168,48 @@
         value
         value.neg
 
+  eq. ++> can-recover-from-partitions-at-the-precision-boundary
+    "recovered"
+    recovered
+      integral
+        I
+        0
+        1
+        9007199254740992
+      "recovered"
+
   integral --> stops-on-fractional-partitions
-    x > [x]
+    I
     0
     1
     1.5
 
   integral --> stops-on-nan-partitions
-    x > [x]
+    I
     0
     1
     nan
 
   integral --> stops-on-negative-partitions
-    x > [x]
+    I
     0
     1
     -1
 
   integral --> stops-on-negatively-infinite-partitions
-    x > [x]
+    I
     0
     1
     ninf
 
   integral --> stops-on-positively-infinite-partitions
-    x > [x]
+    I
     0
     1
     pinf
 
   integral --> stops-on-zero-partitions
-    x > [x]
+    I
     0
     1
     0

--- a/objects/number/is-finite.eo
+++ b/objects/number/is-finite.eo
@@ -1,27 +1,41 @@
-# TRUE when `n` is neither infinite nor not-a-number.
+# TRUE when `n` is a valid eight-byte IEEE-754 value that is neither infinite
+# nor not-a-number. A byte sequence of any other width can never represent a
+# number, so it is not finite: `is-nan` returns FALSE for such widths, which
+# would otherwise let them fall through as finite.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n] > is-finite
-  n.is-nan.not.and > @
-    not.
-      or.
-        n.as-bytes.eq 7F-F0-00-00-00-00-00-00
-        n.as-bytes.eq FF-F0-00-00-00-00-00-00
+[^] > is-finite
+  and. > @
+    n.as-bytes.size.eq 8
+    n.is-nan.not.and
+      not.
+        or.
+          n.as-bytes.eq 7F-F0-00-00-00-00-00-00
+          n.as-bytes.eq FF-F0-00-00-00-00-00-00
+  ^ > n
 
   32.is-finite ++> can-be-finite-when-a-simple-number
 
-  not. ++> cannot-be-finite-when-built-of-infinite-bytes
+  not. ++> can-tell-it-is-not-finite-when-a-single-byte
+    is-finite.
+      number FF-
+
+  not. ++> can-tell-it-is-not-finite-when-built-of-infinite-bytes
     is-finite.
       number pinf.as-bytes
 
-  nan.is-finite.not ++> cannot-be-finite-when-nan
+  not. ++> can-tell-it-is-not-finite-when-fewer-than-eight-bytes
+    is-finite.
+      number 00-00
 
-  ninf.is-finite.not ++> cannot-be-finite-when-negative-infinity
+  nan.is-finite.not ++> can-tell-it-is-not-finite-when-nan
 
-  pinf.is-finite.not ++> cannot-be-finite-when-positive-infinity
+  ninf.is-finite.not ++> can-tell-it-is-not-finite-when-negative-infinity
+
+  pinf.is-finite.not ++> can-tell-it-is-not-finite-when-positive-infinity

--- a/objects/number/is-integer.eo
+++ b/objects/number/is-integer.eo
@@ -3,20 +3,21 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n] > is-integer
+[^] > is-integer
   n.is-finite.and > @
     n.eq n.floor
+  ^ > n
 
   32.is-integer ++> can-be-an-integer-when-a-whole-number
 
-  32.5.is-integer.not ++> cannot-be-an-integer-when-a-float
+  32.5.is-integer.not ++> can-tell-it-is-not-an-integer-when-a-float
 
-  nan.is-integer.not ++> cannot-be-an-integer-when-nan
+  nan.is-integer.not ++> can-tell-it-is-not-an-integer-when-nan
 
-  ninf.is-integer.not ++> cannot-be-an-integer-when-negative-infinity
+  ninf.is-integer.not ++> can-tell-it-is-not-an-integer-when-negative-infinity
 
-  pinf.is-integer.not ++> cannot-be-an-integer-when-positive-infinity
+  pinf.is-integer.not ++> can-tell-it-is-not-an-integer-when-positive-infinity

--- a/objects/number/is-nan.eo
+++ b/objects/number/is-nan.eo
@@ -3,11 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n] > is-nan
+[^] > is-nan
   if. > @
     and.
       bts.size.gt 7
@@ -22,7 +22,7 @@
           bts.and 00-0F-FF-FF-FF-FF-FF-FF
           00-00-00-00-00-00-00-00
     false
-  n.as-bytes > bts
+  ^.as-bytes > bts
 
   is-nan. ++> can-be-nan-when-built-of-nan-bytes
     number nan.as-bytes
@@ -76,8 +76,8 @@
 
   nan.floor.as-bytes.eq nan.as-bytes ++> can-be-nan-when-the-floor-of-nan
 
-  42.5.is-nan.not ++> cannot-be-nan-when-a-simple-number
+  42.5.is-nan.not ++> can-tell-it-is-not-nan-when-a-simple-number
 
-  ninf.is-nan.not ++> cannot-be-nan-when-negative-infinity
+  ninf.is-nan.not ++> can-tell-it-is-not-nan-when-negative-infinity
 
-  pinf.is-nan.not ++> cannot-be-nan-when-positive-infinity
+  pinf.is-nan.not ++> can-tell-it-is-not-nan-when-positive-infinity

--- a/objects/number/ln.eo
+++ b/objects/number/ln.eo
@@ -1,17 +1,19 @@
 # Natural logarithm of `num` with base `e` as `org.eolang.number`. The argument
-# is folded into [1/e, e] by peeling whole factors of `e` and counting them,
-# then the remainder is summed with the area-hyperbolic-tangent series. The
-# limiting cases follow the usual conventions: zero is negative infinity, a
-# negative number and negative infinity are nan, and positive infinity stays.
+# is folded into [1/e, e] by peeling powers of `e` that double at each step
+# (e, e^2, e^4, ..., e^512), so the depth is bounded regardless of how large
+# the argument is, then the remainder is summed with the area-hyperbolic-
+# tangent series. The limiting cases follow the usual conventions: zero is
+# negative infinity, a negative number and negative infinity are nan, and
+# positive infinity stays.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > ln
+[^] > ln
   n.is-nan.if > @
     nan
     if.
@@ -26,23 +28,55 @@
   [p] > lnp
     if. > @
       p.gte e
-      plus.
-        lnp
-          p.div e
-        1
+      climb 9 p
       if.
         p.lt
           1.div e
-        minus.
-          lnp
-            p.times e
-          1
+        descend 9 p
         series p
+    if. > [^ level p] > climb
+      level.lt 0
+      ^.series p
+      if.
+        p.gte
+          ^.epow level
+        plus.
+          ^.climb
+            level.minus 1
+            p.div
+              ^.epow level
+          ^.step level
+        ^.climb
+          level.minus 1
+          p
+    if. > [^ level p] > descend
+      level.lt 0
+      ^.series p
+      if.
+        p.lt
+          1.div
+            ^.epow level
+        minus.
+          ^.descend
+            level.minus 1
+            p.times
+              ^.epow level
+          ^.step level
+        ^.descend
+          level.minus 1
+          p
+    [^ level] > epow
+      if. > @
+        level.eq 0
+        e
+        prev.times prev
+      ^.epow > prev
+        level.minus 1
     [m] > series
       2.times > @
         t.times
           horner 0
-      if. > [k] > horner
+      if. > [^ k] > horner
         k.gt 40
         0
         plus.
@@ -51,56 +85,55 @@
               k.times 2
               1
           times.
-            t.times t
-            horner
+            ^.t.times ^.t
+            ^.horner
               k.plus 1
       div. > t
         m.minus 1
         m.plus 1
-  number num.as-bytes > n
+    [^ level] > step
+      if. > @
+        level.eq 0
+        1
+        prev.plus prev
+      ^.step > prev
+        level.minus 1
+  number ^.as-bytes > n
 
-  lt. ++> can-stay-monotonic
-    ln 2
-    ln 3
+  -2.2.ln.is-nan ++> can-return-nan-for-a-logarithm-of-a-negative-float
+
+  -42.ln.is-nan ++> can-return-nan-for-a-logarithm-of-a-negative-integer
+
+  nan.ln.is-nan ++> can-return-nan-for-a-logarithm-of-nan
+
+  ninf.ln.is-nan ++> can-return-nan-for-a-logarithm-of-negative-infinity
+
+  2.ln.lt 3.ln ++> can-stay-monotonic
 
   lt. ++> can-take-a-logarithm-of-a-fraction
-    abs
-      minus.
-        ln 0.5
-        -0.6931471805599453
-    1.0E-11
+    abs.
+      0.5.ln.minus -0.6931471805599453
+    1.0e-11
 
-  eq. ++> can-take-a-logarithm-of-e
-    ln e
-    1
+  lt. ++> can-take-a-logarithm-of-a-very-large-number-without-overflowing-the-stack
+    abs.
+      1.0e300.ln.minus 690.7755278982137
+    1.0e-9
 
-  eq. ++> can-take-a-logarithm-of-one
-    ln 1
-    0
+  lt. ++> can-take-a-logarithm-of-a-very-small-fraction-without-overflowing-the-stack
+    abs.
+      1.0e-300.ln.minus -690.7755278982137
+    1.0e-9
 
-  eq. ++> can-take-a-logarithm-of-positive-infinity
-    ln pinf
-    pinf
+  e.ln.eq 1 ++> can-take-a-logarithm-of-e
+
+  1.ln.eq 0 ++> can-take-a-logarithm-of-one
+
+  pinf.ln.eq pinf ++> can-take-a-logarithm-of-positive-infinity
 
   lt. ++> can-take-a-logarithm-of-twenty
-    abs
-      minus.
-        ln 20
-        2.995732273553991
-    1.0E-11
+    abs.
+      20.ln.minus 2.995732273553991
+    1.0e-11
 
-  eq. ++> can-take-a-logarithm-of-zero
-    ln 0
-    ninf
-
-  is-nan. ++> cannot-take-a-logarithm-of-a-negative-float
-    ln -2.2
-
-  is-nan. ++> cannot-take-a-logarithm-of-a-negative-integer
-    ln -42
-
-  is-nan. ++> cannot-take-a-logarithm-of-nan
-    ln nan
-
-  is-nan. ++> cannot-take-a-logarithm-of-negative-infinity
-    ln ninf
+  0.ln.eq ninf ++> can-take-a-logarithm-of-zero

--- a/objects/number/lt.eo
+++ b/objects/number/lt.eo
@@ -3,13 +3,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > lt
+[^ x] > lt
   0.gt > @
-    n.minus
+    ^.minus
       number x!
 
   ninf.lt 42.5 ++> can-be-less-than-a-float-when-negative-infinity
@@ -22,48 +22,48 @@
     ninf.lt pinf
     true
 
-  eq. ++> cannot-be-less-than-a-float-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-a-float-when-positive-infinity
     pinf.lt 42.5
     false
 
-  eq. ++> cannot-be-less-than-a-number-when-nan
+  eq. ++> can-tell-it-is-not-less-than-a-number-when-nan
     nan.lt 42
     false
 
-  eq. ++> cannot-be-less-than-a-smaller-integer
+  eq. ++> can-tell-it-is-not-less-than-a-smaller-integer
     not.
       10.lt -5
     true
 
-  eq. ++> cannot-be-less-than-an-equal-integer
+  eq. ++> can-tell-it-is-not-less-than-an-equal-integer
     not.
       10.lt 10
     true
 
-  eq. ++> cannot-be-less-than-an-integer-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-an-integer-when-positive-infinity
     pinf.lt 42
     false
 
-  eq. ++> cannot-be-less-than-itself-when-negative-infinity
+  eq. ++> can-tell-it-is-not-less-than-itself-when-negative-infinity
     ninf.lt ninf
     false
 
-  eq. ++> cannot-be-less-than-itself-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-itself-when-positive-infinity
     pinf.lt pinf
     false
 
-  eq. ++> cannot-be-less-than-nan-when-nan
+  eq. ++> can-tell-it-is-not-less-than-nan-when-nan
     nan.lt nan
     false
 
-  eq. ++> cannot-be-less-than-nan-when-negative-infinity
+  eq. ++> can-tell-it-is-not-less-than-nan-when-negative-infinity
     ninf.lt nan
     false
 
-  eq. ++> cannot-be-less-than-nan-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-nan-when-positive-infinity
     pinf.lt nan
     false
 
-  eq. ++> cannot-be-less-than-negative-infinity-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-negative-infinity-when-positive-infinity
     pinf.lt ninf
     false

--- a/objects/number/lte.eo
+++ b/objects/number/lte.eo
@@ -3,15 +3,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > lte
+[^ x] > lte
   or. > @
     n.lt
       x >> value!
     n.eq value
+  ^ > n
 
   eq. ++> can-be-less-than-or-equal-to-a-float-when-negative-infinity
     ninf.lte 42.5
@@ -41,35 +42,35 @@
     pinf.lte pinf
     true
 
-  eq. ++> cannot-be-less-than-or-equal-to-a-float-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-a-float-when-positive-infinity
     pinf.lte 42.5
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-a-number-when-nan
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-a-number-when-nan
     nan.lte 42
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-a-smaller-integer
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-a-smaller-integer
     not.
       0.lte -10
     true
 
-  eq. ++> cannot-be-less-than-or-equal-to-an-integer-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-an-integer-when-positive-infinity
     pinf.lte 42
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-nan-when-nan
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-nan-when-nan
     nan.lte nan
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-nan-when-negative-infinity
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-nan-when-negative-infinity
     ninf.lte nan
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-nan-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-nan-when-positive-infinity
     pinf.lte nan
     false
 
-  eq. ++> cannot-be-less-than-or-equal-to-negative-infinity-when-positive-infinity
+  eq. ++> can-tell-it-is-not-less-than-or-equal-to-negative-infinity-when-positive-infinity
     pinf.lte ninf
     false

--- a/objects/number/minus.eo
+++ b/objects/number/minus.eo
@@ -3,12 +3,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x] > minus
-  n.plus > @
+[^ x] > minus
+  ^.plus > @
     neg.
       number x!
 

--- a/objects/number/mod.eo
+++ b/objects/number/mod.eo
@@ -1,113 +1,190 @@
 # Calculate MOD.
 # An operation that finds the remainder after dividing `x` by `y`. When `y`
 # is zero, the result is the caller-supplied `cant-mod` fallback, or the
-# bottom object when none was provided, which terminates on use.
+# terminator when none was provided, which terminates on use. Otherwise
+# the divisor is doubled until it reaches the dividend and then halved back
+# down, subtracting it from the dividend whenever it fits. Doubling and
+# halving a double are exact, and every subtraction happens while the
+# remainder is below twice the subtracted value, which is exact too, so the
+# answer matches the true remainder for any pair of finite numbers, however
+# far apart their magnitudes are, at the cost of two recursive steps per
+# bit of the quotient. When the dividend is `nan` or infinite, the result is
+# `nan`, regardless of the divisor.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x y cant-mod] > mod
+[^ y cant-mod] > mod
   if. > @
     eq.
       number y.as-bytes >> divisor
       0
     cant-mod
       "cannot calculate mod by zero"
-    divisor.is-finite.not.if
-      x
-      if.
-        gt.
-          number x.as-bytes >> dividend
-          0
-        [] >> abs-mod
-          minus. > @
-            abs dividend >> absx
-            times.
-              abs divisor >> absy
-              floor.
-                absx.div absy
-        abs-mod.neg
+    dividend.is-finite.not.if
+      nan
+      divisor.is-finite.not.if
+        divisor.is-nan.if nan x
+        if.
+          x.as-bytes.eq 80-00-00-00-00-00-00-00
+          x
+          if.
+            gte.
+              number x.as-bytes >> dividend
+              0
+            [^] >> abs-mod
+              shrink > @
+                grow divisor.abs
+                dividend.abs
+              if. > [^ chunk] > grow
+                or.
+                  chunk.gte dividend.abs
+                  not. (chunk.plus chunk).is-finite
+                chunk
+                ^.grow
+                  chunk.plus chunk
+              if. > [^ chunk rest] > shrink
+                chunk.lt divisor.abs
+                rest
+                ^.shrink
+                  chunk.div 2
+                  if.
+                    rest.gte chunk
+                    rest.minus chunk
+                    rest
+            abs-mod.neg
+  ^ > x
+
+  eq. ++> can-recover-from-a-modulo-by-zero
+    "recovered"
+    5.mod
+      0
+      "recovered" > [message]
+
+  is-nan. ++> can-return-nan-when-the-dividend-is-infinite
+    pinf.mod 5
+
+  is-nan. ++> can-return-nan-when-the-dividend-is-nan
+    nan.mod 5
+
+  is-nan. ++> can-return-nan-when-the-divisor-is-nan
+    5.mod nan
+
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-a-finite-divisor
+    as-bytes.
+      0.neg.mod 3
+    80-00-00-00-00-00-00-00
+
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-negative-infinite-divisor
+    as-bytes.
+      0.neg.mod ninf
+    80-00-00-00-00-00-00-00
+
+  eq. ++> can-return-negative-zero-for-negative-zero-dividend-and-positive-infinite-divisor
+    as-bytes.
+      0.neg.mod pinf
+    80-00-00-00-00-00-00-00
+
+  eq. ++> can-return-positive-zero-when-dividend-is-zero
+    as-bytes.
+      0.mod 3
+    0.as-bytes
+
+  eq. ++> can-return-positive-zero-when-dividend-is-zero-and-divisor-is-negative
+    as-bytes.
+      0.mod -3
+    0.as-bytes
 
   ++> can-stay-compatible-with-division
     eq. > @
       plus.
-        mod dividend divisor
+        dividend.mod divisor
         divisor.times (dividend.div divisor).as-i64.as-number
       dividend
     -13 > dividend
     5 > divisor
 
+  is-nan. ++> can-take-a-modulo-by-nan
+    5.mod nan
+
   eq. ++> can-take-a-modulo-by-one
-    mod
-      133
-      1
+    133.mod 1
     0
 
   eq. ++> can-take-a-modulo-of-a-dividend-below-the-divisor
-    mod
-      -1
-      5
+    -1.mod 5
     -1
 
+  eq. ++> can-take-a-modulo-of-a-large-dividend-by-a-fractional-divisor
+    1000000000000000.mod 0.1
+    0.04448884876874218
+
   eq. ++> can-take-a-modulo-of-a-negative-by-positive-infinity
-    mod
-      -5
-      pinf
+    -5.mod pinf
     -5
 
+  eq. ++> can-take-a-modulo-of-a-negative-large-dividend-by-a-fractional-divisor
+    -1000000000000000.mod 0.1
+    -0.04448884876874218
+
   eq. ++> can-take-a-modulo-of-a-positive-by-negative-infinity
-    mod
-      5
-      ninf
+    5.mod ninf
     5
 
   eq. ++> can-take-a-modulo-of-a-positive-by-positive-infinity
-    mod
-      5
-      pinf
+    5.mod pinf
     5
 
   eq. ++> can-take-a-modulo-of-minus-one-by-seven
-    mod
-      -1
-      7
+    -1.mod 7
+    -1
+
+  eq. ++> can-take-a-modulo-of-minus-seven-by-three
+    -7.mod 3
     -1
 
   eq. ++> can-take-a-modulo-of-one-by-two
-    mod
-      1
-      2
+    1.mod 2
+    1
+
+  eq. ++> can-take-a-modulo-of-seven-by-three
+    7.mod 3
     1
 
   eq. ++> can-take-a-modulo-of-sixteen-by-a-large-negative
-    mod
-      16
-      -200
+    16.mod -200
     16
 
+  eq. ++> can-take-a-modulo-of-the-largest-finite-double-by-the-smallest-subnormal
+    1.7976931348623157e308.mod 4.9e-324
+    0
+
   eq. ++> can-take-a-modulo-of-zero-by-a-negative
-    mod
-      0
-      -15
+    0.mod -15
     0
 
   eq. ++> can-take-a-modulo-of-zero-by-five
-    mod
-      0
-      5
+    0.mod 5
     0
 
-  eq. ++> rejects-a-modulo-by-zero
-    "recovered"
-    mod
-      5
-      0
-      "recovered" > [message]
+  eq. ++> can-take-an-exact-modulo-of-a-large-dividend-by-thirteen
+    10000000000000000.mod 13
+    3
 
-  mod --> stops-on-a-modulo-by-zero
+  eq. ++> can-take-an-exact-modulo-of-a-large-dividend-by-three
+    10000000000000000.mod 3
+    1
+
+  eq. ++> can-take-an-exact-modulo-of-a-very-large-dividend-by-seven
+    9200000000000000000.mod 7
     5
-    0
+
+  eq. ++> can-take-an-exact-modulo-of-a-very-large-dividend-by-three
+    9200000000000000000.mod 3
+    2
+
+  5.mod 0 --> stops-on-a-modulo-by-zero

--- a/objects/number/neg.eo
+++ b/objects/number/neg.eo
@@ -3,12 +3,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n] > neg
-  n.times -1 > @
+[^] > neg
+  ^.times -1 > @
 
   ninf.neg.eq pinf ++> can-negate-negative-infinity
 

--- a/objects/number/power.eo
+++ b/objects/number/power.eo
@@ -7,11 +7,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num x] > power
+[^ x] > power
   if. > @
     eq.
       number x.as-bytes >> expo
@@ -28,44 +28,58 @@
                 number num.as-bytes >> base
                 0
               if.
-                expo.gt 0
-                0
-                pinf
+                and.
+                  num.as-bytes.eq 80-00-00-00-00-00-00-00
+                  odd
+                if.
+                  expo.gt 0
+                  0.neg
+                  ninf
+                if.
+                  expo.gt 0
+                  0
+                  pinf
               expo.is-integer.if
                 if.
                   expo.lt 0
-                  1.div
-                    [b n] >> ipow
-                      if. > @
-                        n.eq 0
-                        1
-                        if.
-                          is-integer. (n.div 2)
-                          half.times half
-                          b.times
-                            ipow b (n.minus 1)
-                      ipow b (n.div 2) > half
-                    | base (abs expo)
-                  ipow base (abs expo)
+                  [^ b n] >> ipow
+                    if. > @
+                      n.eq 0
+                      1
+                      if.
+                        is-integer. (n.div 2)
+                        times.
+                          number half
+                          number half
+                        b.times
+                          ^.ipow b (n.minus 1)
+                    ^.ipow b (n.div 2) > half!
+                  | (1.div base) expo.abs
+                  ipow base expo.abs
                 if.
                   base.gt 0
-                  [y] >> expon
+                  [^ y] >> expon
                     times. > @
                       if.
-                        k.lt 0
+                        lt. (number k) 0
                         1.div
-                          ipow e (abs k)
-                        ipow e (abs k)
+                          ipow e (number k).abs
+                        ipow e (number k).abs
                       fraction 1
-                    if. > [j] > fraction
+                    y > arg!
+                    if. > [^ j] > fraction
                       j.gt 20
                       1
                       1.plus
                         times.
-                          div. (y.minus k) j
-                          fraction (j.plus 1)
-                    floor. (y.plus 0.5) > k
-                  | (expo.times (ln base))
+                          div.
+                            minus.
+                              number ^.arg
+                              number ^.k
+                            j
+                          ^.fraction (j.plus 1)
+                    floor. ((number arg).plus 0.5) > k!
+                  | (expo.times base.ln)
                   nan
             if.
               base.gt 0
@@ -83,27 +97,24 @@
           if.
             expo.gt 0
             if.
-              gt.
-                abs base
-                1
+              base.abs.gt 1
               pinf
               if.
-                eq.
-                  abs base
-                  1
+                base.abs.eq 1
                 nan
                 0
             if.
-              gt.
-                abs base
-                1
+              base.abs.gt 1
               0
               if.
-                eq.
-                  abs base
-                  1
+                base.abs.eq 1
                 nan
                 pinf
+  ^ > num
+
+  gt. ++> can-avoid-underflow-for-a-negative-exponent-that-overflows-positive
+    10.power -315
+    0
 
   eq. ++> can-be-called-as-a-method-on-a-number
     2.power 4
@@ -113,279 +124,232 @@
     3.power 2
     9
 
-  eq. ++> can-be-reached-through-the-package
-    power
-      2
-      4
-    16
-
   eq. ++> can-raise-a-float-to-zero
-    power
-      42.5
-      0
+    42.5.power 0
     1
 
+  lt. ++> can-raise-a-fraction-to-a-fraction
+    abs.
+      minus.
+        0.5.power 1.5
+        0.35355339059327373
+    1.0e-9
+
   eq. ++> can-raise-a-negative-float-to-negative-infinity
-    power
-      -42.5
-      ninf
+    -42.5.power ninf
     0
 
   eq. ++> can-raise-a-negative-float-to-positive-infinity
-    power
-      -4.2
-      pinf
+    -4.2.power pinf
     pinf
 
   eq. ++> can-raise-a-negative-integer-to-negative-infinity
-    power
-      -42
-      ninf
+    -42.power ninf
     0
 
   eq. ++> can-raise-a-negative-integer-to-positive-infinity
-    power
-      -10
-      pinf
+    -10.power pinf
     pinf
 
   eq. ++> can-raise-a-positive-float-to-a-positive-integer
-    power
-      3.5
-      4
+    3.5.power 4
     150.0625
 
   eq. ++> can-raise-a-positive-float-to-negative-infinity
-    power
-      42.5
-      ninf
+    42.5.power ninf
     0
 
   eq. ++> can-raise-a-positive-float-to-positive-infinity
-    power
-      42.5
-      pinf
+    42.5.power pinf
     pinf
 
   eq. ++> can-raise-a-positive-integer-to-a-positive-integer
-    power
-      2
-      3
+    2.power 3
     8
 
   eq. ++> can-raise-a-positive-integer-to-negative-infinity
-    power
-      42
-      ninf
+    42.power ninf
     0
 
   eq. ++> can-raise-a-positive-integer-to-positive-infinity
-    power
-      42
-      pinf
+    42.power pinf
     pinf
 
   eq. ++> can-raise-a-zero-base
-    power
-      0
-      145
+    0.power 145
     0
 
   eq. ++> can-raise-an-integer-to-zero
-    power
-      42
-      0
+    42.power 0
     1
 
   eq. ++> can-raise-four-to-five
-    power
-      4
-      5
+    4.power 5
     1024
 
   eq. ++> can-raise-four-to-minus-three
-    power
-      4
-      -3
+    4.power -3
     0.015625
 
   eq. ++> can-raise-negative-infinity-to-a-positive-float
-    power
-      ninf
-      9.9
+    ninf.power 9.9
     pinf
 
   eq. ++> can-raise-negative-infinity-to-an-even-integer
-    power
-      ninf
-      10
+    ninf.power 10
     pinf
 
   eq. ++> can-raise-negative-infinity-to-an-odd-integer
-    power
-      ninf
-      9
+    ninf.power 9
     ninf
 
   eq. ++> can-raise-negative-infinity-to-negative-infinity
-    power
-      ninf
-      ninf
+    ninf.power ninf
     0
 
+  eq. ++> can-raise-negative-zero-to-even-negative
+    -0.power -4
+    pinf
+
+  eq. ++> can-raise-negative-zero-to-even-positive
+    -0.power 4
+    0
+
+  eq. ++> can-raise-negative-zero-to-odd-negative
+    -0.power -3
+    ninf
+
+  eq. ++> can-raise-negative-zero-to-odd-positive
+    -0.power 3
+    -0
+
+  lt. ++> can-raise-one-to-a-fraction
+    abs.
+      minus.
+        1.power 0.75
+        1
+    1.0e-9
+
   eq. ++> can-raise-positive-infinity-to-a-negative-float
-    power
-      pinf
-      -42.2
+    pinf.power -42.2
     0
 
   eq. ++> can-raise-positive-infinity-to-a-negative-integer
-    power
-      pinf
-      -42
+    pinf.power -42
     0
 
   eq. ++> can-raise-positive-infinity-to-a-positive-float
-    power
-      pinf
-      10.8
+    pinf.power 10.8
     pinf
 
   eq. ++> can-raise-positive-infinity-to-a-positive-integer
-    power
-      pinf
-      42
+    pinf.power 42
     pinf
 
   eq. ++> can-raise-positive-infinity-to-negative-infinity
-    power
-      pinf
-      ninf
+    pinf.power ninf
     0
 
   eq. ++> can-raise-positive-infinity-to-positive-infinity
-    power
-      pinf
-      pinf
+    pinf.power pinf
     pinf
 
   eq. ++> can-raise-three-to-two
-    power
-      3
-      2
+    3.power 2
     9
 
   eq. ++> can-raise-to-a-large-negative-exponent
-    power
-      984782
-      -12341
+    984782.power -12341
     0
 
   eq. ++> can-raise-to-a-zero-exponent
-    power
-      2
-      0
+    2.power 0
     1
 
+  lt. ++> can-raise-two-to-a-negative-fraction
+    abs.
+      minus.
+        2.power -0.5
+        0.7071067811865476
+    1.0e-9
+
   eq. ++> can-raise-two-to-four
-    power
-      2
-      4
+    2.power 4
     16
 
   eq. ++> can-raise-two-to-minus-one
-    power
-      2
-      -1
+    2.power -1
     0.5
 
   eq. ++> can-raise-two-to-minus-three
-    power
-      2
-      -3
+    2.power -3
     0.125
 
   eq. ++> can-raise-two-to-minus-two
-    power
-      2
-      -2
+    2.power -2
     0.25
 
+  lt. ++> can-raise-two-to-three-and-a-half
+    abs.
+      minus.
+        2.power 3.5
+        11.313708498984761
+    1.0e-9
+
   eq. ++> can-raise-zero-to-a-negative
-    power
-      0
-      -52
+    0.power -52
     pinf
 
   eq. ++> can-raise-zero-to-a-negative-odd-integer
-    power
-      0
-      -567
+    0.power -567
     pinf
 
   eq. ++> can-raise-zero-to-a-positive-float
-    power
-      0
-      4.2
+    0.power 4.2
     0
 
   eq. ++> can-raise-zero-to-a-positive-integer
-    power
-      0
-      4
+    0.power 4
     0
 
   eq. ++> can-raise-zero-to-negative-infinity
-    power
-      0
-      ninf
+    0.power ninf
     pinf
 
   eq. ++> can-raise-zero-to-positive-infinity
-    power
-      0
-      pinf
+    0.power pinf
     0
 
+  is-nan. ++> can-return-nan-when-raising-a-negative-to-a-fraction
+    -4.power 0.5
+
+  is-nan. ++> can-return-nan-when-raising-anything-to-nan
+    52.power nan
+
+  is-nan. ++> can-return-nan-when-raising-nan-to-anything
+    nan.power 42
+
+  is-nan. ++> can-return-nan-when-raising-nan-to-nan
+    nan.power nan
+
   lt. ++> can-take-a-cube-root-of-twenty-seven
-    abs
+    abs.
       minus.
-        power
-          27
+        27.power
           1.div 3
         3
-    1.0E-9
+    1.0e-9
 
   lt. ++> can-take-a-square-root-of-nine
-    abs
+    abs.
       minus.
-        power 9 0.5
+        9.power 0.5
         3
-    1.0E-9
+    1.0e-9
 
-  lt. ++> can-take-a-square-root-of-two
-    abs
+  lt. ++> can-take-a-square-root-of-two-by-raising-to-a-power
+    abs.
       minus.
-        power 2 0.5
+        2.power 0.5
         1.4142135623730951
-    1.0E-9
-
-  is-nan. ++> cannot-raise-a-negative-to-a-fraction
-    power
-      -4
-      0.5
-
-  is-nan. ++> cannot-raise-anything-to-nan
-    power
-      52
-      nan
-
-  is-nan. ++> cannot-raise-nan-to-anything
-    power
-      nan
-      42
-
-  is-nan. ++> cannot-raise-nan-to-nan
-    power
-      nan
-      nan
+    1.0e-9

--- a/objects/number/radians.eo
+++ b/objects/number/radians.eo
@@ -4,48 +4,44 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > radians
-  div. > @
-    times.
-      number num.as-bytes
-      pi
-    180
+[^] > radians
+  times. > @
+    div.
+      number ^.as-bytes
+      180
+    pi
 
   lt. ++> can-convert-a-full-turn-to-radians
-    abs
-      minus.
-        radians 360
+    abs.
+      360.radians.minus
         pi.times 2
-    1.0E-4
+    1.0e-4
 
   lt. ++> can-convert-a-half-turn-to-radians
-    abs
-      minus.
-        radians 180
-        pi
-    1.0E-4
+    abs.
+      180.radians.minus pi
+    1.0e-4
+
+  lt. ++> can-convert-a-large-value-to-radians-without-overflow
+    abs.
+      1.0e308.radians.minus 1.7453292519943295e306
+    1.0e293
 
   lt. ++> can-convert-a-negative-half-turn-to-radians
-    abs
-      minus.
-        radians -180
-        pi.neg
-    1.0E-4
+    abs.
+      -180.radians.minus pi.neg
+    1.0e-4
 
   lt. ++> can-convert-a-quarter-turn-to-radians
-    abs
-      minus.
-        radians 90
+    abs.
+      90.radians.minus
         pi.div 2
-    1.0E-4
+    1.0e-4
 
-  eq. ++> can-convert-zero-to-radians
-    radians 0
-    0
+  0.radians.eq 0 ++> can-convert-zero-to-radians
 
-  is-nan. ++> cannot-convert-nan-to-radians
-    radians nan
+  nan.radians.is-nan ++> can-return-nan-when-converting-nan-to-radians

--- a/objects/number/random.eo
+++ b/objects/number/random.eo
@@ -3,15 +3,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
-[seed] > random
+[^] > random
   seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
   [clock] > clocked
-    random > @
+    random. > @
       as-number.
         plus.
           as-i64.
@@ -31,7 +30,7 @@
     35 > shift1
     17 > shift3
     clock.as-bytes > tbytes
-  random > next
+  random. > next
     as-number.
       as-i64.
         and.
@@ -52,6 +51,7 @@
               11.as-i64
           00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
+  ^ > seed
 
   not. ++> can-differ-between-two-draws
     eq.
@@ -61,12 +61,11 @@
   ++> can-reach-the-upper-half
     not. > @
       rand.lt 0.5
-    next. > rand
-      random 178609
+    178609.random.next > rand
 
   eq. ++> can-repeat-itself-with-the-same-seed
-    next. (random 1654).next.next
-    next. (random 1654).next.next
+    1654.random.next.next.next
+    1654.random.next.next.next
 
   ++> can-stay-in-range
     and. > @
@@ -83,10 +82,9 @@
         rand.next.next.lt 1
         not.
           rand.next.next.lt 0
-    next. > rand
-      random 123
+    123.random.next > rand
 
   ++> can-use-a-seed
     not. > @
       r.next.eq r.next.next
-    random 51 > r
+    51.random > r

--- a/objects/number/sine.eo
+++ b/objects/number/sine.eo
@@ -1,27 +1,33 @@
 # Sine of `num` radians as `org.eolang.number`.
-# The argument is reduced into the [-pi, pi] range and the Taylor series
-# is summed through Horner's scheme, so the result stays accurate for
-# angles of any magnitude, while non-finite arguments collapse to nan.
+# The argument is reduced into the [-pi, pi] range with a Cody-Waite style
+# two-part reduction constant, and the Taylor series is summed through
+# Horner's scheme. The high part of that constant has 26 trailing zero
+# mantissa bits, so `k times tau_hi` stays exact only while `k` is under
+# `2^26`, which puts the reduction's few-ULP accuracy at |num| up to about
+# 4e8; past that point the product itself rounds and the error lands
+# straight in the reduced angle. Non-finite arguments collapse to nan.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > sine
+[^] > sine
   times. > @
     minus. >> reduced
-      number num.as-bytes >> arg
-      times.
-        floor.
-          plus.
-            arg.div
-              pi.times 2 >> tau
-            0.5
-        tau
-    if. > [depth] >> factor
+      arg.minus
+        times.
+          floor. >> k
+            plus.
+              div.
+                number ^.as-bytes >> arg
+                pi.times 2
+              0.5
+          6.283185303211212
+      k.times 3.968374318722162e-9
+    if. > [^ depth] >> factor
       depth.gt 15
       1
       1.minus
@@ -33,25 +39,30 @@
               plus.
                 depth.times 2
                 1
-          factor
+          ^.factor
             depth.plus 1
     | 1
 
-  lt. ++> can-behave-as-an-odd-function
-    abs
+  lt. ++> can-be-accurate-near-the-documented-four-hundred-million-boundary
+    abs.
+      400000000.sine.minus 0.9965407850188008
+    1.0e-9
+
+  lt. ++> can-behave-as-an-odd-function-when-taking-sine
+    abs.
       times.
         plus.
-          sine
+          sine.
             pi.div 3
-          sine (pi.div 3).neg
+          sine. (pi.div 3).neg
         1000
     1
 
-  lt. ++> can-reduce-a-large-angle
-    abs
+  lt. ++> can-reduce-a-large-angle-when-taking-sine
+    abs.
       minus.
         times.
-          sine
+          sine.
             plus.
               pi.times 10
               pi.div 6
@@ -59,56 +70,63 @@
         500
     1
 
-  lt. ++> can-take-a-sine-of-minus-pi-halves
-    abs
+  lt. ++> can-reduce-a-very-large-angle-with-cody-waite-precision
+    abs.
       minus.
-        times.
-          sine (pi.div 2).neg
-          1000
+        1000000000000000.sine.times 1000
+        858
+    1
+
+  nan.sine.is-nan ++> can-return-nan-for-a-sine-of-nan
+
+  ninf.sine.is-nan ++> can-return-nan-for-a-sine-of-negative-infinity
+
+  pinf.sine.is-nan ++> can-return-nan-for-a-sine-of-positive-infinity
+
+  lt. ++> can-take-a-sine-of-minus-pi-halves
+    abs.
+      minus.
+        times. (pi.div 2).neg.sine 1000
         -1000
     1
 
   lt. ++> can-take-a-sine-of-pi
-    abs
-      times.
-        sine pi
-        1000
+    abs.
+      pi.sine.times 1000
     1
 
   lt. ++> can-take-a-sine-of-pi-halves
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             pi.div 2
           1000
         1000
     1
 
   lt. ++> can-take-a-sine-of-pi-sixths
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             pi.div 6
           1000
         500
     1
 
   lt. ++> can-take-a-sine-of-seventeen-radians
-    abs
+    abs.
       minus.
-        times.
-          sine 17
-          1000
+        17.sine.times 1000
         -961
     1
 
   lt. ++> can-take-a-sine-of-three-pi-halves
-    abs
+    abs.
       minus.
         times.
-          sine
+          sine.
             div.
               pi.times 3
               2
@@ -117,22 +135,11 @@
     1
 
   lt. ++> can-take-a-sine-of-two-pi
-    abs
+    abs.
       times.
-        sine
+        sine.
           pi.times 2
         1000
     1
 
-  eq. ++> can-take-a-sine-of-zero
-    sine 0
-    0
-
-  is-nan. ++> cannot-take-a-sine-of-nan
-    sine nan
-
-  is-nan. ++> cannot-take-a-sine-of-negative-infinity
-    sine ninf
-
-  is-nan. ++> cannot-take-a-sine-of-positive-infinity
-    sine pinf
+  0.sine.eq 0 ++> can-take-a-sine-of-zero

--- a/objects/number/sqrt.eo
+++ b/objects/number/sqrt.eo
@@ -4,70 +4,57 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[num] > sqrt
+[^] > sqrt
   if. > @
-    lt.
-      number num.as-bytes
-      0
+    arg.lt 0
     nan
-    power
-      num
-      0.5
+    if.
+      arg.as-bytes.eq 80-00-00-00-00-00-00-00
+      arg
+      arg.power 0.5
+  number ^.as-bytes > arg
 
   lt. ++> can-approximate-a-square-root-of-four
-    abs
-      2.minus
-        sqrt 4
-    1.0E-11
+    abs.
+      2.minus 4.sqrt
+    1.0e-11
 
   lt. ++> can-approximate-a-square-root-of-zero
-    abs
-      0.minus
-        sqrt 0
-    1.0E-11
+    abs.
+      0.minus 0.sqrt
+    1.0e-11
+
+  -0.1.sqrt.is-nan ++> can-return-nan-for-a-square-root-of-a-negative
+
+  nan.sqrt.is-nan ++> can-return-nan-for-a-square-root-of-nan
+
+  ninf.sqrt.is-nan ++> can-return-nan-for-a-square-root-of-negative-infinity
 
   lt. ++> can-take-a-square-root-of-a-half
-    abs
-      minus.
-        sqrt 0.25
-        0.5
-    1.0E-9
+    abs.
+      0.25.sqrt.minus 0.5
+    1.0e-9
 
   lt. ++> can-take-a-square-root-of-four
-    abs
-      minus.
-        sqrt 4
-        2
-    1.0E-9
+    abs.
+      4.sqrt.minus 2
+    1.0e-9
 
-  eq. ++> can-take-a-square-root-of-one
-    sqrt 1
-    1
+  eq. ++> can-take-a-square-root-of-negative-zero-preserving-sign
+    0.neg.sqrt.as-bytes
+    80-00-00-00-00-00-00-00
 
-  eq. ++> can-take-a-square-root-of-positive-infinity
-    sqrt pinf
-    pinf
+  1.sqrt.eq 1 ++> can-take-a-square-root-of-one
+
+  pinf.sqrt.eq pinf ++> can-take-a-square-root-of-positive-infinity
 
   lt. ++> can-take-a-square-root-of-two
-    abs
-      minus.
-        sqrt 2
-        1.4142135623730951
-    1.0E-9
+    abs.
+      2.sqrt.minus 1.4142135623730951
+    1.0e-9
 
-  eq. ++> can-take-a-square-root-of-zero
-    sqrt 0
-    0
-
-  is-nan. ++> cannot-take-a-square-root-of-a-negative
-    sqrt -0.1
-
-  is-nan. ++> cannot-take-a-square-root-of-nan
-    sqrt nan
-
-  is-nan. ++> cannot-take-a-square-root-of-negative-infinity
-    sqrt ninf
+  0.sqrt.eq 0 ++> can-take-a-square-root-of-zero

--- a/objects/os.eo
+++ b/objects/os.eo
@@ -1,38 +1,37 @@
 # Represents the current operating system.
 
-+alias string.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [] > os
   name > @
   as-bool. > is-linux
     exists.
       next.
-        match.
-          string.regex "/linux/i"
-          name
+        "/linux/i".regex.match name
   as-bool. > is-macos
     exists.
       next.
-        match.
-          string.regex "/mac/i"
-          name
+        "/mac/i".regex.match name
   as-bool. > is-windows
     exists.
       next.
-        match.
-          string.regex "/windows/i"
-          name
+        "/windows/i".regex.match name
   [] > name /Q.string
+    ? > ^
 
   or. ++> can-check-the-os-family
     os.is-windows.or os.is-macos
     os.is-linux
+
+  not. ++> can-tell-it-does-not-belong-to-two-os-families-at-once
+    or.
+      or.
+        os.is-linux.and os.is-macos
+        os.is-linux.and os.is-windows
+      os.is-macos.and os.is-windows

--- a/objects/output.eo
+++ b/objects/output.eo
@@ -1,15 +1,23 @@
 # Output is an abstract destination of bytes that can be written sequentially.
 # Any output decorates the object bound to its `@` attribute, which must
 # provide a `write` object that takes the bytes to write and returns an
-# output block ready to write the next portion. See `output.dead` and
-# `chunk.to-output`.
+# output block ready to write the next portion. See `dead` and the
+# `to-output` of `chunk`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint unit-test-missing
 
 [@] > output
+
+  eq. ++> can-decorate-a-destination-of-bytes
+    malloc.of
+      3
+      seq * > [m]
+        write.
+          output m.to-output
+          01-02-03
+        m
+    01-02-03

--- a/objects/output/dead.eo
+++ b/objects/output/dead.eo
@@ -1,19 +1,19 @@
-# Dead output is an output that writes to nowhere. Here `origin` is the
-# output this one is taken off, as in `o.dead`. It is ignored, because a
-# dead output writes to nowhere anyway.
+# Dead output is an output that writes to nowhere. It is a method of
+# `output`, as in `o.dead`, and reads nothing from the output it is taken
+# off, because it writes to nowhere anyway.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package output
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[origin] > dead
+[] > dead
   [buffer] > write
-    [] >> output-block
+    [^] >> output-block
       true > @
-      output-block > [buffer] > write
+      ^.^.output-block > [^ buffer] > write
     | > @
 
   malloc.of ++> can-be-taken-off-any-output

--- a/objects/path.eo
+++ b/objects/path.eo
@@ -1,19 +1,11 @@
 # Path `path` that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.
 
-+alias string.index-of
-+alias string.last-index-of
-+alias tuple.reduced
-+alias string.regex
-+alias string.replaced
-+alias string.split
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [uri] > path
   os.is-windows.if > @
@@ -21,50 +13,79 @@
       string uri.as-bytes
     posix
       string uri.as-bytes
-  [sys uri] > impl
+  [^ sys uri] > impl
     uri > @
     directory > as-dir
       file uri
     file uri > as-file
-    [] > basename
+    [^] > basename
       string > @
         if.
           or.
             pth.size.eq 0
             index.eq 0
-          uri >> pth!
+          ^.stripped ^.driveless >> pth!
           as-bytes.
             text.slice
               plus. >> index!
-                string.last-index-of text separator
+                text.last-index-of ^.separator
                 1
               text.length.minus
                 number index
       string pth > text
-    [] > dirname
+    driveless.split separator > chunks
+    unc.and > device
+      and.
+        driveless.size.gt 2
+        or.
+          eq.
+            driveless.slice 2 1
+            "."
+          eq.
+            driveless.slice 2 1
+            "?"
+    [^] > dirname
       string > @
         if.
-          pth.size.eq 0
-          uri >> pth!
-          if.
-            len.eq -1
-            "."
+          ^.unc.and root
+          text
+          ^.drive.concat
             if.
-              len.eq 0
-              separator
-              as-bytes.
-                text.slice
-                  0
-                  string.last-index-of text separator >> len!
+              len.eq -1
+              if.
+                ^.drive.size.eq 0
+                "."
+                --
+              if.
+                len.eq 0
+                ^.separator
+                as-bytes.
+                  text.slice
+                    0
+                    text.last-index-of ^.separator >> len!
+      tail.index-of ^.separator > first!
+      ^.stripped ^.driveless > pth!
+      and. > root
+        text.length.gt 2
+        and.
+          not.
+            first.eq -1
+          first.eq
+            tail.last-index-of ^.separator
+      string > tail
+        as-bytes.
+          text.slice
+            2
+            text.length.minus 2
       string pth > text
     sys.drive uri > drive
     if. > driveless
       drive.size.eq 0
       uri
       uri.slice
-        drive.size
-        uri.size.minus drive.size
-    [] > extname
+        drive.length
+        uri.length.minus drive.length
+    [^] > extname
       if. > @
         or.
           or.
@@ -77,129 +98,220 @@
         string
           as-bytes.
             text.slice
-              string.last-index-of text "." >> index!
+              text.last-index-of "." >> index!
               text.length.minus
                 number index
       string > text
-        basename >> base!
-    is-root-relative.or > is-absolute
-      drive.size.gt 0
-    and. > is-root-relative
+        ^.basename >> base!
+    and. > is-absolute
       driveless.size.gt 0
       eq.
         driveless.slice 0 1
         separator
-    [] > normalized
-      impl > @
-        sys
+    [^] > normalized
+      ^.^.impl > @
+        ^.sys
         if.
           normalized.eq
-            separator.concat separator
-          separator
+            ^.separator.concat ^.separator
+          ^.separator
           if.
             normalized.size.eq 0
             "."
             string normalized
-      as-bytes. > normalized
+      concat. > core!
+        ^.drive.concat
+          ^.is-absolute.if
+            ^.unc.if
+              ^.separator.concat ^.separator
+              ^.separator
+            --
+        ^.separator.joined >> body!
+          reduced.
+            ^.driveless.split ^.separator
+            *
+            if. > [^ accum segment] >>
+              segment.eq ".."
+              if.
+                and.
+                  accum.length.gt 0
+                  not.
+                    accum.head.eq ".."
+                if.
+                  ^.^.unc.and
+                    accum.length.lte 2
+                  accum
+                  accum.tail
+                ^.^.is-absolute.not.if
+                  accum.with segment
+                  accum
+              if.
+                ^.^.device.and
+                  and.
+                    accum.length.eq 0
+                    or.
+                      segment.eq "."
+                      segment.eq "?"
+                accum.with segment
+                if.
+                  or.
+                    segment.eq "."
+                    segment.eq ""
+                  accum
+                  accum.with segment
+      as-bytes. > normalized!
         if.
-          driveless.size.eq 0
+          ^.driveless.size.eq 0
           if.
-            drive.size.eq 0
+            ^.drive.size.eq 0
             "."
-            drive
-          concat.
-            concat.
-              drive.concat
-                is-root-relative.if separator --
-              string.joined >> body!
-                separator
-                tuple.reduced
-                  string.split driveless separator
-                  *
-                  if. > [accum segment] >>
-                    segment.eq ".."
-                    if.
-                      and.
-                        accum.length.gt 0
-                        not. (accum.head.eq "..")
-                      accum.tail
-                      is-root-relative.not.if (accum.with segment) accum
-                    if.
-                      or.
-                        segment.eq "."
-                        segment.eq ""
-                      accum
-                      accum.with segment
-            trailing.if separator --
+            ^.drive
+          if.
+            core.size.eq 0
+            "."
+            if.
+              and.
+                body.size.eq 0
+                and.
+                  ^.drive.size.gt 0
+                  ^.is-absolute.not
+              core.concat
+                ".".concat
+                  if.
+                    trailing.and rooted.not
+                    ^.separator
+                    --
+              core.concat
+                if.
+                  trailing.and rooted.not
+                  ^.separator
+                  --
+      and. > rooted
+        core.size.gt 0
+        eq.
+          core.slice
+            core.size.plus -1
+            1
+          ^.separator
       and. > trailing
         ubts.size.gt 0
         eq.
           slice.
-            uri >> ubts!
+            ^.uri >> ubts!
             ubts.size.plus -1
             1
-          separator
-    [other] > resolved
+          ^.separator
+    [^ other] > resolved
       normalized. > @
-        impl
-          sys
+        ^.^.impl
+          ^.sys
           string
             if.
               valid.size.eq 0
-              uri
+              ^.uri
               if.
-                gt. (sys.drive valid).size 0
+                gt. (^.sys.drive valid).size 0
                 valid
                 if.
-                  eq.
-                    valid.slice 0 1
-                    separator
-                  drive.concat valid
-                  concat. (uri.concat separator) valid
+                  starts-with.
+                    string valid
+                    ^.separator.concat ^.separator
+                  valid
+                  if.
+                    eq.
+                      valid.slice 0 1
+                      ^.separator
+                    ^.unc.if
+                      ^.share.concat valid
+                      ^.drive.concat valid
+                    concat. (^.uri.concat ^.separator) valid
       string > valid!
         as-bytes.
-          sys.sanitized other
+          ^.sys.sanitized other
     sys.separator > separator
-  [paths] > joined
+    if. > share
+      chunks.length.gt 3
+      concat.
+        concat.
+          separator.concat separator
+          chunks.at 2
+        separator.concat
+          chunks.at 3
+      uri
+    if. > [^ tail] > stripped
+      or.
+        tail.size.eq 0
+        tail.eq ^.separator
+      tail
+      if.
+        tail.ends-with ^.separator
+        ^.stripped
+          string
+            as-bytes.
+              tail.slice
+                0
+                tail.length.minus ^.separator.length
+        tail
+    string > [^] > trimmed
+      ^.stripped ^.uri
+    and. > unc
+      separator.eq "\\"
+      and.
+        driveless.size.gt 1
+        driveless.starts-with
+          separator.concat separator
+  [^ paths] > joined
     normalized. > @
       os.is-windows.if
-        win32 jpath
-        posix jpath
+        ^.win32 jpath
+        ^.posix jpath
     string > jpath
       as-bytes.
-        string.joined separator paths
-  [uri] > posix
-    impl > @
+        ^.separator.joined paths
+  [^ uri] > posix
+    ^.impl > @
       sys
       uri
     "/" > separator
-    [] > sys
+    [^] > sys
       -- > [uri] > drive
-      uri > [uri] > sanitized
+      I > sanitized
       ^.separator > separator
   os.is-windows.if > separator
     win32.separator
     posix.separator
-  [uri] > win32
-    impl > @
+  [^ uri] > win32
+    ^.impl > @
       sys
       sys.sanitized uri
     "\\" > separator
-    [] > sys
+    [^] > sys
       if. > [uri] > drive
-        as-bool. ((string.regex "/^[a-zA-Z]:/").match uri).next.exists
+        as-bool. ("/^[a-zA-Z]:/".regex.match uri).next.exists
         uri.slice 0 2
         --
-      [uri] > sanitized
+      [^ uri] > sanitized
         if. > @
           eq.
-            string.index-of pth path.posix.separator
+            pth.index-of path.posix.separator
             -1
           string
             uri >> ubts!
-          string (string.replaced pth (string.regex "/\\//") separator)!
+          string (pth.replaced "/\\//".regex ^.separator)!
         string ubts > pth
       ^.separator > separator
+
+  and. ++> can-classify-a-drive-relative-win32-path-as-non-absolute
+    and.
+      not.
+        is-absolute.
+          path.win32 "C:foo"
+      not.
+        is-absolute.
+          path.win32 "C:.\\foo"
+    not.
+      is-absolute.
+        path.win32 "C:..\\foo"
 
   and. ++> can-detect-an-absolute-posix-path
     is-absolute.
@@ -223,10 +335,30 @@
       path.win32.separator
       path.posix.separator
 
+  eq. ++> can-normalize-a-device-namespace-win32-path-reducing-a-child-directory
+    normalized.
+      path.win32 "\\\\.\\C:\\foo\\.."
+    "\\\\.\\C:"
+
+  eq. ++> can-normalize-a-double-separator-posix-path-to-the-root
+    normalized.
+      path.posix "//"
+    "/"
+
   eq. ++> can-normalize-a-drive-only-win32-path
     normalized.
       path.win32 "C:"
     "C:"
+
+  eq. ++> can-normalize-a-drive-qualified-win32-path-with-a-multibyte-segment
+    normalized.
+      path.win32 "C:\\Ж"
+    "C:\\Ж"
+
+  eq. ++> can-normalize-a-drive-relative-win32-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.win32 "C:foo\\..\\"
+    "C:.\\"
 
   eq. ++> can-normalize-a-drive-relative-win32-path-keeping-a-leading-dotdot
     normalized.
@@ -248,6 +380,11 @@
       path.posix "foo/.."
     "."
 
+  eq. ++> can-normalize-a-posix-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.posix "a/b/../../"
+    "."
+
   eq. ++> can-normalize-a-relative-posix-path
     normalized.
       path.posix "../../foo/./bar/../x/../y"
@@ -258,9 +395,74 @@
       path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
     "..\\..\\foo\\x\\y\\"
 
+  eq. ++> can-normalize-a-root-relative-win32-path-keeping-a-single-separator
+    normalized.
+      path.win32 "\\server\\share"
+    "\\server\\share"
+
+  eq. ++> can-normalize-a-triple-separator-posix-path-to-the-root
+    normalized.
+      path.posix "///"
+    "/"
+
+  eq. ++> can-normalize-a-unc-win32-path-keeping-its-double-separator-prefix
+    normalized.
+      path.win32 "\\\\server\\share"
+    "\\\\server\\share"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-child-directory
+    normalized.
+      path.win32 "\\\\server\\share\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-current-and-a-parent-segment-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-alone-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.."
+    "\\\\server\\share"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-and-a-trailing-separator
+    normalized.
+      path.win32 "\\\\server\\share\\..\\"
+    "\\\\server\\share\\"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-below-a-child-directory
+    normalized.
+      path.win32 "\\\\server\\share\\a\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-parent-segments-past-two-child-directories
+    normalized.
+      path.win32 "\\\\server\\share\\a\\b\\..\\..\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-repeated-parent-segments-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\..\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-win32-drive-root-keeping-a-single-separator
+    normalized.
+      path.win32 "C:\\"
+    "C:\\"
+
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.
       path.win32 "foo\\.."
+    "."
+
+  eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.win32 ".\\"
     "."
 
   eq. ++> can-normalize-a-win32-path-down-to-a-drive-with-a-separator
@@ -271,7 +473,7 @@
   eq. ++> can-normalize-a-win32-path-down-to-a-drive-without-a-separator
     normalized.
       path.win32 "C:hello\\.."
-    "C:"
+    "C:."
 
   eq. ++> can-normalize-a-win32-path-replacing-slashes
     normalized.
@@ -370,6 +572,36 @@
       "\\hello\\var"
     "\\hello\\var"
 
+  eq. ++> can-resolve-a-unc-win32-path-against-a-drive-qualified-path
+    resolved.
+      path.win32 "C:\\work\\project"
+      "\\\\server\\share\\report.txt"
+    "\\\\server\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-a-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      "\\\\server\\share\\report.txt"
+    "\\\\server\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-a-root-relative-path
+    resolved.
+      path.win32 "\\\\server\\share\\folder"
+      "\\other"
+    "\\\\server\\share\\other"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-another-unc-path
+    resolved.
+      path.win32 "\\\\server\\share\\project"
+      "\\\\other\\share\\report.txt"
+    "\\\\other\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-share-root-against-a-root-relative-path
+    resolved.
+      path.win32 "\\\\server\\share"
+      "\\other"
+    "\\\\server\\share\\other"
+
   eq. ++> can-resolve-a-win32-path-against-an-empty-one
     resolved.
       path.win32 "C:\\a\\b"
@@ -393,7 +625,7 @@
       path.posix "/var/www/html/foo\\bar"
     "foo\\bar"
 
-  eq. ++> can-return-an-empty-basename-from-a-path-ending-with-a-separator
+  eq. ++> can-return-the-basename-ignoring-a-trailing-separator
     basename.
       path.joined
         *
@@ -401,7 +633,32 @@
           "www"
           "html"
           path.separator
+    "html"
+
+  eq. ++> can-return-the-basename-ignoring-repeated-trailing-separators
+    basename.
+      path.posix "foo//"
+    "foo"
+
+  eq. ++> can-return-the-basename-of-a-drive-relative-win32-path
+    basename.
+      path.win32 "C:foo"
+    "foo"
+
+  eq. ++> can-return-the-basename-of-a-root-relative-path-ending-with-a-separator
+    basename.
+      path.posix "/foo/"
+    "foo"
+
+  eq. ++> can-return-the-basename-of-a-win32-drive-root
+    basename.
+      path.win32 "C:\\"
     ""
+
+  eq. ++> can-return-the-basename-of-an-absolute-path-with-repeated-trailing-separators
+    basename.
+      path.posix "/foo//"
+    "foo"
 
   eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
     dirname.
@@ -413,6 +670,21 @@
       path.posix "plain"
     "."
 
+  eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
+    dirname.
+      path.posix "foo/"
+    "."
+
+  eq. ++> can-return-the-current-dirname-of-an-empty-path
+    dirname.
+      path ""
+    "."
+
+  eq. ++> can-return-the-dirname-ignoring-repeated-trailing-separators
+    dirname.
+      path.posix "foo//"
+    "."
+
   eq. ++> can-return-the-dirname-of-a-directory-path
     dirname.
       path.joined
@@ -420,8 +692,12 @@
           "var"
           "www"
           path.separator
-    path.joined
-      * "var" "www"
+    "var"
+
+  eq. ++> can-return-the-dirname-of-a-drive-relative-win32-path
+    dirname.
+      path.win32 "C:foo"
+    "C:"
 
   eq. ++> can-return-the-dirname-of-a-file-path
     dirname.
@@ -443,6 +719,36 @@
     path.joined
       * "var" "www"
 
+  eq. ++> can-return-the-dirname-of-a-long-win32-path
+    dirname.
+      path.win32 "C:\\aaaaaaaaaaaa\\aaaaaaaaaaaa\\aaaaaaaaaaaa"
+    "C:\\aaaaaaaaaaaa\\aaaaaaaaaaaa"
+
+  eq. ++> can-return-the-dirname-of-a-win32-path-with-a-drive
+    dirname.
+      path.win32 "C:\\foo"
+    "C:\\"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-root
+    dirname.
+      path.win32 "\\\\server\\share"
+    "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-root-with-a-trailing-separator
+    dirname.
+      path.win32 "\\\\server\\share\\"
+    "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-subfolder
+    dirname.
+      path.win32 "\\\\server\\share\\folder"
+    "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
+    dirname.
+      path.posix "/foo//"
+    "/"
+
   eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
     dirname.
       path.win32 "\\foo"
@@ -451,6 +757,11 @@
   eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path
     dirname.
       path.posix "/foo"
+    "/"
+
+  eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path-ending-with-a-separator
+    dirname.
+      path.posix "/foo/"
     "/"
 
   eq. ++> can-return-the-same-string-without-a-separator
@@ -482,17 +793,17 @@
       path.posix ".config.json"
     ".json"
 
-  eq. ++> cannot-take-an-extname-from-a-dotdot
+  eq. ++> can-take-no-extname-from-a-dotdot
     extname.
       path.posix ".."
     ""
 
-  eq. ++> cannot-take-an-extname-from-a-dotfile
+  eq. ++> can-take-no-extname-from-a-dotfile
     extname.
       path.posix ".gitignore"
     ""
 
-  eq. ++> cannot-take-an-extname-from-a-file-without-an-extension
+  eq. ++> can-take-no-extname-from-a-file-without-an-extension
     extname.
       path.joined
         *
@@ -501,7 +812,7 @@
           "html"
     ""
 
-  eq. ++> cannot-take-an-extname-from-a-path-ending-with-a-separator
+  eq. ++> can-take-no-extname-from-a-path-ending-with-a-separator
     extname.
       path.joined
         *

--- a/objects/pi.eo
+++ b/objects/pi.eo
@@ -2,9 +2,8 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 3.141592653589793 > pi

--- a/objects/pinf.eo
+++ b/objects/pinf.eo
@@ -4,10 +4,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 number > pinf
   7F-F0-00-00-00-00-00-00

--- a/objects/posix.eo
+++ b/objects/posix.eo
@@ -5,31 +5,35 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [name args] > posix
   [] > @ /Q.posix.return
+    ? > ^
   os.is-macos.if > append
     8
     1024
   os.is-macos.if > creat
     512
     64
+  17 > eexist
+  os.is-macos.if > exclusive
+    2048
+    128
   2 > inet
   420 > mode
   -1 > none
   511 > permissions
+  384 > private
   0 > rdonly
   2 > rdwr
-  [code output] > return
+  [^ code output] > return
     output > @
-    return > called
+    ^.return > called
       code
       output
   [family port address] > sockaddr-in
@@ -49,6 +53,7 @@
   os.is-macos.if > trunc
     1024
     512
+  4294967295 > unresolved
   1 > wronly
 
   ++> can-close-a-tcp-socket
@@ -69,6 +74,13 @@
         posix.stream
         posix.tcp
 
+  ++> can-compute-the-size-of-a-sockaddr-in
+    addr.size.eq 16 > @
+    posix.sockaddr-in > addr
+      00-00
+      00-00
+      00-00-00-00
+
   os.is-windows.or ++> can-invoke-getpid
     gt.
       code.
@@ -76,6 +88,36 @@
           "getpid"
           *
       0
+
+  ++> can-open-a-file-with-the-append-flag
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "close"
+            fd
+        fd.gt -1
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly.plus posix.append
+        0
+
+  ++> can-open-a-file-with-the-trunc-flag
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "close"
+            fd
+        fd.gt -1
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly.plus posix.trunc
+        0
 
   ++> can-open-a-tcp-socket
     os.is-windows.or > @
@@ -107,6 +149,31 @@
         0
         0
 
+  os.is-windows.or ++> can-report-eexist-when-creating-an-existing-file-exclusively
+    seq *
+      code.
+        posix *1
+          "open"
+          "/dev/null"
+          plus.
+            posix.rdonly.plus posix.creat
+            posix.exclusive
+          posix.private
+      eq.
+        code.
+          posix
+            "errno"
+            *
+        posix.eexist
+
+  os.is-windows.or ++> can-return-an-inet-address-above-the-signed-range
+    eq.
+      code.
+        posix *1
+          "inet_addr"
+          "10.0.0.200"
+      3355443210
+
   os.is-windows.or ++> can-return-an-inet-address-for-localhost
     eq.
       code.
@@ -114,3 +181,61 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  os.is-windows.or ++> can-return-the-limited-broadcast-address
+    eq.
+      code.
+        posix *1
+          "inet_addr"
+          "255.255.255.255"
+      posix.unresolved
+
+  ++> can-stat-the-size-of-dev-null
+    os.is-windows.or > @
+      info.size.eq 0
+    output. > info
+      posix *1
+        "stat"
+        "/dev/null"
+
+  ++> can-store-seconds-in-a-timeval
+    tv.seconds.eq 5 > @
+    posix.timeval > tv
+      5
+      100
+
+  --> stops-on-write-size-being-negative
+    os.is-windows.if > @
+      1.div 0
+      seq *
+        code.
+          posix *1
+            "write"
+            fd
+            "ab"
+            -1
+        true
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly
+        0
+
+  --> stops-on-write-size-exceeding-buffer-length
+    os.is-windows.if > @
+      1.div 0
+      seq *
+        code.
+          posix *1
+            "write"
+            fd
+            "ab"
+            4096
+        true
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        posix.wronly
+        0

--- a/objects/range.eo
+++ b/objects/range.eo
@@ -20,21 +20,18 @@
 # `1.plus 1` and also has object `next`. Since these objects are ints - they have
 # object `lt` by default.
 
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [start end] > range
   if. > @
     start.lt end
-    if. > [acc current] >> appended
-      current.lt end
-      appended
+    if. > [^ acc current] >> appended
+      current.lt ^.end
+      ^.appended
         acc.with current
         current.next
       acc
@@ -58,9 +55,9 @@
     range > rng
       []
         build 1 > @
-        [i] > build
+        [^ i] > build
           i > @
-          build > next
+          ^.build > next
             1.plus @
       10
 
@@ -78,9 +75,9 @@
     range > rng
       []
         x 1 > @
-        [i] > x
+        [^ i] > x
           i > @
-          x > next
+          ^.x > next
             0.5.plus @
       5
 
@@ -90,14 +87,14 @@
     range > rng
       []
         b 1 > @
-        [num] > b
+        [^ num] > b
           num > @
-          b > next
+          ^.b > next
             5.plus @
       10
 
   ++> can-build-an-empty-range-from-wrong-items
-    tuple.is-empty rng > @
+    rng.is-empty > @
     range > rng
       []
         y 10 > @

--- a/objects/range/naturals.eo
+++ b/objects/range/naturals.eo
@@ -1,27 +1,41 @@
 # Range of natural numbers from `start` to `end` (soft border) with step = 1.
-# The `r` is an instance of `range`, which provides `start` and `end`.
+# It is a method of `range`, so it reads `start` and `end` from the range it
+# is taken from. Both bounds must be integers, otherwise the computation
+# terminates: a fractional or non-finite seed would otherwise stay fractional
+# or non-finite through the whole generated sequence, contradicting the range
+# of natural numbers. `is-integer` already excludes `nan` and the infinities,
+# so it doubles as the finiteness check.
 
-+alias tuple.is-empty
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package range
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
-[r] > naturals
-  range > @
-    [] >>
-      build r.start > @
-      [num] > build
-        num > @
-        build > next
-          1.plus @
-    r.end
+[^] > naturals
+  if. > @
+    and.
+      r.start.is-integer.and r.end.is-integer
+      and.
+        r.start.abs.lt safe
+        r.end.abs.lt safe
+    range
+      [^] >>
+        build ^.r.start > @
+        [^ num] > build
+          num > @
+          ^.build > next
+            1.plus @
+      r.end
+    T
+      "Range bounds must be integers within the safe unit-step range (|x| < 2^53), but were %f and %f".printf
+        * r.start r.end
+  ^ > r
+  2.power 53 > safe
 
   eq. ++> can-build-a-range-of-negatives
-    naturals
+    naturals.
       range -5 0
     *
       -5
@@ -30,16 +44,35 @@
       -2
       -1
 
-  tuple.is-empty ++> can-build-an-empty-range-from-ten-to-ten
-    naturals
+  eq. ++> can-build-a-range-with-a-single-element
+    naturals.
+      range 5 6
+    * 5
+
+  is-empty. ++> can-build-an-empty-range-from-ten-to-ten
+    naturals.
       range 10 10
 
-  tuple.is-empty ++> can-build-an-empty-range-when-descending
-    naturals
+  is-empty. ++> can-build-an-empty-range-when-descending
+    naturals.
       range 10 1
 
+  is-empty. ++> can-build-an-empty-range-when-descending-in-negatives
+    naturals.
+      range -1 -5
+
+  eq. ++> can-build-naturals-crossing-zero
+    naturals.
+      range -2 3
+    *
+      -2
+      -1
+      0
+      1
+      2
+
   eq. ++> can-build-naturals-from-one-to-ten
-    naturals
+    naturals.
       range 1 10
     *
       1
@@ -51,3 +84,43 @@
       7
       8
       9
+
+  naturals. --> rejects-a-fractional-lower-bound
+    range
+      0.5
+      2
+
+  naturals. --> rejects-a-fractional-upper-bound
+    range
+      1
+      3.5
+
+  naturals. --> rejects-a-lower-bound-at-the-precision-boundary
+    range
+      9007199254740992
+      9007199254740994
+
+  naturals. --> rejects-a-nan-upper-bound
+    range
+      0
+      nan
+
+  naturals. --> rejects-a-negative-lower-bound-at-the-precision-boundary
+    range
+      -9007199254740992
+      0
+
+  naturals. --> rejects-a-negative-upper-bound-at-the-precision-boundary
+    range
+      0
+      -9007199254740992
+
+  naturals. --> rejects-a-non-finite-lower-bound
+    range
+      pinf
+      0
+
+  naturals. --> rejects-an-upper-bound-at-the-precision-boundary
+    range
+      0
+      9007199254740992

--- a/objects/recovered.eo
+++ b/objects/recovered.eo
@@ -5,14 +5,14 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [] > recovered /A
+  ? > ^
   ? > value /A?
   ? > alternative /A
 
@@ -21,6 +21,20 @@
       2.as-i64.div 0.as-i64
       7
     7
+
+  eq. ++> can-fall-back-when-a-step-of-a-sequence-terminates
+    recovered
+      seq *
+        2.as-i64.div 0.as-i64
+        true
+      7
+    7
+
+  ++> can-fall-back-when-forcing-a-cached-value-terminates
+    eq. > @
+      recovered cached 7
+      7
+    2.as-i64.div 0.as-i64 > cached!
 
   eq. ++> can-keep-the-value-when-not-terminated
     recovered

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -13,10 +13,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [steps] > seq
   if. > @
@@ -50,7 +49,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             gt.
               seq *
                 m.put
@@ -64,7 +63,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             lt.
               seq *
                 m.put
@@ -78,7 +77,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             eq.
               seq *
                 m.put 0
@@ -93,7 +92,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             eq.
               seq *
                 at.
@@ -110,7 +109,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             lt.
               seq *
                 m.put
@@ -124,7 +123,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [^ m] >>
             lte.
               seq *
                 m.put

--- a/objects/set.eo
+++ b/objects/set.eo
@@ -1,27 +1,23 @@
 # Set - is an unordered `list` of unique objects.
 
-+alias tuple.mapped
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [lst] > set
   [mp] >> ctor
     mp.keys > @
-    mp.has item > [item] > has
+    ^.mp.has item > [^ item] > has
     mp.size > size
-    set.ctor > [item] > with
-      mp.with item true
-    set.ctor > [item] > without
-      mp.without item
+    set.ctor > [^ item] > with
+      ^.mp.with item true
+    set.ctor > [^ item] > without
+      ^.mp.without item
   | > @
     map
-      tuple.mapped
-        lst
+      lst.mapped
         map.entry item true > [item]
 
   has. ++> can-append-a-new-item
@@ -32,7 +28,7 @@
       3
     3
 
-  eq. ++> cannot-append-an-existing-item
+  eq. ++> can-skip-an-existing-item-when-appending
     size.
       with.
         set *

--- a/objects/socket.eo
+++ b/objects/socket.eo
@@ -17,7 +17,7 @@
 # When you dataize `socket.connect`, it creates new socket, connects to the given
 # IP on given port, dataizes provided scope, closes the socket and returns bytes
 # retrieved from scope dataization. On failure at any of the described steps, the fallback of the
-# corresponding operation is returned (or the bottom object when it is left unbound).
+# corresponding operation is returned (or the terminator when it is left unbound).
 #
 # To listen to the incoming connections as server you should do:
 #
@@ -40,45 +40,46 @@
 # and returns `bytes` retrieved from scope dataization. When `s.accept` is dataized - it dataizes
 # given scope, closes client socket and returns `bytes` retrieved from scope dataization.
 # On failure at any of the described steps, the fallback of the corresponding operation is
-# returned (or the bottom object when it is left unbound).
+# returned (or the terminator when it is left unbound).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
-+unlint redundant-object
-+unlint mandatory-package
 
 [address port] > socket
   os.is-windows.if > @
-    [sys] >> impl
+    [^ sys] >> impl
       code. > addr
         sys.raw *1
           "inet_addr"
-          address
-      addr.as-i32 > addrint
-      [descriptor] > closed-socket
+          ^.address
+      as-i32. > addrint
+        if.
+          addr.gt 2147483647
+          addr.minus 4294967296
+          addr
+      [^ descriptor] > closed-socket
         if. > @
           closed.eq -1
           T
             "Couldn't close the socket #%d because %s".printf
-              * descriptor sys.message
+              * descriptor ^.sys.message
           true
         code. > closed
-          sys.raw *1
-            sys.close
+          ^.sys.raw *1
+            ^.sys.close
             descriptor
-      [scope cant-connect] > connect
-        safe-socket > @
-          [] >>
+      [^ scope cant-connect] > connect
+        ^.safe-socket > @
+          [^] >>
             if. > @
               connected.eq -1
-              cant-connect
+              ^.cant-connect
                 "Couldn't connect to %s:%d on socket #%d because %s".printf
                   * sock.address sock.port sock.sd sock.sys.message
-              scope
+              ^.scope
                 sock.scoped-socket sock.sd
             code. > connected
               sock.sys.raw *1
@@ -88,38 +89,37 @@
                 sock.sockaddr.size
             ^.^.^ > sock
           cant-connect
-      [scope cant-listen] > listen
-        safe-socket > @
-          [] >>
+      [^ scope cant-listen] > listen
+        ^.safe-socket > @
+          [^] >>
             if. > @
               bound.eq -1
-              cant-listen
+              ^.cant-listen
                 "Couldn't bind the socket #%d to %s:%d because %s".printf
                   * sock.sd sock.address sock.port sock.sys.message
               if.
                 listened.eq -1
-                cant-listen
+                ^.cant-listen
                   "Failed to listen to %s:%d on the socket #%d because %s".printf
                     * sock.address sock.port sock.sd sock.sys.message
-                scope
-                  [] >>
-                    sock.scoped-socket sock.sd > @
-                    [scope cant-accept] > accept
+                ^.scope
+                  [^] >>
+                    ^.sock.scoped-socket ^.sock.sd > @
+                    [^ scope cant-accept] > accept
                       if. > @
                         client.eq -1
                         cant-accept
                           "Failed to accept a connection on the socket #%d because %s".printf
-                            * sock.sd sock.sys.message
-                        seq *
-                          scope (sock.scoped-socket client) >> handled!
-                          sock.closed-socket client
-                          handled
+                            * ^.^.sock.sd ^.^.sock.sys.message
+                        ^.^.sock.guarded
+                          scope (^.^.sock.scoped-socket client)
+                          ^.^.sock.closed-socket client
                       code. > client
-                        sock.sys.raw *1
+                        ^.^.sock.sys.raw *1
                           "accept"
-                          sock.sd
-                          sock.sockaddr
-                          sock.sockaddr.size
+                          ^.^.sock.sd
+                          ^.^.sock.sockaddr
+                          ^.^.sock.sockaddr.size
             code. > bound
               sock.sys.raw *1
                 "bind"
@@ -133,57 +133,58 @@
                 2048
             ^.^.^ > sock
           cant-listen
-      [scope cant] > safe-socket
+      [^ scope cant] > safe-socket
         if. > @
           not.
-            sys.startup.eq 0
+            ^.sys.startup.eq 0
           cant
             "Couldn't start up the sockets subsystem because %s".printf
-              * sys.message
-          seq *
-            if. >> result!
-              sd.eq -1
-              cant
-                "Couldn't create a socket because %s".printf
-                  * sys.message
-              seq *
-                if. >> used!
-                  addr.eq sys.none
-                  cant
-                    "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
-                      * address sys.message
-                  scope
-                closed-socket sd
-                used
-            sys.cleanup
-            result
-      [descriptor] > scoped-socket
+              * ^.sys.message
+          ^.^.guarded opened ^.sys.cleanup
+        if. > converted
+          and.
+            ^.addr.eq ^.sys.unresolved
+            not.
+              ^.^.address.eq "255.255.255.255"
+          cant
+            "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
+              * ^.^.address ^.sys.message
+          scope
+        if. > opened
+          ^.sd.eq -1
+          cant
+            "Couldn't create a socket because %s".printf
+              * ^.sys.message
+          ^.^.guarded
+            converted
+            ^.closed-socket ^.sd
+      [^ descriptor] > scoped-socket
         ^.^.as-input recv > as-input
         ^.^.as-output send > as-output
-        [size cant-receive] > recv
+        [^ size cant-receive] > recv
           if. > @
             received.code.eq -1
             cant-receive
               "Failed to receive data from the socket #%d because %s".printf
-                * descriptor sys.message
+                * ^.descriptor ^.^.sys.message
             received.output
           called. > received
-            sys.raw *1
+            ^.^.sys.raw *1
               "recv"
-              descriptor
+              ^.descriptor
               size
               0
-        [buffer cant-send] > send
+        [^ buffer cant-send] > send
           if. > @
             sent.eq -1
             cant-send
               "Failed to send a message through the socket #%d because %s".printf
-                * descriptor sys.message
+                * ^.descriptor ^.^.sys.message
             sent
           code. > sent
-            sys.raw *1
+            ^.^.sys.raw *1
               "send"
-              descriptor
+              ^.descriptor
               buffer >> buff!
               buff.size
               0
@@ -195,7 +196,7 @@
           sys.tcp
       sys.sockaddr-in > sockaddr
         sys.inet.as-i16
-        htons port
+        ^.htons ^.checked-port
         addrint
     |
       []
@@ -237,28 +238,54 @@
         posix > raw
         0 > startup
   [recv] > as-input
-    [size] > read
+    [^ size] > read
       @. > @
         read.
           input-block --
           size
-      [buffer] > input-block
+      [^ buffer] > input-block
         buffer > @
-        [size] > read
+        [^ size] > read
           seq * > @
             chunk
-            input-block chunk
+            ^.^.input-block chunk
           as-bytes. > chunk
-            recv size
+            ^.^.^.recv size
   [send] > as-output
-    [buffer] > write
+    [^ buffer] > write
       @. > @
         output-block.write buffer
-      [] > output-block
+      [^] > output-block
         true > @
-        seq * > [buffer] > write
-          send buffer
-          output-block
+        [^ buffer] > write
+          seq > @
+            * sent remainder
+          if. > remainder
+            sent.lt buffer.size
+            ^.^.output-block.write
+              buffer.slice
+                sent
+                buffer.size.minus sent
+            ^.^.output-block
+          ^.^.^.send buffer > sent
+  ^.port.is-integer.not.if > [^] > checked-port
+    T
+      "Port must be an integer in 0 to 65535, but was %f".printf
+        * ^.port
+    if.
+      or.
+        ^.port.lt 0
+        ^.port.gt 65535
+      T
+        "Port %d is out of range; it must be 0 to 65535".printf
+          * ^.port
+      ^.port
+  [scope cleanup] > guarded
+    seq * > @
+      recovered value true
+      cleanup
+      value
+    scope > value!
   [port] > htons
     as-i16. > @
       or.
@@ -268,4 +295,83 @@
         and.
           b.right 8
           00-FF
-    port.as-i16.as-bytes > b
+    port.as-i32.as-bytes.slice > b
+      2
+      2
+
+  eq. ++> can-convert-a-port-above-the-signed-short-limit-in-htons
+    40-9C
+    socket.htons 40000
+
+  eq. ++> can-dataize-a-guarded-scope-once
+    malloc.for
+      0
+      seq * > [m]
+        socket.guarded
+          m.put
+            m.as-number.plus 1
+          true
+        m.as-number
+    1
+
+  eq. ++> can-guard-a-scope-and-behave-as-it
+    socket.guarded
+      42
+      true
+    42
+
+  ++> can-resend-the-remaining-bytes-after-a-short-send
+    eq. > @
+      malloc.of
+        2
+        [c]
+          seq * > @
+            write.
+              socket.as-output
+                partial-send c
+              01-02
+            c.get
+          seq * > [acc buffer] > partial-send
+            acc.write
+              2.minus buffer.size
+              buffer.slice 0 1
+            1
+      01-02
+
+  eq. ++> can-run-a-guard-cleanup-after-a-successful-scope
+    malloc.for
+      0
+      seq * > [m]
+        socket.guarded
+          42
+          m.put
+            m.as-number.plus 1
+        m.as-number
+    1
+
+  eq. ++> can-run-a-guard-cleanup-after-a-terminated-scope
+    malloc.for
+      0
+      seq * > [m]
+        recovered
+          socket.guarded
+            2.as-i64.div 0.as-i64
+            m.put
+              m.as-number.plus 1
+          true
+        m.as-number
+    1
+
+  checked-port. --> rejects-a-fractional-port
+    socket
+      "127.0.0.1"
+      1.5
+
+  checked-port. --> rejects-a-port-above-the-valid-range
+    socket
+      "127.0.0.1"
+      70000
+
+  socket.guarded --> stops-on-a-terminated-guarded-scope
+    2.as-i64.div 0.as-i64
+    true

--- a/objects/stderr.eo
+++ b/objects/stderr.eo
@@ -14,10 +14,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [text] > stderr
   seq * > @
@@ -27,32 +26,100 @@
           [buffer] > write
             @. > @
               output-block.write buffer
-            [] > output-block
+            [^] > output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [^ buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard error"
+                    ^.^.output-block
+                  code
+                  remainder
+                code. > code
                   win32 *1
                     "_write"
                     win32.stderr
                     buffer
                     buffer.size
-                output-block
+                if. > remainder
+                  code.lt buffer.size
+                  ^.^.output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  ^.^.output-block
         [] >>
           [buffer] > write
             @. > @
               output-block.write buffer
-            [] > output-block
+            [^] > output-block
               true > @
-              seq * > [buffer] > write
-                code.
+              [^ buffer] > write
+                seq * > @
+                  if. >>!
+                    code.eq -1
+                    T
+                      "Failed to write to standard error"
+                    ^.^.output-block
+                  code
+                  remainder
+                code. > code
                   posix *1
                     "write"
                     posix.stderr
                     buffer
                     buffer.size
-                output-block
+                if. > remainder
+                  code.lt buffer.size
+                  ^.^.output-block.write
+                    buffer.slice code (buffer.size.minus code)
+                  ^.^.output-block
       text
     true
 
+  stderr ++> can-print-a-multiline-string
+    "Line one\nLine two\nLine three\n"
+
+  stderr "x" ++> can-print-a-single-character
+
+  stderr ++> can-print-a-string-that-is-only-whitespace
+    "   \t  "
+
+  stderr ++> can-print-a-string-with-a-carriage-return
+    "Windows-style line\r\n"
+
+  stderr ++> can-print-a-string-with-emoji
+    "Build failed ⚠️\n"
+
+  stderr "col1\tcol2\t\"quoted\"\n" ++> can-print-a-string-with-tabs-and-quotes
+
+  stderr ++> can-print-a-string-with-unicode-characters
+    "Привет, мир! 你好，世界！\n"
+
+  stderr ++> can-print-a-string-without-a-trailing-newline
+    "no newline at the end"
+
+  stderr ++> can-print-a-very-long-string
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n"
+
+  stderr "" ++> can-print-an-empty-string
+
+  eq. ++> can-print-the-same-string-consistently-across-repeated-calls
+    stderr
+      "Repeatable message\n"
+    stderr
+      "Repeatable message\n"
+
   stderr ++> can-print-to-stderr
     "Hello, stderr-test!\n"
+
+  seq * ++> can-print-to-stderr-multiple-times-in-a-row
+    stderr
+      "First line\n"
+    stderr
+      "Second line\n"
+
+  eq. ++> can-return-true-after-printing-to-stderr
+    stderr
+      "Checking the return value\n"
+    true

--- a/objects/stdin.eo
+++ b/objects/stdin.eo
@@ -12,39 +12,63 @@
 # ```
 #
 # or just dataize `stdin` object.
+#
+# `all-lines` forces the current line's text through `seq` before the next
+# `line-or-eof` probe is even constructed. Both the accumulated text and
+# that probe read from the same console stream: constructing the probe reads
+# its own lookahead byte, and without this ordering that read races ahead of
+# the current line's own multi-byte read, since neither was otherwise forced
+# until the whole recursion bottomed out at the final `string`.
+#
+# That next probe is named through the root `stdin` and not through the
+# receiver, because an attribute answers with the very same object every
+# time it is taken: a probe taken twice from one `stdin` is one probe,
+# holding the one lookahead byte it has already read and the one line it has
+# already assembled. Through the receiver the recursion would see that same
+# line and that same `eof` at every level and never end, while the root
+# names a `stdin` of its own, whose probe reads the next byte of the stream
+# where the previous probe left off.
+#
+# Reading from the console cannot be exercised by a `++>` test, since
+# `console.read` reaches the process's real file descriptor 0 through
+# `posix`/`win32` and neither can be substituted in EO. The
+# `reads-*` snippets of `eo-integration-tests` feed real standard input to a
+# forked JVM and check what comes back.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
-+unlint unit-test-missing
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
++unlint unit-test-missing
 
 [] > stdin
   all-lines > @
-  [] > all-lines
-    [line buffer first] >> rec-read
-      if. > @
-        line.length.eq 0
+  [^] > all-lines
+    [^ scan buffer is-first] >> rec-read
+      scan.eof.if > @
         string buffer
-        rec-read
-          next-line
-          first.if
-            buffer.concat line
-            concat.
-              buffer.concat eol!
-              line
-          false
+        seq *
+          scan.line
+          ^.rec-read
+            stdin.line-or-eof
+            is-first.if
+              buffer.concat scan.line
+              concat.
+                buffer.concat eol!
+                scan.line
+            false
     | > @
-      next-line
-      --
-      true
-  [] > next-line
-    if. > @
-      first.as-bytes.size.eq 0
+      ^.line-or-eof
       ""
-      [input buffer] >> rec-read
+      true
+  [] > line-or-eof
+    first.as-bytes.size.eq 0 > eof
+    @. > first
+      console.read 1
+    eof.if > line
+      ""
+      [^ input buffer] >> rec-read
         if. > @
           or.
             char.eq --
@@ -54,12 +78,11 @@
                 next.as-bytes.eq "\n"
               char.eq "\n"
           string buffer
-          rec-read
+          ^.rec-read
             next
             buffer.concat char
         input.as-bytes > char
         @. > next
           input.read 1
       | first --
-    @. > first
-      console.read 1
+  ^.line-or-eof.line > [^] > next-line

--- a/objects/stdout.eo
+++ b/objects/stdout.eo
@@ -10,10 +10,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [text] > stdout
   seq * > @

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -9,22 +9,22 @@
 # string "Hello, \u4e16\u754c!"  # Unicode string creation
 # "text".length                  # Character count (not bytes)
 # "text".slice 0 2               # Character-based slicing
+# "TEXT".lower                   # Lower case, default English rules
+# "text".upper                   # Upper case, default English rules
+# "text".turkish.upper           # Upper case, Turkish dotted/dotless I
 # ```
+# Case conversion is exposed as string methods `lower` and `upper`, backed
+# by the locale wrappers `string.english` (the default) and `string.turkish`.
 # .
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [as-bytes] > string
   as-bytes > @
-
-  string.contains ++> can-check-containment-through-the-package
-    "hello, world"
-    "world"
 
   not. ++> can-compare-a-string-with-nan
     nan.eq "друг"
@@ -49,25 +49,9 @@
     "x".eq "x"
     true
 
-  contains. ++> can-contain-a-word-in-a-sentence
-    "hello, world, how are you?"
-    "how"
-
-  "eEo".is-alpha ++> can-detect-alphabetic-text
-
-  "2026".is-digit ++> can-detect-digits
-
-  ends-with. ++> can-end-with-a-suffix
-    "hello, world"
-    "world"
-
   D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> can-equal-a-string-through-bytes
 
   "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> can-equal-bytes
-
-  eq. ++> can-find-the-index-of-a-character
-    "hello".index-of "l"
-    2
 
   "Abc".eq "Abc" ++> can-hold-a-one-line-text-block
 
@@ -77,19 +61,9 @@
 
   "e\ne\ne".eq 65-0A-65-0A-65 ++> can-hold-a-three-line-text-block
 
-  "HELLO".low-cased.eq "hello" ++> can-lower-case-text
-
   eq. ++> can-preserve-indentation-in-a-text-block
     "a\n b\n  c"
     "a\n b\n  c"
-
-  eq. ++> can-repeat-text
-    "ha".repeated 3
-    "hahaha"
-
-  starts-with. ++> can-start-with-a-prefix
-    "hello, world"
-    "hello"
 
   "\n".eq "\n" ++> can-support-a-line-break-escape-sequence
 
@@ -103,14 +77,6 @@
     "Hello, друг!\n"
     "Hello, друг!\n"
 
-  eq. ++> can-take-a-character-at-an-index
-    "some".at 1
-    "o"
-
-  eq. ++> can-trim-surrounding-spaces
-    "  spaced  ".trimmed
-    "spaced"
-
   eq. ++> can-turn-into-bytes
     "€ друг".as-bytes
     E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
@@ -121,4 +87,4 @@
 
   "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> can-unescape-symbols
 
-  "hello".up-cased.eq "HELLO" ++> can-upper-case-text
+  "Hey".missing-attr --> stops-on-taking-a-missing-attribute

--- a/objects/string/as-ascii.eo
+++ b/objects/string/as-ascii.eo
@@ -1,52 +1,58 @@
 # Reads the single character `char` as its ASCII numeric value (0-255).
 # The byte of `char` is left-padded with a zero byte into a 16-bit word,
-# read as an integer and then expressed as a number.
+# read as an integer and then expressed as a number. If `char` is not
+# exactly one byte wide (an empty string, or a multi-byte UTF-8
+# character), the `cant-read` fallback is returned, or the terminator
+# when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[char] > as-ascii
-  as-number. > @
-    as-i16.
-      00-.concat char.as-bytes
+[^ cant-read] > as-ascii
+  if. > @
+    char.as-bytes.size.eq 1
+    as-number.
+      as-i16.
+        00-.concat char.as-bytes
+    cant-read
+      "Can't read %x as an ASCII code, it is not a single byte".printf
+        * char.as-bytes
+  ^ > char
 
-  eq. ++> can-read-the-code-of-a-lowercase-letter
-    97
-    as-ascii "a"
+  97.eq "a".as-ascii ++> can-read-the-code-of-a-lowercase-letter
 
-  eq. ++> can-read-the-code-of-a-punctuation-mark
-    33
-    as-ascii "!"
+  33.eq "!".as-ascii ++> can-read-the-code-of-a-punctuation-mark
 
   eq. ++> can-read-the-code-of-a-space
     32
-    as-ascii
-      " "
+    " ".as-ascii
 
-  eq. ++> can-read-the-code-of-an-uppercase-letter
-    65
-    as-ascii "A"
+  65.eq "A".as-ascii ++> can-read-the-code-of-an-uppercase-letter
 
-  eq. ++> can-read-the-code-of-the-last-lowercase-letter
-    122
-    as-ascii "z"
+  122.eq "z".as-ascii ++> can-read-the-code-of-the-last-lowercase-letter
 
-  eq. ++> can-read-the-code-of-the-last-printable-character
-    126
-    as-ascii "~"
+  126.eq "~".as-ascii ++> can-read-the-code-of-the-last-printable-character
 
-  eq. ++> can-read-the-code-of-the-last-uppercase-letter
-    90
-    as-ascii "Z"
+  90.eq "Z".as-ascii ++> can-read-the-code-of-the-last-uppercase-letter
 
-  eq. ++> can-read-the-code-of-the-nine-digit
-    57
-    as-ascii "9"
+  57.eq "9".as-ascii ++> can-read-the-code-of-the-nine-digit
 
-  eq. ++> can-read-the-code-of-the-zero-digit
-    48
-    as-ascii "0"
+  48.eq "0".as-ascii ++> can-read-the-code-of-the-zero-digit
+
+  eq. ++> can-recover-from-a-multi-byte-character
+    "recovered"
+    "Ж".as-ascii
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-empty-string
+    "recovered"
+    "".as-ascii
+      "recovered" > [message]
+
+  "Ж".as-ascii --> stops-on-a-multi-byte-character
+
+  "".as-ascii --> stops-on-an-empty-string

--- a/objects/string/as-number.eo
+++ b/objects/string/as-number.eo
@@ -1,6 +1,6 @@
 # Returns the original `text` as `number`.
 # If the text is not numeric, the `cant-parse` fallback is returned,
-# or the bottom object when unbound.
+# or the terminator when unbound.
 # The whole `text` must be the number: `scanf` matches its `%f` pattern
 # unanchored (via `find`), so on its own it would accept any text that
 # merely contains a number-shaped substring, e.g. `"$100"` or `"12.34.56"`.
@@ -10,67 +10,67 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text cant-parse] > as-number
+[^ cant-parse] > as-number
   if. > @
     not.
-      matches.
-        compiled.
-          regex "/^[+-]?\\d+(?:\\.\\d+)?$/"
-        text
+      "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/".regex.compiled.matches text
     cant-parse
       "Can't convert text %s to number".printf
         * text
-    head.
-      ^.
-        at.
-          scanf "%f" text
+    head. ("%f".scanf text).at.^
+  ^ > text
 
-  eq. ++> can-convert-float-text
-    3.14
-    as-number "3.14"
+  1000.eq "1e3".as-number ++> can-convert-exponent-text
 
-  eq. ++> can-convert-negative-text
-    -42
-    as-number "-42"
+  3.14.eq "3.14".as-number ++> can-convert-float-text
 
-  eq. ++> can-convert-text
-    5
-    as-number "5"
+  -0.0025.eq "-2.5E-3".as-number ++> can-convert-negative-exponent-text
+
+  -42.eq "-42".as-number ++> can-convert-negative-text
+
+  1.0e-320.eq "1e-320".as-number ++> can-convert-subnormal-exponent-text
+
+  5.eq "5".as-number ++> can-convert-text
 
   42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch
 
-  eq. ++> rejects-currency-prefixed-text
+  eq. ++> can-recover-from-a-bare-exponent-marker
     42
-    as-number
-      "$100"
+    "1e".as-number
       42 > [message]
 
-  eq. ++> rejects-non-numeric-text
+  eq. ++> can-recover-from-an-exponent-without-a-mantissa
     42
-    as-number
-      "Hello"
+    "e3".as-number
       42 > [message]
 
-  eq. ++> rejects-space-separated-numbers
+  eq. ++> can-recover-from-currency-prefixed-text
     42
-    as-number
-      "1 2 3"
+    "$100".as-number
       42 > [message]
 
-  eq. ++> rejects-text-with-an-embedded-number
+  eq. ++> can-recover-from-non-numeric-text
     42
-    as-number
-      "abc5"
+    "Hello".as-number
       42 > [message]
 
-  eq. ++> rejects-text-with-multiple-dots
+  eq. ++> can-recover-from-space-separated-numbers
     42
-    as-number
-      "12.34.56"
+    "1 2 3".as-number
       42 > [message]
 
-  as-number "Hello" --> stops-on-converting-non-numeric-text
+  eq. ++> can-recover-from-text-with-an-embedded-number
+    42
+    "abc5".as-number
+      42 > [message]
+
+  eq. ++> can-recover-from-text-with-multiple-dots
+    42
+    "12.34.56".as-number
+      42 > [message]
+
+  "Hello".as-number --> stops-on-converting-non-numeric-text

--- a/objects/string/at.eo
+++ b/objects/string/at.eo
@@ -1,82 +1,89 @@
 # Retrieve symbol by given index as `text`.
 # A negative `index` counts from the end of `text` (`length + index`).
-# If the resolved index is still negative or is >= `text.length`,
-# the `fallback` value is returned, or the bottom object when unbound.
+# If `index` is not a finite integer (fractional, nan or infinite), or the
+# resolved index is still negative or is >= `text.length`, the `fallback`
+# value is returned, or the terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text i fallback] > at
+[^ i fallback] > at
   if. > @
-    or.
-      0.gt
-        if. >> index!
-          0.gt
-            i >> idx!
-          plus.
-            number len
-            idx
-          idx
+    not.
+      eq.
+        floor.
+          number
+            if. >> index!
+              0.gt
+                i >> idx!
+              plus.
+                number len
+                idx
+              idx
+        number index
+    fallback
+      i.is-finite.if
+        "Index must be an integer, but was %f".printf
+          * i
+        "Index must be an integer, but was %s".printf
+          *
+            string i.as-scientific
+    if.
       or.
+        0.gt index
         gte.
           number index
           text.length >> len!
-        not.
-          eq.
-            floor.
-              number index
-            number index
-    fallback
-      "Given index %d is out of text bounds".printf
-        * i
-    slice
-      text
-      index
-      1
+      fallback
+        "Given index %f is out of text bounds".printf
+          * i
+      text.slice index 1
+  ^ > text
 
-  eq. ++> can-return-a-character-at-a-negative-index
-    "m"
-    at
-      "some"
-      -2
+  eq. ++> can-format-the-error-message-of-a-fractional-index-in-bounds
+    "Index must be an integer, but was 1.500000"
+    "some".at
+      1.5
+      I
 
-  eq. ++> can-return-the-first-character
-    "s"
-    at
-      "some"
-      0
+  eq. ++> can-format-the-error-message-of-a-non-finite-index
+    "Index must be an integer, but was nan"
+    "some".at
+      nan
+      I
 
-  eq. ++> can-return-the-third-character
-    "m"
-    at
-      "some"
-      2
-
-  eq. ++> rejects-a-fractional-index-in-bounds
+  eq. ++> can-recover-from-a-fractional-index-in-bounds
     "recovered"
-    at
-      "some"
+    "some".at
       1.5
       "recovered" > [message]
 
-  eq. ++> rejects-a-negative-fractional-index-in-bounds
+  eq. ++> can-recover-from-a-negative-fractional-index-in-bounds
     "recovered"
-    at
-      "some"
+    "some".at
       -1.5
       "recovered" > [message]
 
-  eq. ++> rejects-an-out-of-bounds-index
+  eq. ++> can-recover-from-an-out-of-bounds-index
     "recovered"
-    at
-      "some"
+    "some".at
       10
       "recovered" > [message]
 
-  at --> stops-on-an-index-beyond-the-length
-    "some"
-    10
+  eq. ++> can-return-a-character-at-a-negative-index
+    "m"
+    "some".at -2
+
+  eq. ++> can-return-the-first-character
+    "s"
+    "some".at 0
+
+  eq. ++> can-return-the-third-character
+    "m"
+    "some".at 2
+
+  "some".at 10 --> stops-on-an-index-beyond-the-length

--- a/objects/string/chained.eo
+++ b/objects/string/chained.eo
@@ -1,34 +1,32 @@
 # Returns concatenation of `text` with all `other` strings.
 # Here `others` must be a `tuple` of `strings`.
 
-+alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text others] > chained
+[^ others] > chained
   if. > @
     0.eq others.length
     text
     string
-      tuple.reduced
-        others
+      others.reduced
         text.as-bytes
         accum.concat str.as-bytes > [accum str]
+  ^ > text
 
   eq. ++> can-chain-with-other-strings
     "Hello, world!"
-    chained *1
-      "Hello"
-      ", "
-      "world"
-      "!"
+    "Hello".chained
+      *
+        ", "
+        "world"
+        "!"
 
   eq. ++> can-return-the-same-text-without-other-strings
     "Some"
-    chained
-      "Some"
+    "Some".chained
       *

--- a/objects/string/contains-all.eo
+++ b/objects/string/contains-all.eo
@@ -1,45 +1,45 @@
 # Checks if `text` contains all elements from `substrings`.
 
-+alias tuple.mapped
-+alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substrings] > contains-all
-  tuple.reduced > @
-    tuple.mapped
-      substrings
-      contains text x > [x] >>
+[^ substrings] > contains-all
+  reduced. > @
+    substrings.mapped
+      ^.text.contains x > [^ x] >>
     true
     x.and a > [a x]
+  ^ > text
 
-  contains-all ++> can-contain-all-of-no-substrings
+  contains-all. ++> can-contain-all-of-no-substrings
     "xyz"
     *
 
-  contains-all ++> can-contain-all-of-no-substrings-when-empty
+  contains-all. ++> can-contain-all-of-no-substrings-when-empty
     ""
     *
 
-  contains-all *1 ++> can-contain-all-substrings
+  contains-all. ++> can-contain-all-substrings
     "abcdefghijk"
-    "abc"
-    "ghi"
-
-  contains-all *1 ++> can-contain-all-substrings-written-vertically
-    "Hello, world!"
-    "ell"
-    " "
-    ","
-    "d!"
-
-  not. ++> cannot-contain-all-substrings
-    contains-all *1
-      "qwerty"
-      "qer"
-      "ty"
+    *
       "abc"
+      "ghi"
+
+  contains-all. ++> can-contain-all-substrings-written-vertically
+    "Hello, world!"
+    *
+      "ell"
+      " "
+      ","
+      "d!"
+
+  not. ++> can-tell-it-does-not-contain-all-substrings
+    "qwerty".contains-all
+      *
+        "qer"
+        "ty"
+        "abc"

--- a/objects/string/contains-any.eo
+++ b/objects/string/contains-any.eo
@@ -1,47 +1,45 @@
 # Checks if `text` contains any element from `substrings`.
 
-+alias tuple.mapped
-+alias tuple.reduced
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substrings] > contains-any
-  tuple.reduced > @
-    tuple.mapped
-      substrings
-      contains text! x > [x] >>
+[^ substrings] > contains-any
+  reduced. > @
+    substrings.mapped
+      ^.text.contains x > [^ x] >>
     false
     x.or a > [a x]
+  ^ > text
 
-  contains-any *1 ++> can-contain-any-substring
+  contains-any. ++> can-contain-any-substring
     "Good morning"
-    "oo"
-    "goo"
+    *
+      "oo"
+      "goo"
 
-  contains-any *1 ++> can-contain-any-substring-written-vertically
+  contains-any. ++> can-contain-any-substring-written-vertically
     "foo bar buzz"
-    "bar"
-    " "
-    "o"
+    *
+      "bar"
+      " "
+      "o"
 
-  not. ++> cannot-contain-any-of-no-substrings
-    contains-any
-      "text"
+  not. ++> can-tell-it-does-not-contain-any-of-no-substrings
+    "text".contains-any
       *
 
-  not. ++> cannot-contain-any-of-no-substrings-when-empty
-    contains-any
-      ""
+  not. ++> can-tell-it-does-not-contain-any-of-no-substrings-when-empty
+    "".contains-any
       *
 
-  not. ++> cannot-contain-any-substring
-    contains-any *1
-      "xyzw"
-      "yx"
-      "zyx"
-      "wx"
-      "abc"
+  not. ++> can-tell-it-does-not-contain-any-substring
+    "xyzw".contains-any
+      *
+        "yx"
+        "zyx"
+        "wx"
+        "abc"

--- a/objects/string/contains.eo
+++ b/objects/string/contains.eo
@@ -3,11 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substring] > contains
+[^ substring] > contains
   and. > @
     gte.
       number
@@ -19,12 +19,12 @@
         eq.
           text >> txt!
           substring >> part!
-      [index] >> rec-contains
+      [^ index] >> rec-contains
         if. > @
           end.eq index
           includes
           includes.or
-            rec-contains (index.plus 1).as-number
+            ^.rec-contains (index.plus 1).as-number
         eq. > includes
           txt.slice index size
           part
@@ -32,12 +32,12 @@
   minus. >> end!
     number length
     size
+  ^ > text
 
-  contains ++> can-contain-a-substring
+  contains. ++> can-contain-a-substring
     "Hello, world!"
     "o, wo"
 
-  not. ++> cannot-contain-an-absent-substring
-    contains
-      "Hello, world!"
+  not. ++> can-tell-it-does-not-contain-an-absent-substring
+    "Hello, world!".contains
       "Hey"

--- a/objects/string/ends-with.eo
+++ b/objects/string/ends-with.eo
@@ -3,11 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substring] > ends-with
+[^ substring] > ends-with
   and. > @
     lte.
       number
@@ -21,12 +21,12 @@
           size
         size
       substring >> part!
+  ^ > text
 
-  ends-with ++> can-end-with-a-substring
+  ends-with. ++> can-end-with-a-substring
     "Hello world!"
     "world!"
 
-  not. ++> cannot-end-with-an-absent-substring
-    ends-with
-      "Hello world!"
+  not. ++> can-tell-it-does-not-end-with-an-absent-substring
+    "Hello world!".ends-with
       "Hello"

--- a/objects/string/english.eo
+++ b/objects/string/english.eo
@@ -1,0 +1,85 @@
+# English locale wrapping a `string` and exposing case conversion for it.
+# Being a decorator of its `s` string, an `english` object behaves like the
+# string itself (`.length`, `.eq`, `.slice` and so on pass through), while
+# adding `lower` and `upper` that map the ASCII letters `A`-`Z` and `a`-`z`
+# to their counterparts one-to-one. Every other byte, including accented
+# Latin, Cyrillic and Greek letters and all multi-byte UTF-8 sequences,
+# passes through unchanged. This is the language-neutral default, which is
+# equivalent to English since English has no special casing rules. Locales
+# that diverge from it, such as `string.turkish`, specialize this object.
+# Each conversion hoists its lower letter bound into a `mincode` constant, so
+# the bound is computed once rather than for every byte walked.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > english
+  s > @
+  [^] > lower
+    string > @
+      ^.s.as-bytes.array.reduced
+        --
+        [^ accum byte] >>
+          accum.concat > @
+            if.
+              and.
+                code.lte "Z".as-ascii!
+                code.gte mincode
+              slice.
+                as-bytes.
+                  as-i64.
+                    code.plus
+                      "a".as-ascii.minus (number mincode)
+                7
+                1
+              byte
+          as-ascii. > code
+            string byte
+    "A".as-ascii >> mincode!
+  ^ > s
+  [^] > upper
+    string > @
+      ^.s.as-bytes.array.reduced
+        --
+        [^ accum byte] >>
+          accum.concat > @
+            if.
+              and.
+                code.lte "z".as-ascii!
+                code.gte mincode
+              slice.
+                as-bytes.
+                  as-i64.
+                    code.minus ((number mincode).minus "A".as-ascii)
+                7
+                1
+              byte
+          as-ascii. > code
+            string byte
+    "a".as-ascii >> mincode!
+
+  5.eq "hello".english.length ++> can-behave-like-the-wrapped-english-string
+
+  "hello".eq "HeLlO".english.lower ++> can-convert-already-lower-cased-text
+
+  "HELLO".eq "HeLlO".english.upper ++> can-convert-already-upper-cased-text
+
+  "hello".eq "HELLO".english.lower ++> can-convert-text-to-lower-case
+
+  "HELLO".eq "hello".english.upper ++> can-convert-text-to-upper-case
+
+  "hello".eq "hello".english.lower ++> can-keep-already-lower-cased-text
+
+  "HELLO".eq "HELLO".english.upper ++> can-keep-already-upper-cased-text
+
+  eq. ++> can-keep-non-ascii-letters-when-lower-casing-in-english
+    "ÄÖÜ"
+    "ÄÖÜ".english.lower
+
+  eq. ++> can-keep-non-ascii-letters-when-upper-casing-in-english
+    "äöü"
+    "äöü".english.upper

--- a/objects/string/index-of.eo
+++ b/objects/string/index-of.eo
@@ -4,11 +4,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substring] > index-of
+[^ substring] > index-of
   if. > @
     or.
       or.
@@ -32,49 +32,42 @@
   minus. >> end!
     number tlen
     size
-  [idx] >> rec-index-of
+  [^ idx] >> rec-index-of
     if. > @
       end.eq idx
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus 1).as-number
+        ^.rec-index-of (idx.plus 1).as-number
     eq. > includes
       txt.slice idx size
       part
+  ^ > text
 
   eq. ++> can-find-a-present-substring-in-utf-text
     3
-    index-of
-      "привет, друг!"
+    "привет, друг!".index-of
       "в"
+
+  eq. ++> can-find-no-index-of-a-longer-substring
+    -1
+    "Hello".index-of "Somebody"
+
+  eq. ++> can-find-no-index-of-an-absent-substring-in-utf-text
+    -1
+    "привет, друг!".index-of
+      "x"
+
+  eq. ++> can-find-no-index-of-an-absent-substring-of-the-same-length
+    -1
+    "Hello".index-of "world"
 
   eq. ++> can-return-the-index-of-a-substring
     6
-    index-of
-      "Hello \n world"
+    "Hello \n world".index-of
       "\n"
 
   eq. ++> can-return-the-index-of-a-substring-at-the-end
     6
-    index-of
-      "Hello world"
-      "world"
-
-  eq. ++> cannot-find-a-longer-substring
-    -1
-    index-of
-      "Hello"
-      "Somebody"
-
-  eq. ++> cannot-find-an-absent-substring-in-utf-text
-    -1
-    index-of
-      "привет, друг!"
-      "x"
-
-  eq. ++> cannot-find-an-absent-substring-of-the-same-length
-    -1
-    index-of
-      "Hello"
+    "Hello world".index-of
       "world"

--- a/objects/string/is-alpha.eo
+++ b/objects/string/is-alpha.eo
@@ -4,22 +4,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > is-alpha
-  matches. > @
-    regex "/^[a-zA-Z]+$/"
-    text
+[^] > is-alpha
+  "/^[a-zA-Z]+$/".regex.matches text > @
+  ^ > text
 
-  is-alpha "eEo" ++> can-be-alphabetic-when-simple-text
+  "eEo".is-alpha ++> can-be-alphabetic-when-simple-text
 
-  not. ++> cannot-be-alphabetic-when-empty
-    is-alpha ""
+  "".is-alpha.not ++> can-tell-it-is-not-alphabetic-when-empty
 
-  not. ++> cannot-be-alphabetic-with-a-number
-    is-alpha "ab3d"
+  "ab3d".is-alpha.not ++> can-tell-it-is-not-alphabetic-with-a-number
 
-  not. ++> cannot-be-alphabetic-with-dashes
-    is-alpha "-w-"
+  "-w-".is-alpha.not ++> can-tell-it-is-not-alphabetic-with-dashes

--- a/objects/string/is-alphanumeric.eo
+++ b/objects/string/is-alphanumeric.eo
@@ -4,21 +4,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > is-alphanumeric
-  matches. > @
-    regex "/^[A-Za-z0-9]+$/"
-    text
+[^] > is-alphanumeric
+  "/^[A-Za-z0-9]+$/".regex.matches text > @
+  ^ > text
 
-  is-alphanumeric "eEo" ++> can-be-alphanumeric-when-simple-text
+  "eEo".is-alphanumeric ++> can-be-alphanumeric-when-simple-text
 
-  is-alphanumeric "ab3d" ++> can-be-alphanumeric-with-a-number
+  "ab3d".is-alphanumeric ++> can-be-alphanumeric-with-a-number
 
-  not. ++> cannot-be-alphanumeric-when-empty
-    is-alphanumeric ""
+  "".is-alphanumeric.not ++> can-tell-it-is-not-alphanumeric-when-empty
 
-  not. ++> cannot-be-alphanumeric-with-dashes
-    is-alphanumeric "-w-"
+  "-w-".is-alphanumeric.not ++> can-tell-it-is-not-alphanumeric-with-dashes

--- a/objects/string/is-ascii.eo
+++ b/objects/string/is-ascii.eo
@@ -3,21 +3,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > is-ascii
-  matches. > @
-    regex "/^[\\x00-\\x7F]+$/"
-    text
+[^] > is-ascii
+  "/^[\\x00-\\x7F]+$/".regex.matches text > @
+  ^ > text
 
-  is-ascii "123" ++> can-be-ascii-when-digits
+  "123".is-ascii ++> can-be-ascii-when-digits
 
-  is-ascii "H311oW" ++> can-be-ascii-when-plain-text
+  "H311oW".is-ascii ++> can-be-ascii-when-plain-text
 
-  not. ++> cannot-be-ascii-when-empty
-    is-ascii ""
+  "".is-ascii.not ++> can-tell-it-is-not-ascii-when-empty
 
-  not. ++> cannot-be-ascii-with-an-emoji
-    is-ascii "🌵"
+  "🌵".is-ascii.not ++> can-tell-it-is-not-ascii-with-an-emoji

--- a/objects/string/is-digit.eo
+++ b/objects/string/is-digit.eo
@@ -4,34 +4,27 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > is-digit
-  matches. > @
-    regex "/^[0-9]+$/"
-    text
+[^] > is-digit
+  "/^[0-9]+$/".regex.matches text > @
+  ^ > text
 
-  is-digit "2026" ++> can-be-digits-when-a-number
+  "2026".is-digit ++> can-be-digits-when-a-number
 
-  is-digit "7" ++> can-be-digits-when-a-single-digit
+  "7".is-digit ++> can-be-digits-when-a-single-digit
 
-  is-digit ++> can-be-digits-when-a-very-long-number
+  is-digit. ++> can-be-digits-when-a-very-long-number
     "123456789012345678901234567890123456789012345678901234567890"
 
-  not. ++> cannot-be-digits-when-empty
-    is-digit ""
+  "".is-digit.not ++> can-tell-it-is-not-digits-when-empty
 
-  not. ++> cannot-be-digits-with-a-letter
-    is-digit "1a2"
+  "1a2".is-digit.not ++> can-tell-it-is-not-digits-with-a-letter
 
-  not. ++> cannot-be-digits-with-a-space
-    is-digit
-      "12 34"
+  "12 34".is-digit.not ++> can-tell-it-is-not-digits-with-a-space
 
-  not. ++> cannot-be-digits-with-a-special-character
-    is-digit "1🌵2"
+  "1🌵2".is-digit.not ++> can-tell-it-is-not-digits-with-a-special-character
 
-  not. ++> cannot-be-digits-with-a-trailing-newline
-    is-digit "123\n"
+  "123\n".is-digit.not ++> can-tell-it-is-not-digits-with-a-trailing-newline

--- a/objects/string/joined.eo
+++ b/objects/string/joined.eo
@@ -4,43 +4,49 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text items] > joined
+[^ items] > joined
   string > @
     if. >>!
       items.length.eq 0
       --
-      [acc tup] >> with-delimiter
+      [^ acc tup] >> with-delimiter
         if. > @
           tup.length.eq 0
           acc
-          with-delimiter
+          ^.with-delimiter
             concat.
-              concat. (dataized tup.head) text!
+              concat. (dataized tup.head) ^.text!
               acc
             tup.tail
       | items.head items.tail
+  ^ > text
+
+  matches. ++> can-apply-regex-to-a-joined-string
+    compiled.
+      regex.
+        "".joined
+          * "/[a-z]+/"
+    "hello"
 
   eq. ++> can-join-many-strings
     "hello-world-dear-friend"
-    joined *1
-      "-"
-      "hello"
-      "world"
-      "dear"
-      "friend"
+    "-".joined
+      *
+        "hello"
+        "world"
+        "dear"
+        "friend"
 
   eq. ++> can-join-no-strings
     ""
-    joined
-      "-"
+    "-".joined
       *
 
   eq. ++> can-join-one-string
     "some"
-    joined *1
-      "-"
-      "some"
+    "-".joined
+      * "some"

--- a/objects/string/last-index-of.eo
+++ b/objects/string/last-index-of.eo
@@ -4,11 +4,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substring] > last-index-of
+[^ substring] > last-index-of
   if. > @
     or.
       or.
@@ -32,43 +32,38 @@
             minus.
               number tlen
               size
-  [idx] >> rec-index-of
+  [^ idx] >> rec-index-of
     if. > @
       0.eq idx
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus -1).as-number
+        ^.rec-index-of (idx.plus -1).as-number
     eq. > includes
       txt.slice idx size
       part
+  ^ > text
+
+  eq. ++> can-find-no-last-index-of-an-absent-substring
+    -1
+    "Hello, world".last-index-of
+      "somebody"
+
+  eq. ++> can-find-no-last-index-of-an-absent-substring-in-utf-text
+    -1
+    "привет, друг!".last-index-of
+      "x"
 
   eq. ++> can-find-the-last-index-of-a-substring
     5
-    last-index-of
-      "Hey, Hey, Hey"
+    "Hey, Hey, Hey".last-index-of
       "Hey,"
 
   eq. ++> can-find-the-last-index-of-a-substring-in-utf-text
     3
-    last-index-of
-      "привет, друг!"
+    "привет, друг!".last-index-of
       "в"
 
   eq. ++> can-find-the-last-index-of-the-whole-string
     0
-    last-index-of
-      "Hello"
-      "Hello"
-
-  eq. ++> cannot-find-the-last-index-of-an-absent-substring
-    -1
-    last-index-of
-      "Hello, world"
-      "somebody"
-
-  eq. ++> cannot-find-the-last-index-of-an-absent-substring-in-utf-text
-    -1
-    last-index-of
-      "привет, друг!"
-      "x"
+    "Hello".last-index-of "Hello"

--- a/objects/string/length.eo
+++ b/objects/string/length.eo
@@ -1,63 +1,141 @@
 # Counts the characters in the `text`, and not its bytes. The UTF-8 sequence
 # is walked character by character, so a multi-byte character counts as one.
-# A sequence that does not end with a complete character terminates
-# the computation.
+# Every multi-byte sequence is validated against the UTF-8 rules of the
+# Unicode standard (Table 3-7): the leading byte fixes the character width and
+# each following byte must be a `10xxxxxx` continuation byte, while the second
+# byte is additionally range-checked so that overlong encodings (`C0`/`C1`
+# leads, `E0` with an `80`-`9F` second byte, `F0` with an `80`-`8F` second
+# byte), UTF-16 surrogates (`ED` with an `A0`-`BF` second byte) and code points
+# above U+10FFFF (`F4` with a `90`-`BF` second byte, and `F5`-`FF` leads) are
+# rejected. A sequence that is incomplete or malformed terminates the
+# computation, exactly like `slice` does for a truncated character.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > length
+[^] > length
   if. > @
     eq.
       text.as-bytes.size >> size!
       0
     0
-    [index accum] >> reclen
+    [^ index accum] >> reclen
       if. > @
         index.eq size
         accum
         if.
           eq.
-            byte.and 80-
+            lead.and 80-
             00-
-          inclen index 1 accum
+          ^.reclen
+            index.plus 1
+            accum.plus 1
           if.
             eq.
-              byte.and E0-
+              lead.and E0-
               C0-
-            inclen index 2 accum
+            step
+              index
+              2
+              twovalid
+              accum
             if.
               eq.
-                byte.and F0-
+                lead.and F0-
                 E0-
-              inclen index 3 accum
+              step index 3 threevalid accum
               if.
                 eq.
-                  byte.and F8-
+                  lead.and F8-
                   F0-
-                inclen index 4 accum
+                step index 4 fourvalid accum
                 T
                   "Unknown byte format (%x), can't recognize character".printf
-                    * byte
-      text.as-bytes.slice index 1 > byte
+                    * lead
+      ^.text.as-bytes.slice > b1
+        index.plus 1
+        1
+      eq. > b1808f
+        b1.and F0-
+        80-
+      eq. > b1809f
+        b1.and E0-
+        80-
+      or. > b190bf
+        eq.
+          b1.and F0-
+          90-
+        eq.
+          b1.and E0-
+          A0-
+      eq. > b1a0bf
+        b1.and E0-
+        A0-
+      eq. > b1cont
+        b1.and C0-
+        80-
+      ^.text.as-bytes.slice > b2
+        index.plus 2
+        1
+      eq. > b2cont
+        b2.and C0-
+        80-
+      ^.text.as-bytes.slice > b3
+        index.plus 3
+        1
+      eq. > b3cont
+        b3.and C0-
+        80-
+      b2cont.and > fourvalid
+        b3cont.and second4
+      ^.text.as-bytes.slice index 1 > lead
+      eq. > leadc0c1
+        lead.and FE-
+        C0-
+      lead.eq E0- > leade0
+      lead.eq ED- > leaded
+      lead.eq F0- > leadf0
+      lead.eq F1- > leadf1
+      leadf1.or > leadf1f3
+        leadf2.or leadf3
+      lead.eq F2- > leadf2
+      lead.eq F3- > leadf3
+      lead.eq F4- > leadf4
+      leade0.if > second3
+        b1a0bf
+        leaded.if b1809f b1cont
+      leadf0.if > second4
+        b190bf
+        leadf4.if
+          b1808f
+          leadf1f3.if b1cont false
+      b2cont.and second3 > threevalid
+      leadc0c1.not.and b1cont > twovalid
     | 0 0
-  if. > [index csize len] >> inclen
+  if. > [^ idx csize valid accum] >> step
     gt.
-      index.plus csize
+      idx.plus csize
       size
     T
       "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
         *
           csize
-          index
-          text.as-bytes
-    reclen
-      index.plus csize
-      len.plus 1
+          idx
+          ^.text.as-bytes
+    valid.if
+      reclen
+        idx.plus csize
+        accum.plus 1
+      T
+        "Malformed UTF-8 sequence (%x) at %d index".printf
+          *
+            ^.text.as-bytes.slice idx csize
+            idx
+  ^ > text
 
   eq. ++> can-count-a-text-of-spaces-only
     " ".length
@@ -70,8 +148,7 @@
     "The 😀 smile" > str
 
   eq. ++> can-count-the-characters-of-the-origin-text
-    length
-      "Hello, world!"
+    "Hello, world!".length
     13
 
   ++> can-count-three-byte-characters
@@ -86,5 +163,17 @@
       str.as-bytes.size.eq 16
     "Hello, друг!" > str
 
-  length --> stops-on-an-incomplete-four-byte-character
+  length. --> rejects-a-non-continuation-after-a-four-byte-lead
+    string F0-90-80-41
+
+  length. --> rejects-a-non-continuation-after-a-three-byte-lead-when-measuring
+    string E1-80-41
+
+  length. --> rejects-a-non-continuation-after-a-two-byte-lead
+    string C2-41
+
+  length. --> rejects-an-overlong-two-byte-encoding-when-measuring
+    string C0-80
+
+  length. --> stops-on-an-incomplete-four-byte-character
     string F0-9F-98

--- a/objects/string/lower.eo
+++ b/objects/string/lower.eo
@@ -1,0 +1,26 @@
+# Returns the `text` in lower case, using the default English casing rules.
+# This is a thin string method: `"HELLO".lower` is the same as
+# `(string.english "HELLO").lower`. Only the ASCII letters `A`-`Z` are
+# folded; every other byte, including accented Latin, Cyrillic and Greek
+# letters and all multi-byte UTF-8 sequences, passes through unchanged.
+# For locale specific rules use a locale wrapper such as `string.turkish`,
+# as in `"...".turkish.lower`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > lower
+  text.english.lower > @
+  ^ > text
+
+  "äöü".eq "äöü".lower ++> can-keep-non-ascii-letters-when-lower-casing
+
+  eq. ++> can-lower-case-text
+    "good evening"
+    "Good evening".lower
+
+  "hello".eq "HELLO".lower ++> can-lower-case-text-through-the-package

--- a/objects/string/nsplit.eo
+++ b/objects/string/nsplit.eo
@@ -1,82 +1,138 @@
 # Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
-# If `limit` is not a finite integer of at least 1 (fractional, nan, infinite,
-# zero or negative), the `cant-split` fallback is returned, or the bottom object when unbound.
+# If `delimiter` is empty, or `limit` is not a finite integer of at least 1
+# (fractional, nan, infinite, zero or negative), the `cant-split` fallback is
+# returned, or the terminator when unbound, the same way `split` behaves.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text delimiter limit cant-split] > nsplit
+[^ delimiter limit cant-split] > nsplit
   if. > @
     or.
-      1.gt limit
-      limit.is-integer.not
+      eq.
+        delimiter.size >> size!
+        0
+      or.
+        1.gt limit
+        limit.is-integer.not
     cant-split
-      "Invalid limit %d for nsplit, must be at least 1".printf
-        * limit
-    if.
-      text.size.eq 0
-      *
       if.
-        1.eq limit
-        * text
-        [accum start current count] >> rec-nsplit
-          if. > @
-            text.size.eq current
-            appended
+        size.eq 0
+        "The delimiter must not be empty"
+        limit.is-finite.if
+          "Invalid limit %f for nsplit, must be at least 1".printf
+            * limit
+          "Invalid limit %s for nsplit, must be at least 1".printf
+            *
+              string limit.as-scientific
+    if.
+      1.eq limit
+      * text
+      [^ accum start current count] >> rec-nsplit
+        if. > @
+          ^.text.size.eq current
+          appended
+          if.
+            or.
+              size.eq 0
+              gt.
+                current.plus size
+                ^.text.size
+            ^.rec-nsplit
+              accum
+              start
+              as-number.
+                current.plus 1
+              count
             if.
-              or.
-                size.eq 0
-                gt.
+              and.
+                ^.delimiter.eq
+                  bts.slice current size
+                lt.
+                  number count
+                  minus. (number ^.limit) 1
+              ^.rec-nsplit
+                appended
+                as-number.
                   current.plus size
-                  text.size
-              rec-nsplit
+                as-number.
+                  current.plus size
+                as-number.
+                  count.plus 1
+              ^.rec-nsplit
                 accum
                 start
                 as-number.
                   current.plus 1
                 count
-              if.
-                and.
-                  delimiter.eq
-                    bts.slice current size
-                  lt.
-                    number count
-                    minus. (number limit) 1
-                rec-nsplit
-                  appended
-                  as-number.
-                    current.plus size
-                  as-number.
-                    current.plus size
-                  as-number.
-                    count.plus 1
-                rec-nsplit
-                  accum
-                  start
-                  as-number.
-                    current.plus 1
-                  count
-          accum.with > appended
-            string
-              bts.slice
-                start
-                current.minus start
-        |
-          *
-          0
-          0
-          0
+        accum.with > appended
+          string
+            bts.slice
+              start
+              current.minus start
+      |
+        *
+        0
+        0
+        0
   text.as-bytes >> bts!
-  delimiter.size >> size!
+  ^ > text
+
+  eq. ++> can-format-the-error-message-of-a-fractional-limit
+    "Invalid limit 1.500000 for nsplit, must be at least 1"
+    "a-b-c".nsplit
+      "-"
+      1.5
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-limit-when-splitting
+    "Invalid limit infinity for nsplit, must be at least 1"
+    "a-b-c".nsplit
+      "-"
+      pinf
+      I
+
+  eq. ++> can-nsplit-an-empty-text-into-one-empty-string
+    "".nsplit
+      "-"
+      3
+    * ""
+
+  eq. ++> can-recover-from-a-fractional-limit
+    "recovered"
+    "a-b-c".nsplit
+      "-"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-empty-delimiter-when-nsplitting
+    "recovered"
+    "abc".nsplit
+      ""
+      3
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-limit-when-splitting
+    "recovered"
+    "a-b-c".nsplit
+      "-"
+      pinf
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-invalid-limit
+    "fallback"
+    "text".nsplit
+      "-"
+      0
+      "fallback" > [message]
 
   eq. ++> can-split-into-empty-strings
-    nsplit
-      "-a-b-c"
+    "-a-b-c".nsplit
       "-"
       3
     *
@@ -85,8 +141,7 @@
       "b-c"
 
   eq. ++> can-split-multi-byte-characters
-    nsplit
-      "аХбХв"
+    "аХбХв".nsplit
       "Х"
       3
     *
@@ -95,8 +150,7 @@
       "в"
 
   eq. ++> can-split-on-a-multi-character-delimiter
-    nsplit
-      "a::b::c::d"
+    "a::b::c::d".nsplit
       "::"
       2
     *
@@ -104,8 +158,7 @@
       "b::c::d"
 
   eq. ++> can-split-on-dashes-with-a-limit-of-two
-    nsplit
-      "a-b-c-d"
+    "a-b-c-d".nsplit
       "-"
       2
     *
@@ -113,8 +166,7 @@
       "b-c-d"
 
   eq. ++> can-split-with-a-high-limit
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       10
     *
@@ -123,51 +175,25 @@
       "c"
 
   eq. ++> can-split-with-a-limit-of-one
-    nsplit
-      "a-b-c"
+    "a-b-c".nsplit
       "-"
       1
     * "a-b-c"
 
   eq. ++> can-split-with-a-limit-of-two
-    nsplit
-      "Cookie: a=1; b=2"
+    "Cookie: a=1; b=2".nsplit
       " "
       2
     *
       "Cookie:"
       "a=1; b=2"
 
-  eq. ++> rejects-a-fractional-limit
-    "recovered"
-    nsplit
-      "a-b-c"
-      "-"
-      1.5
-      "recovered" > [message]
-
-  eq. ++> rejects-an-infinite-limit
-    "recovered"
-    nsplit
-      "a-b-c"
-      "-"
-      pinf
-      "recovered" > [message]
-
-  eq. ++> rejects-an-invalid-limit
-    "fallback"
-    nsplit
-      "text"
-      "-"
-      0
-      "fallback" > [message]
-
-  nsplit --> stops-on-a-limit-of-zero
+  nsplit. --> stops-on-a-limit-of-zero
     "text"
     "-"
     0
 
-  nsplit --> stops-on-a-negative-limit
+  nsplit. --> stops-on-a-negative-limit-when-splitting
     "text"
     "-"
     -1

--- a/objects/string/padded-left.eo
+++ b/objects/string/padded-left.eo
@@ -1,0 +1,125 @@
+# Returns `text` padded on the left with `fill` until it counts `width`
+# characters, so that `42` padded to five characters with a space
+# becomes `   42`. Characters are counted, and not bytes, so a multi-byte
+# character widens the text by one. A `text` of `width` characters
+# or longer is returned unchanged.
+# If `width` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), or `fill` is not a single character, the `cant-pad` fallback
+# is returned, or the terminator when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ width fill cant-pad] > padded-left
+  if. > @
+    or.
+      or.
+        0.gt width
+        width.is-integer.not
+      not.
+        1.eq fill.length
+    cant-pad
+      width.is-finite.if
+        "Can't pad text to %f characters with %s".printf
+          * width fill
+        "Can't pad text to %s characters with %s".printf
+          *
+            string width.as-scientific
+            fill
+    if.
+      width.gt
+        text.length >> len!
+      string
+        concat.
+          as-bytes.
+            fill.repeated (width.minus len).as-number cant-pad
+          text.as-bytes
+      text
+  ^ > text
+
+  eq. ++> can-count-characters-and-not-bytes-when-padding-left
+    "  Ж"
+    "Ж".padded-left
+      3
+      " "
+
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-left
+    "Can't pad text to -1.000000 characters with x"
+    "y".padded-left
+      -1
+      "x"
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-left
+    "Can't pad text to infinity characters with x"
+    "y".padded-left
+      pinf
+      "x"
+      I
+
+  eq. ++> can-pad-a-number-with-leading-spaces
+    "   42"
+    "42".padded-left
+      5
+      " "
+
+  eq. ++> can-pad-with-leading-zeros
+    "0042"
+    "42".padded-left
+      4
+      "0"
+
+  eq. ++> can-recover-from-a-multi-character-fill-when-padding-left
+    "recovered"
+    "y".padded-left
+      5
+      "ab"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-negative-width-when-padding-left
+    "recovered"
+    "y".padded-left
+      -1
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-non-integer-width-when-padding-left
+    "recovered"
+    "y".padded-left
+      2.5
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-width-when-padding-left
+    "recovered"
+    "y".padded-left
+      pinf
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-left
+    "hello"
+    "hello".padded-left
+      3
+      " "
+
+  eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-left
+    "hey"
+    "hey".padded-left
+      3
+      " "
+
+  eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-left
+    "x"
+    "x".padded-left
+      0
+      " "
+
+  padded-left. --> stops-on-a-negative-width-when-padding-left
+    "y"
+    -1
+    "x"

--- a/objects/string/padded-right.eo
+++ b/objects/string/padded-right.eo
@@ -1,0 +1,124 @@
+# Returns `text` padded on the right with `fill` until it counts `width`
+# characters, so that `x` padded to five characters with a space
+# becomes `x    `. Characters are counted, and not bytes, so a multi-byte
+# character widens the text by one. A `text` of `width` characters
+# or longer is returned unchanged.
+# If `width` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), or `fill` is not a single character, the `cant-pad` fallback
+# is returned, or the terminator when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ width fill cant-pad] > padded-right
+  if. > @
+    or.
+      or.
+        0.gt width
+        width.is-integer.not
+      not.
+        1.eq fill.length
+    cant-pad
+      width.is-finite.if
+        "Can't pad text to %f characters with %s".printf
+          * width fill
+        "Can't pad text to %s characters with %s".printf
+          *
+            string width.as-scientific
+            fill
+    if.
+      width.gt
+        text.length >> len!
+      string
+        text.as-bytes.concat
+          as-bytes.
+            fill.repeated (width.minus len).as-number cant-pad
+      text
+  ^ > text
+
+  eq. ++> can-count-characters-and-not-bytes-when-padding-right
+    "Ж  "
+    "Ж".padded-right
+      3
+      " "
+
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-right
+    "Can't pad text to -1.000000 characters with x"
+    "y".padded-right
+      -1
+      "x"
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-right
+    "Can't pad text to infinity characters with x"
+    "y".padded-right
+      pinf
+      "x"
+      I
+
+  eq. ++> can-pad-a-text-with-trailing-spaces
+    "x         "
+    "x".padded-right
+      10
+      " "
+
+  eq. ++> can-pad-with-trailing-zeros-when-padding-right
+    "4200"
+    "42".padded-right
+      4
+      "0"
+
+  eq. ++> can-recover-from-a-multi-character-fill-when-padding-right
+    "recovered"
+    "y".padded-right
+      5
+      "ab"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-negative-width-when-padding-right
+    "recovered"
+    "y".padded-right
+      -1
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-non-integer-width-when-padding-right
+    "recovered"
+    "y".padded-right
+      2.5
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-width-when-padding-right
+    "recovered"
+    "y".padded-right
+      pinf
+      "x"
+      "recovered" > [message]
+
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-right
+    "hello"
+    "hello".padded-right
+      3
+      " "
+
+  eq. ++> can-return-a-text-of-the-exact-width-unchanged-when-padding-right
+    "hey"
+    "hey".padded-right
+      3
+      " "
+
+  eq. ++> can-return-a-text-unchanged-at-zero-width-when-padding-right
+    "x"
+    "x".padded-right
+      0
+      " "
+
+  padded-right. --> stops-on-a-negative-width-when-padding-right
+    "y"
+    -1
+    "x"

--- a/objects/string/padded-zeros.eo
+++ b/objects/string/padded-zeros.eo
@@ -1,0 +1,107 @@
+# Returns `text` padded on the left with zeros until it counts `width`
+# characters, keeping a leading minus sign in front of them, so that `-42`
+# padded to five characters becomes `-0042` and not `00-42`. Characters are
+# counted, and not bytes. A `text` of `width` characters or longer is
+# returned unchanged.
+# If `width` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-pad` fallback is returned, or the terminator
+# when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ width cant-pad] > padded-zeros
+  if. > @
+    or.
+      0.gt width
+      width.is-integer.not
+    cant-pad
+      width.is-finite.if
+        "Can't pad text to %f characters with zeros".printf
+          * width
+        "Can't pad text to %s characters with zeros".printf
+          *
+            string width.as-scientific
+    if.
+      and.
+        0.lt
+          text.length >> len!
+        "-".eq
+          text.slice 0 1
+      string
+        2D-.concat
+          as-bytes.
+            padded-left.
+              text.slice 1 ((number len).minus 1).as-number
+              if.
+                1.gt width
+                0
+                as-number.
+                  width.minus 1
+              "0"
+              cant-pad
+      text.padded-left
+        width
+        "0"
+        cant-pad
+  ^ > text
+
+  eq. ++> can-count-characters-and-not-bytes-when-padding-with-zeros
+    "00Ж"
+    "Ж".padded-zeros 3
+
+  eq. ++> can-format-the-error-message-of-a-negative-width-when-padding-with-zeros
+    "Can't pad text to -4.000000 characters with zeros"
+    "7".padded-zeros
+      -4
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-with-zeros
+    "Can't pad text to infinity characters with zeros"
+    "7".padded-zeros
+      pinf
+      I
+
+  eq. ++> can-keep-a-minus-sign-in-front-of-the-zeros
+    "-0042"
+    "-42".padded-zeros 5
+
+  eq. ++> can-pad-a-positive-number-with-leading-zeros
+    "00042"
+    "42".padded-zeros 5
+
+  eq. ++> can-pad-an-empty-text
+    "000"
+    "".padded-zeros 3
+
+  eq. ++> can-recover-from-a-negative-width-when-padding-with-zeros
+    "recovered"
+    "7".padded-zeros
+      -4
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-non-integer-width-when-padding-with-zeros
+    "recovered"
+    "7".padded-zeros
+      3.5
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-width-when-padding-with-zeros
+    "recovered"
+    "7".padded-zeros
+      pinf
+      "recovered" > [message]
+
+  eq. ++> can-return-a-longer-text-unchanged-when-padding-with-zeros
+    "12345"
+    "12345".padded-zeros 3
+
+  eq. ++> can-return-a-negative-text-of-the-exact-width-unchanged
+    "-42"
+    "-42".padded-zeros 3
+
+  "7".padded-zeros -4 --> stops-on-a-negative-width-when-padding-with-zeros

--- a/objects/string/printf.eo
+++ b/objects/string/printf.eo
@@ -1,6 +1,12 @@
 # Object `printf` allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.
 #
+# A specifier reads as `%[N$][flags][width][.precision]conversion`, where
+# `N$` picks the `N`-th argument (1-based) instead of the next sequential
+# one, `-` justifies to the left, `0` pads a number with leading zeros,
+# `width` is the minimum count of characters and `.precision` truncates
+# the text (or, for `%f`, counts the fraction digits).
+#
 # When arguments are processed - they're dataized and converted to objects
 # depending on next flags:
 # - %s - converts object to `string`
@@ -8,227 +14,627 @@
 # - %f - converts object to `float`
 # - %x - converts object to `bytes`
 # - %b - converts object to boolean, `true` or `false`.
+#
+# The format is walked over its bytes, and not over its characters, because
+# `%` never occurs inside a UTF-8 multi-byte sequence, so a literal byte is
+# copied through untouched and the walk stays linear in allocation.
+#
+# The work is done by two objects calling each other, so that the format is
+# traversed exactly once: `walk` copies a literal byte and steps forward,
+# handing every `%` to `spec`, which reads one specifier and asks `walk` to
+# continue after it.
+#
+# `spec` reads that specifier from left to right and names every position it
+# stops at: `dollar` is the `$` of a positional argument, `flags` opens
+# the specifier itself, `digits` follows the `-` and `0` flags, `dot`
+# follows the width digits, and `end` holds the conversion letter. Those
+# positions, and everything derived from them, are memoized, because the
+# language caches through `!` alone, and they are listed alphabetically
+# rather than in reading order, because the linter sorts them by name.
+#
+# The `%s` conversion refuses an argument whose bytes do not decode as UTF-8.
+# `false` and `true` dataize to the single bytes `00-` and `01-`, which are
+# also the valid one-character encodings of U+0000 and U+0001, so an object
+# knows its own bytes here and not its type: a boolean routed through `%s`
+# is printed as that control character instead of being rejected, and `%b`
+# remains the conversion to reach for a boolean.
+#
+# The `%d` guard names the number it rejects through `as-scientific` and not
+# through `%f`, because every magnitude it rejects is past the range `as-fixed`
+# writes, and a reason rendered with `%f` destroyed itself instead of arriving.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+rt jvm org.eolang:eo-runtime:0.62.0
-+rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > printf /Q.string
-  ? > format /Q.string
-  ? > args /Q.tuple
+[^ args] > printf
+  string > @
+    [^ index auto acc] >> walk
+      if. > @
+        gte.
+          number cursor
+          number span
+        acc
+        if.
+          25-.eq char
+          spec
+            number cursor
+            auto
+            acc
+          ^.walk
+            as-number.
+              plus.
+                number cursor
+                1
+            auto
+            acc.concat char
+      slice. > char!
+        bytes raw
+        number cursor
+        1
+      index > cursor!
+    | 0 0 --
+  slice. > [^ i] >> byte
+    bytes raw
+    i
+    1
+  as-ascii. > [^ i] >> code
+    string
+      byte i
+  if. > [^ i] >> digits-end
+    i.gte
+      number span
+    i
+    if.
+      and.
+        48.lte
+          code i
+        57.gte
+          code i
+      ^.digits-end
+        as-number.
+          i.plus 1
+      i
+  if. > [^ from to acc] >> digits-value
+    from.gte to
+    acc
+    ^.digits-value
+      as-number.
+        from.plus 1
+      to
+      as-number.
+        plus.
+          acc.times 10
+          minus.
+            code from
+            48
+  T message > [message] >> failure
+  if. > [^ i] >> flags-end
+    i.gte
+      number span
+    i
+    if.
+      or.
+        2D-.eq
+          byte i
+        30-.eq
+          byte i
+      ^.flags-end
+        as-number.
+          i.plus 1
+      i
+  ^ > format
+  2.power 63 >> limit!
+  size. >> span!
+    bytes
+      format.as-bytes >> raw!
+  [^ index auto acc] >> spec
+    if. > @
+      gte.
+        number end
+        number span
+      T
+        "The format %s ends with an incomplete specifier, a conversion character is missing".printf
+          * ^.format
+      if.
+        25-.eq conv
+        if.
+          eq.
+            number end
+            as-number.
+              index.plus 1
+          walk
+            as-number.
+              plus.
+                number end
+                1
+            auto
+            acc.concat 25-
+          T
+            "The escaped %% conversion does not take flags, width or precision".printf
+              * ^.format
+        walk
+          as-number.
+            plus.
+              number end
+              1
+          positional.as-bool.if
+            auto
+            as-number.
+              auto.plus 1
+          seq *
+            value
+            acc.concat padded
+    ^.args.at > arg
+      number idx
+    byte > conv!
+      number end
+    if. > converted!
+      73-.eq conv
+      as-bytes. > [^ text] >> capped
+        ^.precise.as-bool.if
+          truncated.
+            string text
+            number ^.precision
+            failure
+          text
+      |
+        seq *
+          length.
+            string datum
+          capped datum
+      if.
+        64-.eq conv
+        as-decimal.
+          if.
+            or.
+              gte.
+                number numeric
+                number limit
+              lt.
+                number numeric
+                times.
+                  number limit
+                  -1
+            T
+              "The number %s doesn't fit into the long range of the '%%d' conversion".printf
+                *
+                  string (number numeric).as-scientific
+            number numeric
+        if.
+          66-.eq conv
+          as-fixed.
+            number numeric
+            precise.as-bool.if
+              number precision
+              6
+            failure
+          if.
+            78-.eq conv
+            capped (bytes datum).as-hex
+            if.
+              62-.eq conv
+              capped
+                arg.as-bool.if "true" "false"
+              T
+                "The conversion %x in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
+                  *
+                    bytes conv
+    arg.as-bytes > datum!
+    flags-end > digits!
+      number flags
+    digits-end > dollar!
+      as-number.
+        index.plus 1
+    digits-end > dot!
+      number digits
+    precise.as-bool.if > end!
+      digits-end
+        as-number.
+          plus.
+            number dot
+            1
+      number dot
+    as-bytes. > filled!
+      padded-zeros.
+        string value
+        number width
+        failure
+    positional.as-bool.if > flags!
+      as-number.
+        plus.
+          number dollar
+          1
+      as-number.
+        index.plus 1
+    positional.as-bool.if > idx!
+      as-number.
+        minus.
+          digits-value
+            as-number.
+              index.plus 1
+            number dollar
+            0
+          1
+      auto
+    number arg > numeric!
+    if. > padded!
+      if. > [^ i c] >> flagged
+        i.gte
+          number ^.digits
+        false
+        if.
+          c.eq
+            byte i
+          true
+          ^.flagged
+            as-number.
+              i.plus 1
+            c
+      | (number flags) 2D-
+      as-bytes.
+        padded-right.
+          string value
+          number width
+          " "
+          failure
+      zero.as-bool.if
+        filled
+        as-bytes.
+          padded-left.
+            string value
+            number width
+            " "
+            failure
+    and. > positional!
+      gt.
+        number dollar
+        index.plus 1
+      and.
+        lt.
+          number dollar
+          number span
+        24-.eq
+          byte
+            number dollar
+    and. > precise!
+      lt.
+        number dot
+        number span
+      2E-.eq
+        byte
+          number dot
+    precise.as-bool.if > precision!
+      digits-value
+        as-number.
+          plus.
+            number dot
+            1
+        number end
+        0
+      0
+    if. > value!
+      positional.as-bool.and
+        18.lt
+          minus.
+            number dollar
+            index.plus 1
+      T
+        "The positional argument index in the format %s is too large".printf
+          * ^.format
+      if.
+        positional.as-bool.and
+          lt.
+            number idx
+            0
+        T
+          "The positional argument index %d in the format must be 1 or greater".printf
+            *
+              plus.
+                number idx
+                1
+        if.
+          gte.
+            number idx
+            ^.args.length
+          T
+            "The argument index %d in the format is out of bounds, only %d given".printf
+              *
+                plus.
+                  number idx
+                  1
+                ^.args.length
+          if.
+            precise.as-bool.and
+              64-.eq conv
+            T
+              "A precision of %d can't be applied to the %%d conversion".printf
+                *
+                  number precision
+            if.
+              zero.as-bool.and
+                not.
+                  or.
+                    64-.eq conv
+                    66-.eq conv
+              T
+                "The zero flag can't be applied to the %x conversion, only to %%d and %%f".printf
+                  *
+                    bytes conv
+              converted
+    digits-value > width!
+      number digits
+      number dot
+      0
+    flagged > zero!
+      number flags
+      30-
+
+  eq. ++> can-answer-the-size-of-the-formatted-text
+    size.
+      "Hello, %s".printf
+        * "Jeff"
+    11
+
+  eq. ++> can-apply-a-precision-to-a-non-ascii-string
+    "Жир"
+    "%.3s".printf
+      * "Жирафы"
+
+  eq. ++> can-apply-a-precision-to-a-string
+    "Jef"
+    "%.3s".printf
+      * "Jeffrey"
 
   eq. ++> can-apply-a-precision-to-bytes
     "40-"
-    printf *1
-      "%.3x"
-      42.as-bytes
+    "%.3x".printf
+      * 42.as-bytes
+
+  eq. ++> can-apply-a-precision-wider-than-a-non-ascii-string
+    "Жирафы"
+    "%.10s".printf
+      * "Жирафы"
 
   eq. ++> can-apply-a-width-to-bytes
     "  40-45-00-00-00-00-00-00"
-    printf *1
-      "%25x"
-      42.as-bytes
+    "%25x".printf
+      * 42.as-bytes
+
+  eq. ++> can-format-a-boolean-as-a-control-character
+    "\u0001"
+    "%s".printf
+      * true
+
+  eq. ++> can-format-a-computed-string
+    "abcd"
+    "%s".printf
+      *
+        "ab".concat "cd"
+
+  eq. ++> can-format-a-decimal-above-two-to-the-53rd
+    "9007199254740992"
+    "%d".printf
+      * 9007199254740992
+
+  eq. ++> can-format-a-float-above-two-to-the-53rd
+    "9007199254740992.000000"
+    "%f".printf
+      * 9007199254740992
 
   eq. ++> can-format-a-float-with-six-fraction-digits
     "1.250000"
-    printf *1
-      "%f"
-      1.25
+    "%f".printf
+      * 1.25
+
+  eq. ++> can-format-a-large-negative-decimal
+    "-9007199254740992"
+    "%d".printf
+      * -9007199254740992
+
+  eq. ++> can-format-a-null-control-character-as-a-string
+    "\u0000"
+    "%s".printf
+      * "\u0000"
 
   eq. ++> can-format-a-numbered-substitution
     "Hello, Jeff! Bye, Jeff!"
-    printf *1
-      "Hello, %s! Bye, %1$s!"
-      "Jeff"
+    "Hello, %s! Bye, %1$s!".printf
+      * "Jeff"
 
   eq. ++> can-format-a-numbered-substitution-with-many-arguments
     "This is the first; This is the first as well; The second; and the 3"
-    printf *1
-      "This is the %s; This is the %1$s as well; The %s; and the %d"
-      "first"
-      "second"
-      3
+    "This is the %s; This is the %1$s as well; The %s; and the %d".printf
+      *
+        "first"
+        "second"
+        3
 
   eq. ++> can-format-a-precision-of-two-decimals
     "3.14"
-    printf *1
-      "%.2f"
-      3.1415
+    "%.2f".printf
+      * 3.1415
+
+  eq. ++> can-format-a-start-of-heading-control-character-as-a-string
+    "\u0001"
+    "%s".printf
+      * "\u0001"
 
   eq. ++> can-format-a-width-with-leading-spaces
     "   42"
-    printf *1
-      "%5d"
-      42
+    "%5d".printf
+      * 42
 
   eq. ++> can-format-a-zero-float-with-six-fraction-digits
     "0.000000"
-    printf *1
-      "%f"
-      0
+    "%f".printf
+      * 0
 
   eq. ++> can-format-left-justified-with-trailing-spaces
     "x         "
-    printf *1
-      "%-10s"
-      "x"
+    "%-10s".printf
+      * "x"
 
   eq. ++> can-format-objects-of-every-type
     "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
-    printf *1
-      "string %s, bytes %x, float %f, int %d, bool %b"
-      "Jeff"
-      "Jeff".as-bytes
-      42.3
-      14
-      false
+    "string %s, bytes %x, float %f, int %d, bool %b".printf
+      *
+        "Jeff"
+        "Jeff".as-bytes
+        42.3
+        14
+        false
 
   eq. ++> can-format-ordered-numbered-substitutions
     "first second second is after first"
-    printf *1
-      "%s %s %2$s is after %1$s"
-      "first"
-      "second"
+    "%s %s %2$s is after %1$s".printf
+      * "first" "second"
 
   eq. ++> can-ignore-extra-arguments
     "Hey"
-    printf *1
-      "%s"
-      "Hey"
-      "Jeff"
+    "%s".printf
+      * "Hey" "Jeff"
 
   eq. ++> can-left-align-bytes
     "40-45-00-00-00-00-00-00  "
-    printf *1
-      "%-25x"
-      42.as-bytes
+    "%-25x".printf
+      * 42.as-bytes
 
   eq. ++> can-preserve-an-escaped-bytes-format
     "%x"
-    printf
-      "%%x"
+    "%%x".printf
       *
 
   eq. ++> can-print-a-complex-string
     "Привет 3.140000 Jeff X!"
-    printf *1
-      "Привет %f %s %s!"
-      3.14
-      "Jeff"
-      "X"
+    "Привет %f %s %s!".printf
+      *
+        3.14
+        "Jeff"
+        "X"
 
   eq. ++> can-print-a-percent-sign
     "%Jeff"
-    printf *1
-      "%%%s"
-      "Jeff"
+    "%%%s".printf
+      * "Jeff"
 
   eq. ++> can-print-a-simple-string
     "Hello, Jeffrey!"
-    printf *1
-      "Hello, %s!"
-      "Jeffrey"
+    "Hello, %s!".printf
+      * "Jeffrey"
 
   eq. ++> can-print-an-i64-as-a-number
     "42"
-    printf *1
-      "%d"
-      42.as-i64.as-number
+    "%d".printf
+      * 42.as-i64.as-number
+
+  not. ++> can-print-an-i64-not-as-a-number
+    eq.
+      "%d".printf
+        * 42.as-i64
+      "42"
 
   eq. ++> can-print-bytes
     "40-45-00-00-00-00-00-00"
-    printf *1
-      "%x"
-      42.as-bytes
+    "%x".printf
+      * 42.as-bytes
 
   eq. ++> can-round-a-float-carrying-into-the-integer-part
     "1.000000"
-    printf *1
-      "%f"
-      0.9999999
+    "%f".printf
+      * 0.9999999
 
   eq. ++> can-truncate-a-negative-float-toward-zero
     "-7"
-    printf *1
-      "%d"
-      -7.89
+    "%d".printf
+      * -7.89
 
   eq. ++> can-truncate-a-positive-float-toward-zero
     "42"
-    printf *1
-      "%d"
-      42.321
+    "%d".printf
+      * 42.321
 
   eq. ++> can-truncate-rather-than-round-a-float
     "9"
-    printf *1
-      "%d"
-      9.99
+    "%d".printf
+      * 9.99
 
-  not. ++> cannot-print-an-i64
-    eq.
-      printf *1
-        "%d"
-        42.as-i64
-      "42"
+  eq. ++> can-write-the-negative-long-boundary-as-a-decimal
+    "-9223372036854775808"
+    "%d".printf
+      * -9.223372036854776e18
 
-  printf *1 --> stops-on-a-comma-flag-with-s
+  printf. --> stops-on-a-comma-flag-with-s
     "%,s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-comma-flag-with-x
+  printf. --> stops-on-a-comma-flag-with-x
     "%,x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-hash-flag-with-s
+  printf. --> stops-on-a-flag-before-an-escaped-percent
+    "%-%s"
+    * "x"
+
+  printf. --> stops-on-a-hash-flag-with-s
     "%#s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-hash-flag-with-x
+  printf. --> stops-on-a-hash-flag-with-x
     "%#x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-non-utf8-byte-argument-as-a-string
+  printf. --> stops-on-a-non-utf8-byte-argument-as-a-string
     "%s"
-    3.14
+    * 3.14
 
-  printf *1 --> stops-on-a-paren-flag-with-s
+  printf. --> stops-on-a-number-as-a-string
+    "%s"
+    * 42
+
+  printf. --> stops-on-a-paren-flag-with-s
     "%(s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-a-precision-with-d
+  printf. --> stops-on-a-precision-with-d
     "%.2d"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-zero-flag-with-x
+  printf. --> stops-on-a-width-before-an-escaped-percent
+    "%5%s"
+    * "x"
+
+  printf. --> stops-on-a-zero-flag-with-x
     "%0x"
-    5
+    * 5
 
-  printf *1 --> stops-on-a-zero-positional-index
+  printf. --> stops-on-a-zero-positional-index
     "%0$s"
-    "first"
+    * "first"
 
-  printf *1 --> stops-on-an-oversized-positional-index
+  printf. --> stops-on-an-i64-as-a-string
+    "%s"
+    * 42.as-i64
+
+  printf. --> stops-on-an-oversized-positional-index
     "%99999999999999999999$s"
-    "Jeff"
+    * "Jeff"
 
-  printf --> stops-on-an-unsupported-format
+  printf. --> stops-on-an-unsupported-format
     "%o"
     *
 
-  printf *1 --> stops-on-arguments-that-do-not-match
+  printf. --> stops-on-arguments-that-do-not-match
     "%s%s"
-    "Jeff"
+    * "Jeff"
 
-  printf *1 --> stops-on-formatting-a-huge-number-as-a-decimal
+  printf. --> stops-on-formatting-a-huge-number-as-a-decimal
     "%d"
-    1.0e30
+    * 1.0e30
 
-  printf *1 --> stops-on-formatting-nan-as-a-decimal
+  printf. --> stops-on-formatting-nan-as-a-decimal
     "%d"
-    nan
+    * nan

--- a/objects/string/regex.eo
+++ b/objects/string/regex.eo
@@ -17,30 +17,39 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
-[expression] > regex
+[^] > regex
   compile > @
   [] > compile /Q.string.regex.pattern
+    ? > ^
     ? > cant-compile /{Q.string}
-  [serialized] > pattern
-    pattern serialized > compiled
-    [txt] > match
-      [position start from to groups] > matched
+  ^ > expression
+  [^ serialized] > pattern
+    ^.pattern serialized > compiled
+    [^ txt] > match
+      [^ position start from to groups] > matched
         groups.length > count
         start.gte 0 > exists
-        groups.at index > [index] > group
+        ^.groups.at index > [^ index] > group
         $ > matched
         exists.if > next
-          matched.
-            matched-from-index
-              position.plus 1
-              to
+          if.
+            and.
+              from.eq to
+              to.eq ^.txt.length
+            ^.missing
+            matched.
+              ^.matched-from-index
+                position.plus 1
+                if.
+                  from.eq to
+                  to.plus 1
+                  to
           T
             "Matched block does not exist, can't get next"
         exists.if > text
@@ -48,17 +57,66 @@
           T
             "Matched block does not exist, can't get text"
       [] > matched-from-index /Q.string.regex.pattern.match.matched
+        ? > ^
         ? > position /Q.number
         ? > start /Q.number
+      [] > missing
+        T > count
+          "Matched block does not exist, can't get count"
+        start.gte 0 > exists
+        T > from
+          "Matched block does not exist, can't get 'from' position"
+        T > [index] > group
+          "Matched block does not exist, can't get group"
+        T > groups
+          "Matched block does not exist, can't get groups"
+        T > next
+          "Matched block does not exist, can't get next"
+        0 > position
+        -1 > start
+        T > text
+          "Matched block does not exist, can't get text"
+        T > to
+          "Matched block does not exist, can't get 'to' position"
       matched. > next
         matched-from-index 1 0
-    [txt] > matches
+    [^ txt] > matches
       found.exists.and > @
         and.
           found.to.eq txt.length
           found.from.eq 0
+      "/(?:%s)(?![\\s\\S])/%s".printf > anchored
+        * group1 group2
+      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented
+        * group1 group2
       next. > found
-        match txt
+        match.
+          anchored.regex.compile retry-commented
+          txt
+      parsed.group 1 > group1!
+      parsed.group 2 > group2!
+      next. > parsed
+        "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match ^.^.expression
+      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
+        * group1 group2
+      ^.commented.regex.compile ^.retry-quoted > [^ message] > retry-commented
+      ^.quoted.regex.compile > [^ message] > retry-quoted
+
+  eq. ++> can-advance-after-a-zero-width-match
+    1
+    from. ("/a*/".regex.match "xa").next.next
+
+  ++> can-count-supplementary-characters-as-one-position
+    and. > @
+      and.
+        0.eq first.from
+        1.eq first.to
+      and.
+        1.eq second.from
+        2.eq second.to
+    next. > first
+      "/./".regex.compiled.match "😀x"
+    first.next > second
 
   ++> can-expose-groups-on-each-matched-block
     and. > @
@@ -81,57 +139,54 @@
           second.group 2
           "2"
     next. > first
-      match.
-        compiled.
-          regex "/([a-z]+)([1-9]{1})/"
-        "!hello1!world2"
+      "/([a-z]+)([1-9]{1})/".regex.compiled.match "!hello1!world2"
     first.next > second
 
   matches. ++> can-ignore-comments-in-a-pattern
-    compiled.
-      regex
-        "/(\\d) #ignore this comment/x"
+    "/(\\d) #ignore this comment/x".regex.compiled
     "4"
 
-  matches. ++> can-match-a-text-against-a-pattern
-    compiled.
-      regex "/[a-z]+/"
-    "hello"
+  "/[a-z]+/".regex.compiled.matches "hello" ++> can-match-a-text-against-a-pattern
 
-  matches. ++> can-match-an-entire-pattern
-    compiled.
-      regex "/[0-9]/\\d+/"
-    "2/75"
+  matches. ++> can-match-a-text-containing-supplementary-characters
+    "/😀x/".regex.compiled
+    "😀x"
+
+  "/[0-9]/\\d+/".regex.compiled.matches "2/75" ++> can-match-an-entire-pattern
 
   matches. ++> can-match-with-the-case-insensitive-option
-    compiled.
-      regex "/(string)/i"
+    "/(string)/i".regex.compiled
     "StRiNg"
 
   matches. ++> can-match-with-the-case-insensitive-option-and-capitals
-    compiled.
-      regex "/(word)/i"
+    "/(word)/i".regex.compiled
     "WORD"
 
   matches. ++> can-match-with-the-dotall-option
-    compiled.
-      regex "/(.*)/s"
+    "/(.*)/s".regex.compiled
     "too \\n many \\n line \\n Feed\\n"
 
   matches. ++> can-match-with-the-multiline-option
-    compiled.
-      regex "/(^([0-9]+).*)/m"
+    "/(^([0-9]+).*)/m".regex.compiled
     "1 bottle of water on the wall. \\n1 bottle of water."
 
   matches. ++> can-match-with-the-unicode-case-option
-    compiled.
-      regex "/(yildirim)/ui"
+    "/(yildirim)/ui".regex.compiled
     "Yıldırım"
 
   matches. ++> can-match-with-the-unix-lines-option
-    compiled.
-      regex "/(.+)/d"
+    "/(.+)/d".regex.compiled
     "A\\r\\nB\\rC\\nD"
+
+  eq. ++> can-recover-from-a-pattern-with-a-missing-slash
+    "no-slash"
+    "(.)+".regex.compile
+      "no-slash" > [message]
+
+  eq. ++> can-recover-from-invalid-regex-syntax
+    "recovered"
+    "/[a-z/".regex.compile
+      "recovered" > [message]
 
   ++> can-report-the-border-indexes-of-a-match
     and. > @
@@ -140,16 +195,12 @@
         1.eq n.from
         6.eq n.to
     next. > n
-      match.
-        regex "/[a-z]+/"
-        "!hello!"
+      "/[a-z]+/".regex.match "!hello!"
 
   eq. ++> can-return-the-matched-string-sequence
     text.
       next.
-        match.
-          regex "/[a-z]+/"
-          "!hello!"
+        "/[a-z]+/".regex.match "!hello!"
     "hello"
 
   ++> can-return-the-second-matched-block
@@ -164,88 +215,77 @@
       second.to.eq 12
     next. > second
       next.
-        match.
-          regex "/[a-z]+/"
-          "!hello!world!"
+        "/[a-z]+/".regex.match "!hello!world!"
 
-  not. ++> cannot-match-a-text-against-a-wrong-pattern
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "123"
+  not. ++> can-stop-at-a-terminal-zero-width-match
+    exists. ("/$/".regex.match "x").next.next
 
-  not. ++> cannot-match-an-anchored-pattern-with-a-trailing-newline
-    matches.
-      compiled.
-        regex "/^[0-9]+$/"
-      "123\n"
+  not. ++> can-tell-it-does-not-match-a-text-against-a-wrong-pattern
+    "/[a-z]+/".regex.compiled.matches "123"
 
-  not. ++> cannot-match-with-unmatched-leading-characters
-    matches.
-      compiled.
-        regex "/[a-z]+/"
-      "1abc"
+  not. ++> can-tell-it-does-not-match-an-anchored-pattern-with-a-trailing-newline
+    "/^[0-9]+$/".regex.compiled.matches "123\n"
 
-  eq. ++> rejects-a-pattern-with-a-missing-slash
-    "no-slash"
-    compile.
-      regex "(.)+"
-      "no-slash" > [message]
+  not. ++> can-tell-it-does-not-match-with-unmatched-leading-characters
+    "/[a-z]+/".regex.compiled.matches "1abc"
 
-  eq. ++> rejects-invalid-regex-syntax
-    "recovered"
-    compile.
-      regex "/[a-z/"
-      "recovered" > [message]
+  next. --> rejects-serialized-bytes-of-the-wrong-type
+    match.
+      ^.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
+      "hello"
 
-  compiled. --> stops-on-a-missing-closing-slash
-    regex "/pattern"
+  "/pattern".regex.compiled --> stops-on-a-missing-closing-slash
 
-  compiled. --> stops-on-a-missing-first-slash
-    regex "(.)+"
+  "(.)+".regex.compiled --> stops-on-a-missing-first-slash
 
-  compile. --> stops-on-compiling-an-invalid-pattern
-    regex "/[a-z/"
+  "/[a-z/".regex.compile --> stops-on-compiling-an-invalid-pattern
+
+  group. --> stops-on-taking-a-group-of-a-terminal-zero-width-match
+    next.
+      next.
+        "/$/".regex.match "x"
+    1
 
   group. --> stops-on-taking-a-group-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
     1
 
   to. --> stops-on-taking-the-end-position-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
+
+  count. --> stops-on-taking-the-group-count-of-a-terminal-zero-width-match
+    next.
+      next.
+        "/$/".regex.match "x"
 
   count. --> stops-on-taking-the-group-count-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   groups. --> stops-on-taking-the-groups-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
+
+  next. --> stops-on-taking-the-next-of-a-terminal-zero-width-match
+    next.
+      next.
+        "/$/".regex.match "x"
 
   next. --> stops-on-taking-the-next-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
 
   from. --> stops-on-taking-the-start-position-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"
+
+  text. --> stops-on-taking-the-text-of-a-terminal-zero-width-match
+    next.
+      next.
+        "/$/".regex.match "x"
 
   text. --> stops-on-taking-the-text-of-an-unmatched-block
     next.
-      match.
-        regex "/[a-z]+/"
-        "123"
+      "/[a-z]+/".regex.match "123"

--- a/objects/string/repeated.eo
+++ b/objects/string/repeated.eo
@@ -1,80 +1,90 @@
 # Returns `text` repeated `times` times.
 # If `times` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-repeat` fallback is returned,
-# or the bottom object when unbound.
+# or the terminator when unbound.
 # If `times` == 0, empty text is returned.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text times cant-repeat] > repeated
+[^ times cant-repeat] > repeated
   if. > @
     or.
       0.gt times
       times.is-integer.not
     cant-repeat
-      "Can't repeat text %f times".printf
-        * times
+      times.is-finite.if
+        "Can't repeat text %f times".printf
+          * times
+        "Can't repeat text %s times".printf
+          *
+            string times.as-scientific
     string
-      if. >> result!
-        0.eq
-          times >> amount!
-        --
-        if. > [accum index] >> rec-repeated
-          amount.eq index
-          accum
-          rec-repeated
-            accum.concat b
-            as-number.
-              index.plus 1
-        |
-          text >> b!
-          1
+      [^ n] >> rec-repeated
+        if. > @
+          0.eq n
+          --
+          if.
+            0.eq
+              n.mod 2
+            twice
+            concat.
+              half.concat >> twice
+                ^.rec-repeated (n.div 2).floor >> half!
+              ^.text.as-bytes
+      | times
+  ^ > text
 
   eq. ++> can-format-the-error-message-of-a-negative-count
     "Can't repeat text -1.000000 times"
-    repeated
-      "x"
+    "x".repeated
       -1
-      message > [message]
+      I
 
-  eq. ++> can-repeat-a-text-five-times
-    "heyheyheyheyhey"
-    repeated
-      "hey"
-      5
+  eq. ++> can-format-the-error-message-of-an-infinite-count
+    "Can't repeat text infinity times"
+    "x".repeated
+      pinf
+      I
 
-  eq. ++> can-repeat-a-text-zero-times
-    ""
-    repeated
-      "some"
-      0
-
-  eq. ++> rejects-a-negative-count
+  eq. ++> can-recover-from-a-negative-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       -1
       "recovered" > [message]
 
-  eq. ++> rejects-a-non-integer-count
+  eq. ++> can-recover-from-a-non-integer-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       2.5
       "recovered" > [message]
 
-  eq. ++> rejects-an-infinite-count
+  eq. ++> can-recover-from-an-infinite-count
     "recovered"
-    repeated
-      "x"
+    "x".repeated
       pinf
       "recovered" > [message]
 
-  repeated --> stops-on-a-negative-count
+  eq. ++> can-repeat-a-text-five-times
+    "heyheyheyheyhey"
+    "hey".repeated 5
+
+  eq. ++> can-repeat-a-text-six-times
+    "zxzxzxzxzxzx"
+    "zx".repeated 6
+
+  eq. ++> can-repeat-a-text-twenty-thousand-times
+    20000
+    size.
+      as-bytes.
+        "x".repeated 20000
+
+  eq. ++> can-repeat-a-text-zero-times
     ""
-    -1
+    "some".repeated 0
+
+  "".repeated -1 --> stops-on-a-negative-count

--- a/objects/string/replaced.eo
+++ b/objects/string/replaced.eo
@@ -6,22 +6,22 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text target replacement] > replaced
+[^ target replacement] > replaced
   matched.exists.not.if > @
     string text! >> reinit
-    block.exists.if > [block accum start] >> rec-replaced
-      rec-replaced
+    block.exists.if > [^ block accum start] >> rec-replaced
+      ^.rec-replaced
         block.next
         concat.
           accum.concat
             reinit.slice
               start
               block.from.minus start
-          replacement
+          ^.replacement
         block.to
       string
         accum.concat
@@ -34,38 +34,40 @@
       start.
         next. >> matched
           target.match reinit
+  ^ > text
+
+  eq. ++> can-replace-a-nullable-pattern-like-java
+    "abc".replaced
+      "/x*/".regex
+      "-"
+    "-a-b-c-"
 
   eq. ++> can-replace-a-windows-separator-with-a-slash
-    replaced
-      "C:\\Windows\\Users\\AppLocal\\shrek"
-      regex "/[\\\\:]+/"
+    "C:\\Windows\\Users\\AppLocal\\shrek".replaced
+      "/[\\\\:]+/".regex
       "/"
     "C/Windows/Users/AppLocal/shrek"
 
   eq. ++> can-replace-digits-with-a-string
-    replaced
-      "Hell0, w0rld"
-      regex "/[0-9]+/"
+    "Hell0, w0rld".replaced
+      "/[0-9]+/".regex
       "o"
     "Hello, world"
 
+  eq. ++> can-replace-nothing-when-the-pattern-is-absent
+    "Hello, world".replaced
+      "/[0-9]+/".regex
+      "12345"
+    "Hello, world"
+
   eq. ++> can-replace-slashes-with-a-windows-separator
-    replaced
-      "C:\\Windows/foo\\bar/hello.txt"
-      regex "/\\//"
+    "C:\\Windows/foo\\bar/hello.txt".replaced
+      "/\\//".regex
       "\\"
     "C:\\Windows\\foo\\bar\\hello.txt"
 
   eq. ++> can-sanitize-a-windows-path
-    replaced
-      "foo\\bar<:>?*\"|baz\\asdf"
-      regex "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/"
+    "foo\\bar<:>?*\"|baz\\asdf".replaced
+      "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/".regex
       ""
     "foo\\barbaz\\asdf"
-
-  eq. ++> cannot-replace-when-the-pattern-is-absent
-    replaced
-      "Hello, world"
-      regex "/[0-9]+/"
-      "12345"
-    "Hello, world"

--- a/objects/string/scanf.eo
+++ b/objects/string/scanf.eo
@@ -7,53 +7,137 @@
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
+#
+# The `%f` conversion never materializes the whole power of ten at once,
+# because `10.power 309` is already infinity: a single multiplication by it
+# turns every mantissa into infinity and a single division by it turns every
+# mantissa into zero, whatever the written value is. `raised` and `lowered`
+# therefore scale in steps of at most `10^200`, so every intermediate stays
+# inside the double range and an underflow happens only when the value itself
+# underflows. Both stop as soon as the value is zero or infinite, since no
+# further step can move it, and that is what keeps the recursion short for an
+# exponent written far outside the range, such as `1e999999999`. The step was
+# `10^300` until #7456: `number.power`'s exponentiation by squaring drifts
+# further from the exact power of ten the larger the exponent it is asked
+# for, and at 300 that drift was already enough to carry a text naming a
+# value inside the double range past its edge into infinity; 200 keeps the
+# same one-step shape for every exponent this parser is ever asked to
+# handle while landing on a smaller power of ten to start the drift from.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[format read] > scanf
-  [pattern specifiers] >>
-    [text] > as-float
-      negative.if negated magnitude > @
-      index-of unsigned "." > dot
+[^ read] > scanf
+  ^ > format
+  [^ pattern specifiers] >>
+    [^ text] > as-float
+      negative.if negated scaled > @
+      mantissa.index-of "." > dot
+      esign.index-of "e" > eloc
+      unsigned.replaced "/[eE]/".regex "e" > esign
+      [^ txt] > exp-value
+        if. > @
+          eq.
+            txt.slice 0 1
+            "-"
+          folded.times -1
+          if.
+            eq.
+              txt.slice 0 1
+              "+"
+            folded
+            folded
+        ^.^.fold-digits > folded
+          signed.if
+            txt.slice
+              1
+              txt.length.minus 1
+            txt
+        or. > signed
+          eq.
+            txt.slice 0 1
+            "-"
+          eq.
+            txt.slice 0 1
+            "+"
+      if. > exponent
+        eloc.eq -1
+        0
+        exp-value
+          esign.slice
+            eloc.plus 1
+            esign.length.minus
+              eloc.plus 1
+      if. > [^ value power] > lowered
+        and.
+          power.gt 200
+          ^.scalable value
+        ^.lowered
+          value.div
+            10.power 200
+          power.minus 200
+        value.div
+          10.power power
       if. > magnitude
         not.
           dot.eq -1
         plus.
-          fold-digits
-            slice unsigned 0 dot
+          ^.fold-digits
+            mantissa.slice 0 dot
           div.
-            fold-digits
-              slice
-                unsigned
+            ^.fold-digits
+              mantissa.slice
                 dot.plus 1
                 places
             10.power places
-        fold-digits unsigned
-      magnitude.times -1 > negated
+        ^.fold-digits mantissa
+      if. > mantissa
+        eloc.eq -1
+        esign
+        esign.slice 0 eloc
+      scaled.times -1 > negated
       eq. > negative
-        slice
-          text
-          0
-          1
+        text.slice 0 1
         "-"
-      unsigned.length.minus > places
+      mantissa.length.minus > places
         dot.plus 1
+      if. > [^ value power] > raised
+        and.
+          power.gt 200
+          ^.scalable value
+        ^.raised
+          value.times
+            10.power 200
+          power.minus 200
+        value.times
+          10.power power
+      and. > [value] > scalable
+        not.
+          value.eq 0
+        value.is-finite
+      if. > scaled
+        exponent.eq 0
+        magnitude
+        if.
+          exponent.gt 0
+          raised magnitude exponent
+          lowered
+            magnitude
+            exponent.times -1
       negative.or > signed
         eq.
-          slice text 0 1
+          text.slice 0 1
           "+"
       signed.if > unsigned
-        slice
-          text
+        text.slice
           1
           text.length.minus 1
         text
-    [text] > as-integer
+    [^ text] > as-integer
       if. > @
         or.
           normalized.length.gt 19
@@ -64,36 +148,34 @@
                 digits-lte normalized "9223372036854775808"
                 digits-lte normalized "9223372036854775807"
         T
-          "The number doesn't fit into long range for the '%%d' conversion"
+          "The number doesn't fit into long range for the '%%d' conversion".printf
+            *
         negative.if negated folded
       [a b] > digits-lte
-        if. > [index] >> rec
-          index.eq a.length
+        if. > [^ index] >> rec
+          index.eq ^.a.length
           true
           if.
             lt.
-              as-ascii
-                slice a index 1
-              as-ascii
-                slice b index 1
+              as-ascii.
+                ^.a.slice index 1
+              as-ascii.
+                ^.b.slice index 1
             true
             if.
               gt.
-                as-ascii
-                  slice a index 1
-                as-ascii
-                  slice b index 1
+                as-ascii.
+                  ^.a.slice index 1
+                as-ascii.
+                  ^.b.slice index 1
               false
-              rec
+              ^.rec
                 index.plus 1
         | 0 > @
-      fold-digits normalized > folded
+      ^.fold-digits normalized > folded
       folded.times -1 > negated
       eq. > negative
-        slice
-          text
-          0
-          1
+        text.slice 0 1
         "-"
       if. > normalized
         stripped.eq ""
@@ -101,65 +183,61 @@
         stripped
       negative.or > signed
         eq.
-          slice text 0 1
+          text.slice 0 1
           "+"
-      replaced > stripped
+      replaced. > stripped
         signed.if
-          slice
-            text
+          text.slice
             1
             text.length.minus 1
           text
-        regex "/^0+/"
+        "/^0+/".regex
         ""
-    [group acc] >> convert
-      matched.exists.not.if > @
+    [^ group acc] >> convert
+      ^.matched.exists.not.if > @
         *
         if.
-          group.gt specifiers.length
+          group.gt ^.specifiers.length
           acc
           next
-      convert > next
+      ^.convert > next
         group.plus 1
         acc.with
-          converted
-            specifiers.at
+          ^.converted
+            ^.specifiers.at
               group.minus 1
               T
-            matched.group group
+            ^.matched.group group
     | > @
       1
       *
-    if. > [spec text] > converted
+    if. > [^ spec text] > converted
       spec.eq "s"
       text
       if.
         spec.eq "d"
-        as-integer text
-        as-float text
+        ^.as-integer text
+        ^.as-float text
     [text] > fold-digits
-      [index acc] >> rec
+      [^ index acc] >> rec
         if. > @
-          index.eq text.length
+          index.eq ^.text.length
           acc
           next
-        rec > next
+        ^.rec > next
           index.plus 1
           plus.
             acc.times 10
             minus.
-              as-ascii
-                slice text index 1
+              as-ascii.
+                ^.text.slice index 1
               48
       | 0 0 > @
     match. > found
-      regex
-        chained *1
-          "/"
-          "^"
-          pattern
-          "/"
-      read
+      regex.
+        "/".chained
+          * "^" pattern "/"
+      ^.read
     found.next > matched
   | > @
     tokens.at
@@ -187,13 +265,12 @@
         "}"
         "/"
       ch
-    chained *1
-      "\\"
-      ch
+    "\\".chained
+      * ch
     ch
-  [position accumulated found pending] >> tokenize
+  [^ position accumulated found pending] >> tokenize
     if. > @
-      position.gte format.length
+      position.gte ^.format.length
       pending.if *1
         T
           "The format string ends with a dangling percent and no specifier after it"
@@ -202,57 +279,52 @@
       pending.if
         if.
           ch.eq "%"
-          tokenize
+          ^.tokenize
             position.plus 1
-            chained *1
-              accumulated
-              "%"
+            accumulated.chained
+              * "%"
             found
             false
           if.
             ch.eq "d"
-            tokenize
+            ^.tokenize
               position.plus 1
-              chained *1
-                accumulated
-                "([+-]?\\d+)"
+              accumulated.chained
+                * "([+-]?\\d+)"
               found.with "d"
               false
             if.
               ch.eq "f"
-              tokenize
+              ^.tokenize
                 position.plus 1
-                chained *1
-                  accumulated
-                  "([+-]?\\d+(?:\\.\\d+)?)"
+                accumulated.chained
+                  * "([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"
                 found.with "f"
                 false
               if.
                 ch.eq "s"
-                tokenize
+                ^.tokenize
                   position.plus 1
-                  chained *1
-                    accumulated
-                    "(\\S+)"
+                  accumulated.chained
+                    * "(\\S*)"
                   found.with "s"
                   false
                 T "Unsupported format specifier"
         if.
           ch.eq "%"
-          tokenize
+          ^.tokenize
             position.plus 1
             accumulated
             found
             true
-          tokenize
+          ^.tokenize
             position.plus 1
-            chained *1
-              accumulated
-              escaped ch
+            accumulated.chained
+              *
+                escaped ch
             found
             false
-    slice > ch
-      format
+    ^.format.slice > ch
       position
       1
   | >> tokens
@@ -262,75 +334,70 @@
     false
 
   eq. ++> can-scan-a-complex-format
-    scanf
-      "Im%d %s old and this is! Let's calculate %f + %f= %f"
+    "Im%d %s old and this is! Let's calculate %f + %f= %f".scanf
       "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
     *
       18
       "years"
-      9.999999999E7
+      9.999999999e7
       0.01
       100000000
 
   eq. ++> can-scan-a-complex-float
     1991.01
     head.
-      scanf
-        "this will be=%f"
+      "this will be=%f".scanf
         "this will be=1991.01"
 
   eq. ++> can-scan-a-complex-integer
     734987259
     head.
-      scanf "!%d!" "!734987259!"
+      "!%d!".scanf "!734987259!"
 
   eq. ++> can-scan-a-complex-string
     "test"
     head.
-      scanf "some%sstring" "someteststring"
+      "some%sstring".scanf "someteststring"
 
   eq. ++> can-scan-a-float
     0.24
     head.
-      scanf "%f" "0.24"
+      "%f".scanf "0.24"
 
   eq. ++> can-scan-an-integer
     33
     head.
-      scanf "%d" "33"
+      "%d".scanf "33"
 
   eq. ++> can-scan-a-negative-integer
     -42
     head.
-      scanf "%d" "-42"
+      "%d".scanf "-42"
 
   eq. ++> can-scan-a-positive-signed-integer
     42
     head.
-      scanf "%d" "+42"
+      "%d".scanf "+42"
 
   eq. ++> can-scan-a-zero-padded-integer
     42
     head.
-      scanf "%d" "00000000000000000042"
+      "%d".scanf "00000000000000000042"
 
   eq. ++> can-scan-a-zero-padded-negative-integer
     -42
     head.
-      scanf "%d" "-00000000000000000042"
+      "%d".scanf "-00000000000000000042"
 
   eq. ++> can-scan-many-zeroes-as-zero
     0
     head.
-      scanf "%d" "00000000000000000000"
+      "%d".scanf "00000000000000000000"
 
   eq. ++> can-scan-what-printf-wrote
-    scanf
-      "%s is about %d?"
-      printf *1
-        "%s is about %d?"
-        "This"
-        8
+    "%s is about %d?".scanf
+      "%s is about %d?".printf
+        * "This" 8
     *
       "This"
       8
@@ -338,11 +405,24 @@
   eq. ++> can-scan-a-string
     "hello"
     head.
-      scanf "%s" "hello"
+      "%s".scanf "hello"
+
+  eq. ++> can-scan-an-empty-string
+    "%s".scanf ""
+    * ""
+
+  eq. ++> can-scan-an-empty-string-between-literals
+    "[%s]".scanf "[]"
+    * ""
+
+  eq. ++> can-scan-an-empty-string-printed-by-printf
+    "%s".scanf
+      "%s".printf
+        * ""
+    * ""
 
   eq. ++> can-scan-a-string-an-integer-and-a-float
-    scanf
-      "%s %d %f"
+    "%s %d %f".scanf
       "hello 33 0.24"
     *
       "hello"
@@ -352,52 +432,101 @@
   eq. ++> can-scan-a-string-followed-by-a-literal
     "hello"
     head.
-      scanf "%s!" "hello!"
+      "%s!".scanf "hello!"
 
   eq. ++> can-scan-while-ignoring-trailing-text
     42
     head.
-      scanf
-        "id=%d"
+      "id=%d".scanf
         "id=42 suffix"
 
-  eq. ++> cannot-scan-past-unmatched-leading-text
+  eq. ++> can-scan-nothing-past-unmatched-leading-text
     length.
-      scanf
-        "id=%d"
+      "id=%d".scanf
         "prefix id=42"
     0
 
-  scanf --> stops-on-a-dangling-percent
-    "hello%"
-    "hello"
+  "hello%".scanf "hello" --> stops-on-a-dangling-percent
 
-  scanf --> stops-on-an-oversized-integer
-    "%d"
-    "99999999999999999999"
+  "%d".scanf "99999999999999999999" --> stops-on-an-oversized-integer
+
+  eq. ++> can-format-the-oversized-integer-message-with-a-single-percent
+    "The number doesn't fit into long range for the '%%d' conversion".printf
+      *
+    "The number doesn't fit into long range for the '%d' conversion"
 
   gt. ++> can-scan-a-nineteen-digit-value-at-long-max
     head.
-      scanf "%d" "9223372036854775807"
+      "%d".scanf "9223372036854775807"
     9000000000000000000
 
   lt. ++> can-scan-a-nineteen-digit-value-at-long-min
     head.
-      scanf "%d" "-9223372036854775808"
+      "%d".scanf "-9223372036854775808"
     -9000000000000000000
 
-  scanf --> stops-on-a-nineteen-digit-value-above-long-max
+  scanf. --> stops-on-a-nineteen-digit-value-above-long-max
     "%d"
     "9223372036854775808"
 
-  scanf --> stops-on-a-nineteen-digit-value-below-long-min
+  scanf. --> stops-on-a-nineteen-digit-value-below-long-min
     "%d"
     "-9223372036854775809"
 
-  scanf --> stops-on-a-zero-padded-integer-above-long-max
+  scanf. --> stops-on-a-zero-padded-integer-above-long-max
     "%d"
     "00009223372036854775808"
 
-  scanf --> stops-on-a-wrong-format
-    "%l"
-    "error"
+  "%l".scanf "error" --> stops-on-a-wrong-format
+
+  eq. ++> can-scan-a-float-in-scientific-notation
+    1000
+    head.
+      "%f".scanf "1e3"
+
+  eq. ++> can-scan-a-float-in-scientific-notation-with-a-negative-exponent
+    -0.02
+    head.
+      "%f".scanf "-2E-2"
+
+  eq. ++> can-scan-a-float-in-scientific-notation-with-a-signed-exponent
+    150
+    head.
+      "%f".scanf "1.5e+2"
+
+  eq. ++> can-scan-a-float-in-scientific-notation-with-a-zero-exponent
+    1
+    head.
+      "%f".scanf "1e0"
+
+  eq. ++> can-scan-a-float-at-the-edge-of-the-power-of-ten-range
+    1.0e-309
+    head.
+      "%f".scanf "0.1e-308"
+
+  eq. ++> can-scan-a-subnormal-float-with-an-exponent-below-the-range
+    1.0e-320
+    head.
+      "%f".scanf "1e-320"
+
+  eq. ++> can-scan-the-smallest-positive-float
+    4.9e-324
+    head.
+      "%f".scanf "5e-324"
+
+  gt. ++> can-scan-a-normal-float-with-an-exponent-below-the-range
+    head.
+      "%f".scanf "123.456e-310"
+    1.0e-308
+
+  is-finite. ++> can-scan-a-finite-float-with-an-exponent-above-the-range
+    head.
+      "%f".scanf "0.001e311"
+
+  is-finite. ++> can-scan-a-value-at-the-double-maximum
+    head.
+      "%f".scanf "1.7976931348623157e308"
+
+  is-finite. ++> can-scan-a-value-below-the-double-maximum
+    head.
+      "%f".scanf "1.7976931348623156e308"

--- a/objects/string/slice.eo
+++ b/objects/string/slice.eo
@@ -1,28 +1,49 @@
 # Takes a piece of the `text` as another `text`, counting characters and not
-# bytes. Here `start` must be a non-negative index to start slicing from, while
-# `len` must be a non-negative amount of characters to take. Both of them walk
-# the UTF-8 sequence character by character, so a multi-byte character counts
-# as one. An index outside the bounds of the `text` terminates the computation.
+# bytes. Here `start` must be a non-negative integer index to start slicing
+# from, while `len` must be a non-negative integer amount of characters to
+# take. A fractional, `nan` or infinite `start` or `len` terminates the
+# computation immediately. Both of them walk the UTF-8 sequence character by
+# character, so a multi-byte character counts as one. An index outside the
+# bounds of the `text` terminates the computation. Every multi-byte sequence is
+# validated against the UTF-8 rules of the Unicode standard (Table 3-7), the
+# same way `length` does: each following byte must be a `10xxxxxx` continuation
+# byte, and the second byte is range-checked so that overlong encodings
+# (`C0`/`C1` leads, `E0` with an `80`-`9F` second byte, `F0` with an `80`-`8F`
+# second byte), UTF-16 surrogates (`ED` with an `A0`-`BF` second byte) and code
+# points above U+10FFFF (`F4` with a `90`-`BF` second byte, and `F5`-`FF` leads)
+# are rejected. A malformed sequence terminates the computation, exactly like a
+# truncated character does.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
 
-[text start len] > slice
+[^ start len] > slice
   if. > @
-    nstart.lt 0
+    or.
+      nstart.lt 0
+      nstart.is-integer.not
     T
-      "Start index must be >= 0, but was %d".printf
-        * nstart
+      nstart.is-finite.if
+        "Start index must be a non-negative integer, but was %f".printf
+          * nstart
+        "Start index must be a non-negative integer, but was %s".printf
+          *
+            string nstart.as-scientific
     if.
-      nlen.lt 0
+      or.
+        nlen.lt 0
+        nlen.is-integer.not
       T
-        "Length to slice must be >= 0, but was %d".printf
-          * nlen
+        nlen.is-finite.if
+          "Length to slice must be a non-negative integer, but was %f".printf
+            * nlen
+          "Length to slice must be a non-negative integer, but was %s".printf
+            *
+              string nlen.as-scientific
       seq *
         recidx >> bstart!
           0
@@ -37,7 +58,7 @@
           string
             text.as-bytes.slice bstart blen
   minus. > blen
-    [index accum result cause] >> recidx
+    [^ index accum result cause] >> recidx
       if. > @
         accum.eq result
         index
@@ -46,36 +67,100 @@
           T cause
           if.
             eq.
-              byte.and p1
-              r1
-            increase
-              index
-              1
-              accum
+              byte.and ^.p1
+              ^.r1
+            ^.recidx
+              ^.increase index 1 true
+              accum.plus 1
               result
               cause
             if.
               eq.
-                byte.and p2
-                r2
-              increase
-                index
-                2
-                accum
+                byte.and ^.p2
+                ^.r2
+              ^.recidx
+                ^.increase index 2 twovalid
+                accum.plus 1
                 result
                 cause
               if.
                 eq.
-                  byte.and p3
-                  r3
-                increase index 3 accum result cause
+                  byte.and ^.p3
+                  ^.r3
+                ^.recidx
+                  ^.increase index 3 threevalid
+                  accum.plus 1
+                  result
+                  cause
                 if.
-                  eq. (byte.and p4) r4
-                  increase index 4 accum result cause
+                  eq. (byte.and ^.p4) ^.r4
+                  ^.recidx
+                    ^.increase index 4 fourvalid
+                    accum.plus 1
+                    result
+                    cause
                   T
                     "Unknown byte format (%x), can't recognize character".printf
                       * byte
-      text.as-bytes.slice index 1 > byte
+      ^.text.as-bytes.slice > b1
+        index.plus 1
+        1
+      eq. > b1808f
+        b1.and F0-
+        80-
+      eq. > b1809f
+        b1.and E0-
+        80-
+      or. > b190bf
+        eq.
+          b1.and F0-
+          90-
+        eq.
+          b1.and E0-
+          A0-
+      eq. > b1a0bf
+        b1.and E0-
+        A0-
+      eq. > b1cont
+        b1.and C0-
+        80-
+      ^.text.as-bytes.slice > b2
+        index.plus 2
+        1
+      eq. > b2cont
+        b2.and C0-
+        80-
+      ^.text.as-bytes.slice > b3
+        index.plus 3
+        1
+      eq. > b3cont
+        b3.and C0-
+        80-
+      ^.text.as-bytes.slice index 1 > byte
+      b2cont.and > fourvalid
+        b3cont.and second4
+      eq. > leadc0c1
+        byte.and FE-
+        C0-
+      byte.eq E0- > leade0
+      byte.eq ED- > leaded
+      byte.eq F0- > leadf0
+      byte.eq F1- > leadf1
+      leadf1.or > leadf1f3
+        leadf2.or leadf3
+      byte.eq F2- > leadf2
+      byte.eq F3- > leadf3
+      byte.eq F4- > leadf4
+      leade0.if > second3
+        b1a0bf
+        leaded.if b1809f b1cont
+      leadf0.if > second4
+        b190bf
+        leadf4.if
+          b1808f
+          leadf1f3.if b1cont false
+      b2cont.and second3 > threevalid
+      leadc0c1.not.and b1cont > twovalid
     |
       number bstart
       0
@@ -84,7 +169,7 @@
         *
           nstart.plus nlen
     bstart
-  if. > [index csize accum result cause] > increase
+  if. > [^ index csize valid] > increase
     gt.
       index.plus csize
       size
@@ -93,12 +178,14 @@
         *
           csize
           index
-          text.as-bytes
-    recidx
+          ^.text.as-bytes
+    valid.if
       index.plus csize
-      accum.plus 1
-      result
-      cause
+      T
+        "Malformed UTF-8 sequence (%x) at %d index".printf
+          *
+            ^.text.as-bytes.slice index csize
+            index
   number len! > nlen
   number start! > nstart
   80- > p1
@@ -110,6 +197,7 @@
   E0- > r3
   F0- > r4
   text.as-bytes.size >> size!
+  ^ > text
 
   eq. ++> can-slice-a-line-break-escape-sequence
     "\n".slice
@@ -172,8 +260,7 @@
     ""
 
   eq. ++> can-slice-the-origin-string
-    slice
-      "Hello, world!"
+    "Hello, world!".slice
       7
       5
     "world"
@@ -190,17 +277,52 @@
       2
     "ри"
 
-  slice --> stops-on-a-start-below-zero
+  slice. --> rejects-a-non-continuation-after-a-three-byte-lead-when-slicing
+    string E1-80-41
+    0
+    1
+
+  slice. --> rejects-a-utf-16-surrogate-encoding
+    string ED-A0-80
+    0
+    1
+
+  slice. --> rejects-an-overlong-two-byte-encoding-when-slicing
+    string C0-80
+    0
+    1
+
+  slice. --> stops-on-a-fractional-length
+    "some"
+    0
+    1.5
+
+  slice. --> stops-on-a-fractional-start
+    "some"
+    0.5
+    1
+
+  slice. --> stops-on-a-start-below-zero
     "some string"
     -1
     1
 
-  slice --> stops-on-an-end-below-the-start
+  slice. --> stops-on-an-end-below-the-start
     "some string"
     2
     -1
 
-  slice --> stops-on-an-end-beyond-the-length
+  slice. --> stops-on-an-end-beyond-the-length
     "some string"
     7
     5
+
+  slice. --> stops-on-an-infinite-length
+    "some"
+    0
+    pinf
+
+  slice. --> stops-on-an-infinite-start
+    "some"
+    pinf
+    1

--- a/objects/string/split.eo
+++ b/objects/string/split.eo
@@ -1,64 +1,71 @@
 # Returns a `tuple` of `strings`: `text` separated by `delimiter`.
+# If `delimiter` is empty, the `cant-split` fallback is returned, or the
+# terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text delimiter] > split
+[^ delimiter cant-split] > split
   if. > @
-    eq.
-      size. >> len!
-        text >> bts!
-      0
-    *
-    [accum start current] >> rec-split
-      if. > @
-        len.eq current
-        appended
-        if.
-          or.
-            size.eq 0
-            gt.
-              current.plus size
-              len
-          rec-split
-            accum
-            start
-            as-number.
-              current.plus 1
+    delimiter.size.eq 0
+    cant-split
+      "The delimiter must not be empty"
+    if.
+      eq.
+        size. >> len!
+          text >> bts!
+        0
+      * ""
+      [^ accum start current] >> rec-split
+        if. > @
+          len.eq current
+          appended
           if.
-            delim.eq
-              bts.slice current size
-            rec-split
-              appended
-              as-number.
+            or.
+              size.eq 0
+              gt.
                 current.plus size
-              as-number.
-                current.plus size
-            rec-split
+                len
+            ^.rec-split
               accum
               start
               as-number.
                 current.plus 1
-      accum.with > appended
-        string
-          bts.slice
-            start
-            current.minus start
-    |
-      *
-      0
-      0
+            if.
+              delim.eq
+                bts.slice current size
+              ^.rec-split
+                appended
+                as-number.
+                  current.plus size
+                as-number.
+                  current.plus size
+              ^.rec-split accum start (current.plus 1).as-number
+        accum.with > appended
+          string
+            bts.slice
+              start
+              current.minus start
+      |
+        *
+        0
+        0
   size. >> size!
     delimiter >> delim!
+  ^ > text
+
+  eq. ++> can-recover-from-an-empty-delimiter
+    "recovered"
+    "abc".split
+      ""
+      "recovered" > [message]
 
   eq. ++> can-split-a-text-into-empty-strings
-    split
-      "-a-b-"
-      "-"
+    "-a-b-".split "-"
     *
       ""
       "a"
@@ -66,28 +73,29 @@
       ""
 
   eq. ++> can-split-a-text-on-a-dash
-    split
-      "a-b-c"
-      "-"
+    "a-b-c".split "-"
     *
       "a"
       "b"
       "c"
 
   eq. ++> can-split-a-text-on-a-multi-character-delimiter
-    split
-      "a::b::c"
-      "::"
+    "a::b::c".split "::"
     *
       "a"
       "b"
       "c"
 
+  eq. ++> can-split-an-empty-text-into-one-empty-string
+    "".split "-"
+    * ""
+
   eq. ++> can-split-into-strings
     length.
       at.
-        split
-          "hello world!"
+        "hello world!".split
           " "
         1
     6
+
+  "abc".split "" --> stops-on-an-empty-delimiter

--- a/objects/string/starts-with.eo
+++ b/objects/string/starts-with.eo
@@ -3,11 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text substring] > starts-with
+[^ substring] > starts-with
   and. > @
     lte.
       number
@@ -19,12 +19,12 @@
         0
         size
       substring >> part!
+  ^ > text
 
-  starts-with ++> can-start-with-a-substring
+  starts-with. ++> can-start-with-a-substring
     "Hello, world"
     "Hello"
 
-  not. ++> cannot-start-with-an-absent-substring
-    starts-with
-      "Hello, world"
+  not. ++> can-tell-it-does-not-start-with-an-absent-substring
+    "Hello, world".starts-with
       "world"

--- a/objects/string/trimmed-left.eo
+++ b/objects/string/trimmed-left.eo
@@ -7,11 +7,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > trimmed-left
+[^] > trimmed-left
   if. > @
     0.eq
       b.size >> len!
@@ -23,13 +23,13 @@
         minus.
           number len
           idx
-  [index] >> first-non-ws-index
+  [^ index] >> first-non-ws-index
     if. > @
       len.eq index
       index
       if.
         is-ws (b.slice index 1)!
-        first-non-ws-index (index.plus 1).as-number
+        ^.first-non-ws-index (index.plus 1).as-number
         index
   or. > [c] >> is-ws
     c.eq 20-
@@ -42,43 +42,30 @@
           or.
             c.eq 0C-
             c.eq 0D-
+  ^ > text
 
-  eq. ++> can-trim-a-leading-carriage-return
-    trimmed-left "\rvalue"
-    "value"
+  "\rvalue".trimmed-left.eq "value" ++> can-trim-a-leading-carriage-return
 
-  eq. ++> can-trim-a-leading-form-feed
-    trimmed-left "\fvalue"
-    "value"
+  "\fvalue".trimmed-left.eq "value" ++> can-trim-a-leading-form-feed
 
-  eq. ++> can-trim-a-leading-line-feed
-    trimmed-left "\nvalue"
-    "value"
+  "\nvalue".trimmed-left.eq "value" ++> can-trim-a-leading-line-feed
 
-  eq. ++> can-trim-a-leading-tab
-    trimmed-left "\tvalue"
-    "value"
+  "\tvalue".trimmed-left.eq "value" ++> can-trim-a-leading-tab
 
   eq. ++> can-trim-a-text-of-leading-spaces-only
-    trimmed-left
-      "     "
+    "     ".trimmed-left
     ""
 
-  eq. ++> can-trim-an-empty-text
-    trimmed-left ""
-    ""
+  "".trimmed-left.eq "" ++> can-trim-an-empty-text-from-the-left
 
   eq. ++> can-trim-many-leading-spaces
-    trimmed-left
-      "     some"
+    "     some".trimmed-left
     "some"
 
   eq. ++> can-trim-mixed-leading-whitespace
-    trimmed-left
-      " \t\n\f\rvalue"
+    " \t\n\f\rvalue".trimmed-left
     "value"
 
-  eq. ++> can-trim-one-leading-space
-    trimmed-left
-      " s"
+  eq. ++> can-trim-one-leading-space-from-the-left
+    " s".trimmed-left
     "s"

--- a/objects/string/trimmed-right.eo
+++ b/objects/string/trimmed-right.eo
@@ -7,11 +7,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > trimmed-right
+[^] > trimmed-right
   if. > @
     0.eq
       b.size >> len!
@@ -20,13 +20,13 @@
       slice.
         text >> b!
         0
-        [index] >> first-non-ws-index
+        [^ index] >> first-non-ws-index
           if. > @
             -1.eq index
             0
             if.
               is-ws (b.slice index 1)!
-              first-non-ws-index (index.plus -1).as-number
+              ^.first-non-ws-index (index.plus -1).as-number
               index.plus 1
         | ((number len).plus -1)
   or. > [c] >> is-ws
@@ -40,43 +40,30 @@
           or.
             c.eq 0C-
             c.eq 0D-
+  ^ > text
 
   eq. ++> can-trim-a-text-of-trailing-spaces-only
-    trimmed-right
-      "     "
+    "     ".trimmed-right
     ""
 
-  eq. ++> can-trim-a-trailing-carriage-return
-    trimmed-right "value\r"
-    "value"
+  "value\r".trimmed-right.eq "value" ++> can-trim-a-trailing-carriage-return
 
-  eq. ++> can-trim-a-trailing-form-feed
-    trimmed-right "value\f"
-    "value"
+  "value\f".trimmed-right.eq "value" ++> can-trim-a-trailing-form-feed
 
-  eq. ++> can-trim-a-trailing-line-feed
-    trimmed-right "value\n"
-    "value"
+  "value\n".trimmed-right.eq "value" ++> can-trim-a-trailing-line-feed
 
-  eq. ++> can-trim-a-trailing-tab
-    trimmed-right "value\t"
-    "value"
+  "value\t".trimmed-right.eq "value" ++> can-trim-a-trailing-tab
 
-  eq. ++> can-trim-an-empty-text
-    trimmed-right ""
-    ""
+  "".trimmed-right.eq "" ++> can-trim-an-empty-text-from-the-right
 
   eq. ++> can-trim-many-trailing-spaces
-    trimmed-right
-      "some     "
+    "some     ".trimmed-right
     "some"
 
   eq. ++> can-trim-mixed-trailing-whitespace
-    trimmed-right
-      "value \t\n\f\r"
+    "value \t\n\f\r".trimmed-right
     "value"
 
-  eq. ++> can-trim-one-trailing-space
-    trimmed-right
-      "s "
+  eq. ++> can-trim-one-trailing-space-from-the-right
+    "s ".trimmed-right
     "s"

--- a/objects/string/trimmed.eo
+++ b/objects/string/trimmed.eo
@@ -8,56 +8,45 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > trimmed
+[^] > trimmed
   if. > @
     0.eq text.as-bytes.size
     text
-    trimmed-left
-      trimmed-right text
+    text.trimmed-right.trimmed-left
+  ^ > text
 
-  eq. ++> can-preserve-inner-content
-    trimmed "no-whitespace"
-    "no-whitespace"
+  "no-whitespace".trimmed.eq "no-whitespace" ++> can-preserve-inner-content
 
   eq. ++> can-preserve-inner-whitespace
-    trimmed
-      "\t hello world \n"
+    "\t hello world \n".trimmed
     "hello world"
 
   eq. ++> can-trim-a-text-of-spaces-only
-    trimmed
-      "        "
+    "        ".trimmed
     ""
 
-  eq. ++> can-trim-an-empty-text
-    trimmed ""
-    ""
+  "".trimmed.eq "" ++> can-trim-an-empty-text
 
   eq. ++> can-trim-many-surrounding-spaces
-    trimmed
-      "    some     "
+    "    some     ".trimmed
     "some"
 
   eq. ++> can-trim-mixed-whitespace-on-both-sides
-    trimmed
-      " \t\n\f\rvalue \t\n\f\r"
+    " \t\n\f\rvalue \t\n\f\r".trimmed
     "value"
 
   eq. ++> can-trim-one-leading-space
-    trimmed
-      " some"
+    " some".trimmed
     "some"
 
   eq. ++> can-trim-one-space-on-both-sides
-    trimmed
-      " some "
+    " some ".trimmed
     "some"
 
   eq. ++> can-trim-one-trailing-space
-    trimmed
-      "some "
+    "some ".trimmed
     "some"

--- a/objects/string/truncated.eo
+++ b/objects/string/truncated.eo
@@ -1,0 +1,85 @@
+# Returns the first `limit` characters of `text`, so that `Jeffrey` truncated
+# to three characters becomes `Jef`. Characters are counted, and not bytes,
+# so a multi-byte character counts as one. A `text` of `limit` characters
+# or shorter is returned unchanged, which is how this differs from `slice`,
+# where a `limit` beyond the end of the `text` terminates the computation.
+# If `limit` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-truncate` fallback is returned, or the terminator
+# when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^ limit cant-truncate] > truncated
+  if. > @
+    or.
+      0.gt limit
+      limit.is-integer.not
+    cant-truncate
+      limit.is-finite.if
+        "Can't truncate text to %f characters".printf
+          * limit
+        "Can't truncate text to %s characters".printf
+          *
+            string limit.as-scientific
+    if.
+      limit.lt text.length
+      text.slice 0 limit
+      text
+  ^ > text
+
+  eq. ++> can-count-characters-and-not-bytes-when-truncating
+    "Жу"
+    "Жук".truncated 2
+
+  eq. ++> can-format-the-error-message-of-a-negative-limit
+    "Can't truncate text to -3.000000 characters"
+    "Jeff".truncated
+      -3
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-limit
+    "Can't truncate text to infinity characters"
+    "Jeff".truncated
+      pinf
+      I
+
+  eq. ++> can-recover-from-a-negative-limit
+    "recovered"
+    "Jeff".truncated
+      -3
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-a-non-integer-limit
+    "recovered"
+    "Jeff".truncated
+      1.75
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-limit-when-truncating
+    "recovered"
+    "Jeff".truncated
+      pinf
+      "recovered" > [message]
+
+  eq. ++> can-return-a-shorter-text-unchanged
+    "hi"
+    "hi".truncated 9
+
+  eq. ++> can-return-a-text-of-the-exact-limit-unchanged
+    "hey"
+    "hey".truncated 3
+
+  eq. ++> can-truncate-to-an-empty-text
+    ""
+    "Jeffrey".truncated 0
+
+  eq. ++> can-truncate-to-fewer-characters
+    "Jef"
+    "Jeffrey".truncated 3
+
+  "Jeff".truncated -3 --> stops-on-a-negative-limit-when-truncating

--- a/objects/string/turkish.eo
+++ b/objects/string/turkish.eo
@@ -1,0 +1,54 @@
+# Turkish locale specializing the default `english` casing with the dotted
+# and dotless I mappings that Turkish and Azeri override the default with.
+# Being a decorator of its `s` string, a `turkish` object behaves like the
+# string itself (`.length`, `.eq` and so on pass through), while adding
+# `lower` and `upper` that honour those mappings. Lower casing maps capital
+# dotless I (U+0049) to small dotless i (U+0131) and capital dotted I
+# (U+0130) to small dotted i (U+0069); upper casing maps small dotted i
+# (U+0069) to capital dotted I (U+0130) and small dotless i (U+0131) to
+# capital dotless I (U+0049). Each direction only touches two of the four
+# characters, which is why `lower` and `upper` list different regexes. The
+# Turkish replacements run before the `english` ASCII pass on purpose: once
+# that pass folds capital dotless I into small dotted i the distinction is
+# gone, so the order must not swap.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > turkish
+  s > @
+  lower. > [^] > lower
+    english.
+      replaced.
+        ^.s.replaced "/I/".regex "ı"
+        "/İ/".regex
+        "i"
+  ^ > s
+  upper. > [^] > upper
+    english.
+      replaced.
+        ^.s.replaced "/i/".regex "İ"
+        "/ı/".regex
+        "I"
+
+  8.eq "İSTANBUL".turkish.length ++> can-behave-like-the-wrapped-turkish-string
+
+  "ıistanbul".eq "IİSTANBUL".turkish.lower ++> can-lower-case-dotted-and-dotless-i
+
+  eq. ++> can-lower-case-every-occurrence-of-a-mapped-character
+    "ıııı"
+    "IIII".turkish.lower
+
+  eq. ++> can-round-trip-a-lower-cased-word
+    "ıstanbul"
+    "ıstanbul".turkish.upper.turkish.lower
+
+  eq. ++> can-round-trip-an-upper-cased-word
+    "İSTANBUL"
+    "İSTANBUL".turkish.lower.turkish.upper
+
+  "İSTANBUL".eq "istanbul".turkish.upper ++> can-upper-case-dotted-and-dotless-i

--- a/objects/string/upper.eo
+++ b/objects/string/upper.eo
@@ -1,0 +1,24 @@
+# Returns the `text` in upper case, using the default English casing rules.
+# This is a thin string method: `"hello".upper` is the same as
+# `(string.english "hello").upper`. Only the ASCII letters `a`-`z` are
+# folded; every other byte, including accented Latin, Cyrillic and Greek
+# letters and all multi-byte UTF-8 sequences, passes through unchanged.
+# For locale specific rules use a locale wrapper such as `string.turkish`,
+# as in `"...".turkish.upper`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.63.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > upper
+  text.english.upper > @
+  ^ > text
+
+  "ÄÖÜ".eq "ÄÖÜ".upper ++> can-keep-non-ascii-letters-when-upper-casing
+
+  "HELLO".eq "hello".upper ++> can-upper-case-text
+
+  "HELLO".eq "hello".upper ++> can-upper-case-text-through-the-package

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -14,15 +14,15 @@
 #       "this value will be skipped"
 # ```
 #
-# This object returns the value of the first true statement.
+# This object returns the value of the first true statement,
+# or invokes `fallback` with a descriptive message when `cases`
+# is empty or when every case condition is false.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [cases fallback] > switch
   if. > @
@@ -33,40 +33,39 @@
       true.eq
         match.
           @. >> found
-            [tup] >> rec-case
+            [^ tup] >> rec-case
               if. > @
                 and.
                   tup.length.gt 1
                   previous.match
                 previous
-                [] >>
-                  tup.head.head > head
-                  tup.head.tail.head > match!
+                [^] >>
+                  ^.tup.head.head > head
+                  ^.tup.head.tail.head > match!
               @. > previous
-                rec-case tup.tail
+                ^.rec-case tup.tail
             | cases
       found.head
-      true
+      fallback
+        "No switch case matched"
 
-  switch * ++> can-return-true-when-all-cases-are-false
-    *
-      false
-      "false1"
-    *
-      false
-      "false2"
+  eq. ++> can-recover-from-an-empty-switch
+    "recovered"
+    switch
+      *
+      "recovered" > [message]
 
   ++> can-switch-on-a-complex-case
     eq. > @
       switch *
         *
-          c1 > [] >>
+          ^.c1 > [^] >>
           22
         *
-          c2 > [] >>
+          ^.c2 > [^] >>
           0
         *
-          c3 > [] >>
+          ^.c3 > [^] >>
           "true case"
       "true case"
     false > c1
@@ -78,6 +77,14 @@
       * false "1"
       * true "2"
     "2"
+
+  eq. ++> can-switch-on-all-false-cases-with-fallback
+    "fallback"
+    switch
+      *
+        * false "false1"
+        * false "false2"
+      "fallback" > [message]
 
   ++> can-switch-on-strings
     eq. > @
@@ -101,11 +108,13 @@
       * true "TRUE2"
     "TRUE1"
 
-  eq. ++> rejects-an-empty-switch
-    "recovered"
-    switch
-      *
-      "recovered" > [message]
+  switch * --> stops-on-all-false-cases-without-fallback
+    *
+      false
+      "false1"
+    *
+      false
+      "false2"
 
   switch --> stops-on-an-empty-switch
     *

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -4,13 +4,51 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
-bool > true
-  []
-    ? >> left
-    ? >> right
-    left > @
+[^] > true
+  bool > @
+    [^]
+      ? >> left
+      ? >> right
+      left > @
+
+  true.and true ++> can-conjoin-true-with-true
+
+  true.or true ++> can-disjoin-true-with-true
+
+  not. ++> can-ignore-the-right-argument-of-if
+    eq.
+      true.if 1 2
+      2
+
+  true.if ++> can-pick-itself-as-the-left-branch
+    true
+    false
+
+  eq. ++> can-pick-the-left-argument-among-different-types
+    true.if
+      "left"
+      8
+    "left"
+
+  eq. ++> can-pick-the-left-argument-of-if
+    true.if
+      42
+      8
+    42
+
+  eq. ++> can-pick-the-left-branch-when-nested
+    true.if
+      true.if 1 2
+      3
+    1
+
+  not. ++> can-tell-true-is-not-its-own-negation
+    true.eq true.not
+
+  true.as-bytes.eq 01- ++> can-turn-into-a-single-true-byte
+
+  true.if --> stops-on-if-without-arguments

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -3,35 +3,33 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [tail head length] > tuple
-  [i fallback] > at
+  [^ i fallback] > at
     if. > @
       or.
         0.gt
           if. >> index!
             0.gt
               i >> idx!
-            length.plus idx
+            ^.length.plus idx
             idx
-        length.lte index
+        ^.length.lte index
       fallback
         "Given index is out of tuple bounds"
-      if. > [tup] >> at-fast
+      if. > [^ tup] >> at-fast
         0.eq tup.length
-        fallback
+        ^.fallback
           "Given index is out of tuple bounds"
         if.
           eq.
             tup.length.plus -1
             index
           tup.head
-          at-fast tup.tail
+          ^.at-fast tup.tail
       | ^
   tuple > empty
     T
@@ -39,21 +37,21 @@
     T
       "Can't get head from the empty tuple"
     0
-  [other] > eq
+  [^ other] > eq
     and. > @
-      length.eq other.length
-      if. > [first second] >> receq
+      ^.length.eq other.length
+      if. > [^ first second] >> receq
         first.length.eq 0
         true
         and.
           first.head.eq second.head
-          receq first.tail second.tail
+          ^.receq first.tail second.tail
       | ^ other
-  tuple > [x] > with
+  tuple > [^ x] > with
     ^
     x
     as-number.
-      length.plus 1
+      ^.length.plus 1
 
   ++> can-add-an-item
     and. > @
@@ -154,13 +152,6 @@
         2
       3
 
-  tuple.contains ++> can-check-containment-through-the-package
-    *
-      1
-      2
-      3
-    2
-
   eq. ++> can-concat-with-another-tuple
     concat.
       * 0 1
@@ -170,13 +161,6 @@
       1
       2
       3
-
-  contains. ++> can-contain-an-element
-    *
-      1
-      2
-      3
-    2
 
   ++> can-create-an-empty-tuple-with-a-number
     eq. > @
@@ -204,15 +188,6 @@
       2
       3
 
-  eq. ++> can-find-the-index-of-an-element
-    index-of.
-      *
-        10
-        20
-        30
-      20
-    1
-
   ++> can-get-the-length-of-an-empty-tuple
     a.length.eq 0 > @
     * > a
@@ -227,6 +202,27 @@
     length.
       * 1 2
     2
+
+  eq. ++> can-recover-from-a-fractional-index
+    "recovered"
+    at.
+      *
+        "zero"
+        "one"
+        "two"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-out-of-bounds-index
+    "recovered"
+    at.
+      *
+        1
+        2
+        3
+        4
+      20
+      "recovered" > [message]
 
   ++> can-report-the-length-of-a-non-empty-tuple
     eq. > @
@@ -272,15 +268,7 @@
       3
       4
 
-  not. ++> cannot-contain-an-absent-element
-    contains.
-      *
-        1
-        2
-        3
-      5
-
-  not. ++> cannot-equal-a-different-tuple
+  not. ++> can-tell-it-does-not-equal-a-different-tuple
     eq.
       *
         1
@@ -290,27 +278,6 @@
         3
         2
         1
-
-  eq. ++> rejects-a-fractional-index
-    "recovered"
-    at.
-      *
-        "zero"
-        "one"
-        "two"
-      1.5
-      "recovered" > [message]
-
-  eq. ++> rejects-an-out-of-bounds-index
-    "recovered"
-    at.
-      *
-        1
-        2
-        3
-        4
-      20
-      "recovered" > [message]
 
   at. --> stops-on-a-wrong-index
     *

--- a/objects/tuple/back.eo
+++ b/objects/tuple/back.eo
@@ -4,25 +4,28 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index] > back
-  if. > @
-    0.gt
-      list.length.minus index! >> start!
-    list
-    reducedi
+[^ index] > back
+  index.is-integer.if > @
+    if.
+      0.gt
+        list.length.minus index! >> start!
       list
-      *
-      if. > [accum item idx] >>
-        idx.gte start
-        accum.with item
-        accum
+      list.reducedi
+        *
+        if. > [^ accum item idx] >>
+          idx.gte start
+          accum.with item
+          accum
+    T
+      "Given index must be an integer"
+  ^ > list
 
   eq. ++> can-take-a-back-slice
-    back
+    back.
       *
         1
         2
@@ -35,7 +38,7 @@
       5
 
   eq. ++> can-take-a-back-slice-with-a-large-index
-    back
+    back.
       *
         1
         2
@@ -50,8 +53,8 @@
       4
       5
 
-  is-empty ++> can-take-a-back-slice-with-a-zero-index
-    back
+  is-empty. ++> can-take-a-back-slice-with-a-zero-index
+    back.
       *
         1
         2
@@ -59,3 +62,9 @@
         4
         5
       0
+
+  back. --> stops-on-a-fractional-index-when-taking-the-back
+    *
+      "a"
+      "b"
+    0.5

--- a/objects/tuple/concat.eo
+++ b/objects/tuple/concat.eo
@@ -3,17 +3,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list passed] > concat
-  reducedi > @
-    passed
-    list
-    with > [accum item index]
-      accum
-      item
+[^ passed] > concat
+  passed.reducedi > @
+    ^
+    accum.with item > [accum item index]
 
   ++> can-concat-two-lists
     and. > @
@@ -24,18 +21,16 @@
           1
           2
           3
-    withouti > list3
-      concat *1
+    withouti. > list3
+      concat.
         * 0 1
-        2
-        3
+        * 2 3
       0
 
   eq. ++> can-concat-with-a-tuple
-    concat *1
+    concat.
       * 0 1
-      2
-      4
+      * 2 4
     *
       0
       1

--- a/objects/tuple/contains.eo
+++ b/objects/tuple/contains.eo
@@ -3,16 +3,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list element] > contains
+[^ element] > contains
   not. > @
     -1.eq
-      index-of list element
+      ^.index-of element
 
-  contains ++> can-contain-a-number
+  contains. ++> can-contain-a-number
     *
       "qwerty"
       "asdfgh"
@@ -20,7 +20,7 @@
       "qwerty"
     3
 
-  contains ++> can-contain-a-string
+  contains. ++> can-contain-a-string
     *
       "qwerty"
       "asdfgh"
@@ -28,8 +28,8 @@
       "qwerty"
     "qwerty"
 
-  not. ++> cannot-contain-an-absent-item
-    contains
+  not. ++> can-tell-it-does-not-contain-an-absent-item
+    contains.
       *
         "Привет"
         "asdfgh"

--- a/objects/tuple/each.eo
+++ b/objects/tuple/each.eo
@@ -5,33 +5,32 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > each
-  eachi > @
-    list
-    func item > [item index] >>
+[^ func] > each
+  ^.eachi > @
+    ^.func item > [^ item index] >>
 
   ++> can-iterate-over-a-list
     eq. > @
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 1 2 3
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [^ i] >>
+              ^.m.as-number.plus i
       6
 
   eq. ++> can-return-the-result-of-the-last-call
-    each
+    each.
       *
         1
         2
         3
-      x > [x]
+      I
     3
 
   ++> can-sum-many-numbers
@@ -39,10 +38,10 @@
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 10 20 30
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [^ i] >>
+              ^.m.as-number.plus i
       60
 
   ++> can-walk-a-single-element-list
@@ -50,12 +49,11 @@
       malloc.for
         0
         [m]
-          each > @
+          each. > @
             * 7
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [^ i] >>
+              ^.m.as-number.plus i
       7
 
-  each ++> can-walk-an-empty-list
-    *
+  tuple.empty.each ++> can-walk-an-empty-list
     false > [x]

--- a/objects/tuple/eachi.eo
+++ b/objects/tuple/eachi.eo
@@ -7,27 +7,26 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > eachi
-  reducedi > @
-    list
+[^ func] > eachi
+  ^.reducedi > @
     true
-    seq * > [acc item index] >>
+    seq * > [^ acc item index] >>
       acc
-      func item index
+      ^.func item index
 
   ++> can-iterate-over-a-list-with-indexes
     eq. > @
       malloc.for
         0
         [m]
-          eachi > @
+          eachi. > @
             * 1 2 3
-            m.put > [item index] >>
+            ^.m.put > [^ item index] >>
               plus.
-                m.as-number.plus item
+                ^.m.as-number.plus item
                 index
       9

--- a/objects/tuple/filtered.eo
+++ b/objects/tuple/filtered.eo
@@ -7,17 +7,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > filtered
-  filteredi > @
-    list
-    func item > [item index] >>
+[^ func] > filtered
+  ^.filteredi > @
+    ^.func item > [^ item index] >>
 
   eq. ++> can-filter-a-list
-    filtered
+    filtered.
       *
         3
         1
@@ -31,7 +30,7 @@
       5
 
   eq. ++> can-filter-bools
-    filtered
+    filtered.
       *
         true
         false

--- a/objects/tuple/filteredi.eo
+++ b/objects/tuple/filteredi.eo
@@ -8,24 +8,24 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > filteredi
-  [tup] >> recfilter
+[^ func] > filteredi
+  [^ tup] >> recfilter
     if. > @
       tup.length.eq 0
       *
       if.
-        func tup.head tup.tail.length
+        ^.func tup.head tup.tail.length
         next.with tup.head
         next
-    recfilter tup.tail > next
-  | list > @
+    ^.recfilter tup.tail > next
+  | ^ > @
 
   eq. ++> can-filter-by-a-less-than-condition
-    filteredi
+    filteredi.
       *
         3
         1
@@ -38,7 +38,7 @@
       2
 
   eq. ++> can-filter-by-string-length
-    filteredi
+    filteredi.
       *
         "Hello"
         "Name"
@@ -47,13 +47,12 @@
       v.length.gt 4 > [v i]
     * "Hello"
 
-  is-empty ++> can-filter-an-empty-list
-    filteredi
-      *
+  is-empty. ++> can-filter-an-empty-list
+    tuple.empty.filteredi
       v.lt 3 > [v i]
 
   eq. ++> can-filter-by-index
-    filteredi
+    filteredi.
       *
         3
         1
@@ -64,7 +63,7 @@
       4
 
   eq. ++> can-filter-bools-with-indexes
-    filteredi
+    filteredi.
       *
         true
         false

--- a/objects/tuple/front.eo
+++ b/objects/tuple/front.eo
@@ -3,34 +3,35 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index] > front
-  if. > @
-    idx.eq 0
-    *
+[^ index] > front
+  index.is-integer.if > @
     if.
-      0.gt
-        index >> idx!
-      back
-        list
-        neg.
-          number idx
+      idx.eq 0
+      *
       if.
-        gte.
-          number idx
-          list.length
-        list
-        if. > [tup] >> rechead
-          tup.length.eq idx
-          tup
-          rechead tup.tail
-        | list
+        0.gt
+          index >> idx!
+        list.back (number idx).neg
+        if.
+          gte.
+            number idx
+            list.length
+          list
+          if. > [^ tup] >> rechead
+            tup.length.eq idx
+            tup
+            ^.rechead tup.tail
+          | list
+    T
+      "Given index must be an integer"
+  ^ > list
 
   eq. ++> can-take-a-front-slice
-    front
+    front.
       *
         1
         2
@@ -41,7 +42,7 @@
     * 1
 
   eq. ++> can-take-a-front-slice-of-a-complex-list
-    front
+    front.
       *
         "foo"
         2.2
@@ -53,7 +54,7 @@
       2.2
 
   eq. ++> can-take-a-front-slice-of-a-complex-list-with-a-negative-index
-    front
+    front.
       *
         "foo"
         2.2
@@ -66,7 +67,7 @@
       "bar"
 
   eq. ++> can-take-a-front-slice-with-a-negative-index
-    front
+    front.
       *
         1
         2
@@ -74,8 +75,8 @@
       -1
     * 3
 
-  is-empty ++> can-take-a-front-slice-with-a-zero-index
-    front
+  is-empty. ++> can-take-a-front-slice-with-a-zero-index
+    front.
       *
         1
         2
@@ -83,7 +84,7 @@
       0
 
   eq. ++> can-take-a-front-slice-with-the-length-as-index
-    front
+    front.
       *
         1
         2
@@ -93,3 +94,9 @@
       1
       2
       3
+
+  front. --> stops-on-a-fractional-index-when-taking-the-front
+    *
+      "a"
+      "b"
+    0.5

--- a/objects/tuple/index-of.eo
+++ b/objects/tuple/index-of.eo
@@ -4,28 +4,48 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list wanted] > index-of
+[^ wanted] > index-of
   number > @
-    [tup] >> recidx
+    [^ tup] >> recidx
       if. > @
         tup.length.eq 0
         -1
         if.
           next.eq -1
           if.
-            tup.head.eq wanted
-            tup.tail.length
+            tup.head.eq ^.wanted
+            tup.length.minus 1
             -1
-          recidx tup.tail >> next!
-    | list
+          ^.recidx tup.tail >> next!
+    | ^
+
+  eq. ++> can-find-no-index-of-an-absent-item
+    -1
+    index-of.
+      *
+        "qwerty"
+        2
+        3
+      7
+
+  eq. ++> can-find-the-index-of-a-non-symmetric-match
+    1
+    index-of.
+      *
+        10
+        20
+        30
+        40
+        50
+      20
 
   eq. ++> can-find-the-index-of-a-string
     1
-    index-of
+    index-of.
       *
         "asdfgh"
         "qwerty"
@@ -34,7 +54,7 @@
 
   eq. ++> can-return-the-first-index-of-an-element
     0
-    index-of
+    index-of.
       *
         -1
         2
@@ -43,18 +63,9 @@
 
   eq. ++> can-return-the-index-of-an-element
     1
-    index-of
+    index-of.
       *
         1
         2
         3
       2
-
-  eq. ++> cannot-find-the-index-of-an-absent-item
-    -1
-    index-of
-      *
-        "qwerty"
-        2
-        3
-      7

--- a/objects/tuple/is-empty.eo
+++ b/objects/tuple/is-empty.eo
@@ -3,30 +3,26 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list] > is-empty
-  0.eq list.length > @
+[^] > is-empty
+  0.eq ^.length > @
 
-  is-empty ++> can-be-empty-when-built-empty
-    *
+  tuple.empty.is-empty ++> can-be-empty-when-built-empty
 
-  ++> cannot-be-empty-with-one-anonymous-object
-    not. > @
-      is-empty xs
+  ++> can-tell-it-is-not-empty-with-one-anonymous-object
+    xs.is-empty.not > @
     * > xs
       [f]
 
-  not. ++> cannot-be-empty-with-one-item
-    is-empty *
-      1
-      2
+  not. ++> can-tell-it-is-not-empty-with-one-item
+    is-empty.
+      * 1 2
 
-  ++> cannot-be-empty-with-three-objects
-    not. > @
-      is-empty xs
+  ++> can-tell-it-is-not-empty-with-three-objects
+    xs.is-empty.not > @
     * > xs
       [x]
       [y]

--- a/objects/tuple/last-index-of.eo
+++ b/objects/tuple/last-index-of.eo
@@ -4,23 +4,23 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list wanted] > last-index-of
-  if. > [t] >> rec
+[^ wanted] > last-index-of
+  if. > [^ t] >> rec
     t.length.eq 0
     -1
     if.
-      t.head.eq wanted
-      t.tail.length
-      rec t.tail
-  | list > @
+      t.head.eq ^.wanted
+      t.length.minus 1
+      ^.rec t.tail
+  | ^ > @
 
   eq. ++> can-find-the-last-index-of-an-item
     1
-    last-index-of
+    last-index-of.
       *
         "qwerty"
         2
@@ -29,31 +29,29 @@
 
   eq. ++> can-find-the-last-index-of-a-repeated-item
     2
-    last-index-of
+    last-index-of.
       *
         24
         42
         24
       24
 
-  eq. ++> cannot-find-the-last-index-of-an-absent-item
+  eq. ++> can-find-no-last-index-of-an-absent-item
     -1
-    last-index-of
+    last-index-of.
       *
         1
         2
         3
       0
 
-  eq. ++> cannot-find-the-last-index-in-an-empty-list
+  eq. ++> can-find-no-last-index-in-an-empty-list
     -1
-    last-index-of
-      *
-      "abc"
+    tuple.empty.last-index-of "abc"
 
   eq. ++> can-find-the-last-index-of-a-unicode-item
     3
-    last-index-of
+    last-index-of.
       *
         "Hi"
         "Привет"
@@ -61,3 +59,14 @@
         "Привет"
         "こんにちわ"
       "Привет"
+
+  eq. ++> can-find-the-last-index-of-a-non-symmetric-match
+    4
+    last-index-of.
+      *
+        10
+        20
+        30
+        40
+        20
+      20

--- a/objects/tuple/mapped.eo
+++ b/objects/tuple/mapped.eo
@@ -5,17 +5,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > mapped
-  mappedi > @
-    list
-    func item > [item idx] >>
+[^ func] > mapped
+  ^.mappedi > @
+    ^.func item > [^ item idx] >>
 
   eq. ++> can-map-a-list
-    mapped
+    mapped.
       *
         1
         2

--- a/objects/tuple/mappedi.eo
+++ b/objects/tuple/mappedi.eo
@@ -6,19 +6,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list func] > mappedi
-  reducedi > @
-    list
+[^ func] > mappedi
+  ^.reducedi > @
     *
-    accum.with > [accum item idx] >>
-      func item idx
+    accum.with > [^ accum item idx] >>
+      ^.func item idx
 
   eq. ++> can-map-a-list-with-indexes
-    mappedi
+    mappedi.
       *
         1
         2

--- a/objects/tuple/maximum.eo
+++ b/objects/tuple/maximum.eo
@@ -5,54 +5,66 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-max] > maximum
-  if. > @
-    is-empty sequence
+[^ cant-max] > maximum
+  sequence.is-empty.if > @
     cant-max
       "cannot get the maximum number from an empty sequence"
-    reduced
-      sequence
+    sequence.reduced
       ninf
       if. > [max item]
-        item.as-number.gt max
+        item.as-number.is-nan.or
+          item.as-number.gt max
         item
         max
+  ^ > sequence
+
+  is-nan. ++> can-be-nan-when-taking-the-maximum-of-a-lone-nan
+    maximum.
+      * nan
+
+  is-nan. ++> can-be-nan-when-taking-the-maximum-of-a-nan-alongside-numbers
+    maximum.
+      *
+        5
+        nan
+        -3
+
+  eq. ++> can-recover-from-an-empty-list-when-taking-the-maximum
+    "recovered"
+    tuple.empty.maximum
+      "recovered" > [msg]
 
   eq. ++> can-take-a-maximum-of-one-item
-    maximum
+    maximum.
       * 42
     42
 
   eq. ++> can-take-a-maximum-that-is-first
-    maximum *
-      25
-      12
-      -2
+    maximum.
+      *
+        25
+        12
+        -2
     25
 
   eq. ++> can-take-a-maximum-that-is-in-the-middle
-    maximum *
-      12
-      25
-      -2
+    maximum.
+      *
+        12
+        25
+        -2
     25
 
   eq. ++> can-take-a-maximum-that-is-last
-    maximum *
-      12
-      -2
-      25
+    maximum.
+      *
+        12
+        -2
+        25
     25
 
-  eq. ++> rejects-an-empty-list
-    "recovered"
-    maximum
-      *
-      "recovered" > [msg]
-
-  maximum --> stops-on-an-empty-list
-    *
+  tuple.empty.maximum --> stops-on-an-empty-list-when-taking-the-maximum

--- a/objects/tuple/minimum.eo
+++ b/objects/tuple/minimum.eo
@@ -5,54 +5,66 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[sequence cant-min] > minimum
-  if. > @
-    is-empty sequence
+[^ cant-min] > minimum
+  sequence.is-empty.if > @
     cant-min
       "cannot get the minimum number from an empty sequence"
-    reduced
-      sequence
+    sequence.reduced
       pinf
       if. > [min item]
-        min.gt item.as-number
+        item.as-number.is-nan.or
+          min.gt item.as-number
         item
         min
+  ^ > sequence
+
+  is-nan. ++> can-be-nan-when-taking-the-minimum-of-a-lone-nan
+    minimum.
+      * nan
+
+  is-nan. ++> can-be-nan-when-taking-the-minimum-of-a-nan-alongside-numbers
+    minimum.
+      *
+        5
+        nan
+        -3
+
+  eq. ++> can-recover-from-an-empty-list-when-taking-the-minimum
+    "recovered"
+    tuple.empty.minimum
+      "recovered" > [msg]
 
   eq. ++> can-take-a-minimum-of-one-item
-    minimum
+    minimum.
       * 42
     42
 
   eq. ++> can-take-a-minimum-that-is-first
-    minimum *
-      -2
-      25
-      12
+    minimum.
+      *
+        -2
+        25
+        12
     -2
 
   eq. ++> can-take-a-minimum-that-is-in-the-middle
-    minimum *
-      12
-      -2
-      25
+    minimum.
+      *
+        12
+        -2
+        25
     -2
 
   eq. ++> can-take-a-minimum-that-is-last
-    minimum *
-      12
-      25
-      -2
+    minimum.
+      *
+        12
+        25
+        -2
     -2
 
-  eq. ++> rejects-an-empty-list
-    "recovered"
-    minimum
-      *
-      "recovered" > [msg]
-
-  minimum --> stops-on-an-empty-list
-    *
+  tuple.empty.minimum --> stops-on-an-empty-list-when-taking-the-minimum

--- a/objects/tuple/reduced.eo
+++ b/objects/tuple/reduced.eo
@@ -6,20 +6,19 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start func] > reduced
-  reducedi > @
-    list
+[^ start func] > reduced
+  ^.reducedi > @
     start
-    func > [accum item index] >>
+    ^.func > [^ accum item index] >>
       accum
       item
 
   eq. ++> can-reduce-a-list
-    reduced
+    reduced.
       *
         1
         2
@@ -30,7 +29,7 @@
     -24
 
   eq. ++> can-reduce-a-list-into-a-string
-    reduced
+    reduced.
       * 0 1
       ""
       acc.concat > [acc item]

--- a/objects/tuple/reducedi.eo
+++ b/objects/tuple/reducedi.eo
@@ -6,39 +6,39 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start func] > reducedi
-  if. > @
-    is-empty list
+[^ start func] > reducedi
+  list.is-empty.if > @
     start
-    if. > [tup] >> rec-reducedi
+    if. > [^ tup] >> rec-reducedi
       tup.length.eq 1
-      func
-        start
+      ^.func
+        ^.start
         tup.head
         0
-      func
-        rec-reducedi tup.tail
+      ^.func
+        ^.rec-reducedi tup.tail
         tup.head
         tup.tail.length
     | list
+  ^ > list
 
-  ++> can-reduce-a-list-with-indexes
-    6.eq > @
-      reducedi
-        * 1 1
-        0
-        x.plus > [a x i] >>
-          a.plus
-            at.
-              * 2 2
-              i
+  eq. ++> can-reduce-a-list-with-indexes
+    6
+    reducedi.
+      * 1 1
+      0
+      x.plus > [a x i]
+        a.plus
+          at.
+            * 2 2
+            i
 
   eq. ++> can-reduce-a-long-integer-list-with-indexes
-    reducedi
+    reducedi.
       *
         0
         0
@@ -90,7 +90,7 @@
     1
 
   not. ++> can-reduce-bools-with-indexes
-    reducedi
+    reducedi.
       *
         true
         true
@@ -100,14 +100,14 @@
 
   ++> can-reduce-with-nested-functions
     eq. > @
-      reducedi
+      reducedi.
         * 10 500
         0
         [acc x i]
           check x > @
-          if. > [el] > check
-            x.lt 100
-            acc.plus x
-            acc.minus x
+          if. > [^ el] > check
+            ^.x.lt 100
+            ^.acc.plus ^.x
+            ^.acc.minus ^.x
       10.plus
         0.minus 500

--- a/objects/tuple/shifted.eo
+++ b/objects/tuple/shifted.eo
@@ -1,20 +1,64 @@
-# Drop the first `shift` elements of `list`.
+# Drop the first `shift` elements of `list` (a negative `shift` drops nothing).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list shift] > shifted
-  slice > @
-    list
-    shift
-    list.length
+[^ shift] > shifted
+  shift.is-integer.if > @
+    list.slice
+      if.
+        shift.lt 0
+        0
+        shift
+      list.length
+    T
+      "Given shift must be an integer"
+  ^ > list
+
+  eq. ++> can-ignore-a-negative-shift
+    shifted.
+      *
+        "привет"
+        -42
+        0
+        "ξ"
+      -1
+    *
+      "привет"
+      -42
+      0
+      "ξ"
+
+  eq. ++> can-ignore-a-shift-below-the-negative-length
+    shifted.
+      *
+        82.42
+        ""
+        "日本"
+      -9
+    *
+      82.42
+      ""
+      "日本"
+
+  eq. ++> can-ignore-a-zero-shift
+    shifted.
+      *
+        "a"
+        -0.5
+        "Ω"
+      0
+    *
+      "a"
+      -0.5
+      "Ω"
 
   eq. ++> can-shift-by-less-than-the-length
-    shifted
+    shifted.
       *
         8
         2
@@ -28,7 +72,7 @@
       5
 
   eq. ++> can-shift-by-more-than-the-length
-    shifted
+    shifted.
       *
         8
         2
@@ -37,3 +81,15 @@
         5
       6
     *
+
+  shifted. --> stops-on-a-negative-fractional-shift
+    *
+      "a"
+      "b"
+    -0.5
+
+  shifted. --> stops-on-a-positive-fractional-shift
+    *
+      "a"
+      "b"
+    0.5

--- a/objects/tuple/slice.eo
+++ b/objects/tuple/slice.eo
@@ -4,47 +4,51 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list start end] > slice
+[^ start end] > slice
   if. > @
-    gte.
-      number
-        if. >> s!
-          start.gte 0
+    start.is-integer.and end.is-integer
+    if.
+      gte.
+        number
+          if. >> s!
+            start.gte 0
+            if.
+              start.gte list.length
+              list.length
+              start
+            if.
+              list.length.neg.lte start
+              start.plus list.length
+              0
+        if. >> e!
+          end.gte 0
           if.
-            start.gte list.length
+            end.gte list.length
             list.length
-            start
+            end
           if.
-            list.length.neg.lte start
-            start.plus list.length
+            list.length.neg.lte end
+            end.plus list.length
             0
-      if. >> e!
-        end.gte 0
-        if.
-          end.gte list.length
-          list.length
-          end
-        if.
-          list.length.neg.lte end
-          end.plus list.length
-          0
-    *
-    reducedi
-      list
       *
-      if. > [accum item index] >>
-        and.
-          index.gte s
-          index.lt e
-        accum.with item
-        accum
+      list.reducedi
+        *
+        if. > [^ accum item index] >>
+          and.
+            index.gte s
+            index.lt e
+          accum.with item
+          accum
+    T
+      "Given slice start and end must both be integers"
+  ^ > list
 
   eq. ++> can-slice-a-list
-    slice
+    slice.
       *
         1
         2
@@ -60,7 +64,7 @@
       5
 
   eq. ++> can-slice-with-a-negative-end
-    slice
+    slice.
       *
         "a"
         2
@@ -78,7 +82,7 @@
       82.42
 
   eq. ++> can-slice-with-a-negative-start
-    slice
+    slice.
       *
         8
         76
@@ -95,7 +99,7 @@
       8
 
   eq. ++> can-slice-with-a-negative-start-and-end
-    slice
+    slice.
       *
         8
         23
@@ -110,7 +114,7 @@
       0
 
   eq. ++> can-slice-with-a-negative-start-not-below-the-end
-    slice
+    slice.
       *
         "f"
         1
@@ -123,7 +127,7 @@
     *
 
   eq. ++> can-slice-with-a-start-below-the-negative-length
-    slice
+    slice.
       *
         9
         99
@@ -137,7 +141,7 @@
       999
 
   eq. ++> can-slice-with-a-start-not-below-a-negative-end
-    slice
+    slice.
       *
         8
         -2
@@ -150,7 +154,7 @@
     *
 
   eq. ++> can-slice-with-a-start-not-below-the-end-when-both-negative
-    slice
+    slice.
       *
         3
         92
@@ -164,7 +168,7 @@
     *
 
   eq. ++> can-slice-with-a-start-not-below-the-end-when-both-positive
-    slice
+    slice.
       *
         3
         "-5"
@@ -175,7 +179,7 @@
     *
 
   eq. ++> can-slice-with-an-end-below-the-negative-length
-    slice
+    slice.
       *
         "A"
         "b"
@@ -187,7 +191,7 @@
     *
 
   eq. ++> can-slice-with-an-end-beyond-the-length
-    slice
+    slice.
       *
         "foo"
         "bar"
@@ -197,3 +201,19 @@
     *
       "bar"
       "buzz"
+
+  slice. --> stops-on-a-fractional-end
+    *
+      1
+      2
+      3
+    0
+    2.5
+
+  slice. --> stops-on-a-fractional-start
+    *
+      1
+      2
+      3
+    0.5
+    2

--- a/objects/tuple/withi.eo
+++ b/objects/tuple/withi.eo
@@ -1,23 +1,64 @@
 # Insert `item` into collection `list` at the given `index`.
+# The `index` must be an integer, the same requirement `tuple.front` and
+# `tuple.back` make; anything else terminates. A negative index is clamped
+# to the front of the list and an index past the end appends the item.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list index item] > withi
-  concat > @
-    with
-      front list index
-      item
-    back
-      list
-      list.length.minus index
+[^ index item] > withi
+  index.is-integer.if > @
+    concat.
+      with.
+        list.front bounded
+        item
+      list.back
+        list.length.minus bounded
+    T
+      "Given index must be an integer"
+  if. > bounded
+    0.gt index
+    0
+    if.
+      index.gt list.length
+      list.length
+      index
+  ^ > list
+
+  eq. ++> can-clamp-a-negative-index-to-the-front-without-duplicating
+    withi.
+      *
+        1
+        2
+        3
+      -1
+      9
+    *
+      9
+      1
+      2
+      3
+
+  eq. ++> can-clamp-an-index-beyond-the-end-without-duplicating
+    withi.
+      *
+        1
+        2
+        3
+      5
+      9
+    *
+      1
+      2
+      3
+      9
 
   eq. ++> can-insert-at-a-zero-index
-    withi
+    withi.
       *
         1
         2
@@ -35,7 +76,7 @@
       5
 
   eq. ++> can-insert-at-an-index
-    withi
+    withi.
       *
         1
         2
@@ -51,3 +92,19 @@
       "hello"
       4
       5
+
+  withi. --> stops-on-a-negative-fractional-index
+    *
+      1
+      2
+      3
+    -0.5
+    9
+
+  withi. --> stops-on-a-positive-fractional-index
+    *
+      1
+      2
+      3
+    0.5
+    9

--- a/objects/tuple/without.eo
+++ b/objects/tuple/without.eo
@@ -3,21 +3,20 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list element] > without
-  reduced > @
-    list
+[^ element] > without
+  ^.reduced > @
     *
-    if. > [accum item] >>
-      element.eq item
+    if. > [^ accum item] >>
+      ^.element.eq item
       accum
       accum.with item
 
   eq. ++> can-drop-an-item
-    without
+    without.
       *
         1
         2

--- a/objects/tuple/withouti.eo
+++ b/objects/tuple/withouti.eo
@@ -3,21 +3,23 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[list i] > withouti
-  reducedi > @
-    list
-    *
-    if. > [accum item index] >>
-      i.eq index
-      accum
-      accum.with item
+[^ i] > withouti
+  i.is-integer.if > @
+    ^.reducedi
+      *
+      if. > [^ accum item index] >>
+        ^.i.eq index
+        accum
+        accum.with item
+    T
+      "Given index must be an integer"
 
   eq. ++> can-drop-an-item-by-index
-    withouti
+    withouti.
       *
         1
         2
@@ -34,12 +36,10 @@
         "text"
         "f"
       * "text" "f"
-    withouti > [a] > foo
-      a
-      0
+    a.withouti 0 > [a] > foo
 
   eq. ++> can-drop-an-item-by-index-in-a-nested-list
-    withouti
+    withouti.
       *
         "smthg"
         27
@@ -51,3 +51,9 @@
     *
       "smthg"
       27
+
+  withouti. --> stops-on-a-fractional-index-when-dropping-an-item
+    *
+      "a"
+      "b"
+    0.5

--- a/objects/u16.eo
+++ b/objects/u16.eo
@@ -4,51 +4,49 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u16
   as-bytes > @
-  i32 > [] > as-i32
-    00-00.concat as-bytes
+  i32 > [^] > as-i32
+    00-00.concat ^.as-bytes
   as-i32.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u16 >> other
         00-00
       cant-divide
         "Can't divide %d by u16 zero".printf
-          * as-number
+          * ^.as-number
       u16
         slice.
           as-bytes.
-            as-i32.div other.as-i32
+            ^.as-i32.div other.as-i32
           2
           2
-  as-i32.gt x.as-u16.as-i32 > [x] > gt
-  as-i32.gte x.as-u16.as-i32 > [x] > gte
-  as-i32.lt x.as-u16.as-i32 > [x] > lt
-  as-i32.lte x.as-u16.as-i32 > [x] > lte
-  u16 > [x] > minus
+  ^.as-i32.gt x.as-u16.as-i32 > [^ x] > gt
+  ^.as-i32.gte x.as-u16.as-i32 > [^ x] > gte
+  ^.as-i32.lt x.as-u16.as-i32 > [^ x] > lt
+  ^.as-i32.lte x.as-u16.as-i32 > [^ x] > lte
+  u16 > [^ x] > minus
     slice.
       as-bytes.
-        as-i32.minus x.as-u16.as-i32
+        ^.as-i32.minus x.as-u16.as-i32
       2
       2
-  u16 > [x] > plus
+  u16 > [^ x] > plus
     slice.
       as-bytes.
-        as-i32.plus x.as-u16.as-i32
+        ^.as-i32.plus x.as-u16.as-i32
       2
       2
-  u16 > [x] > times
+  u16 > [^ x] > times
     slice.
       as-bytes.
-        as-i32.times x.as-u16.as-i32
+        ^.as-i32.times x.as-u16.as-i32
       2
       2
 
@@ -86,6 +84,12 @@
     00-06.as-u16.times 00-07.as-u16
     00-2A.as-u16
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    00-02.as-u16.div
+      00-00.as-u16
+      "recovered" > [message]
+
   eq. ++> can-subtract
     00-05.as-u16.minus 00-03.as-u16
     00-02.as-u16
@@ -93,6 +97,18 @@
   eq. ++> can-subtract-with-underflow
     00-00.as-u16.minus 00-01.as-u16
     FF-FF.as-u16
+
+  not. ++> can-tell-it-does-not-equal-a-different-u16
+    00-2A.as-u16.eq 00-2B.as-u16
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-u16
+    00-00.as-u16.gte 00-0A.as-u16
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-u16
+    00-0A.as-u16.lt 00-0A.as-u16
+
+  not. ++> can-tell-it-is-not-less-than-one-with-a-high-bit
+    FF-FF.as-u16.lt 00-01.as-u16
 
   FF-FF.as-u16.gt 00-01.as-u16 ++> can-treat-a-high-bit-as-magnitude-when-greater
 
@@ -103,23 +119,5 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
     01-00.as-u16.times 01-00.as-u16
     00-00.as-u16
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u16
-    00-00.as-u16.gte 00-0A.as-u16
-
-  not. ++> cannot-be-less-than-an-equal-u16
-    00-0A.as-u16.lt 00-0A.as-u16
-
-  not. ++> cannot-be-less-than-one-with-a-high-bit
-    FF-FF.as-u16.lt 00-01.as-u16
-
-  not. ++> cannot-equal-a-different-u16
-    00-2A.as-u16.eq 00-2B.as-u16
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    00-02.as-u16.div
-      00-00.as-u16
-      "recovered" > [message]
 
   00-02.as-u16.div 00-00.as-u16 --> stops-on-division-by-zero

--- a/objects/u32.eo
+++ b/objects/u32.eo
@@ -4,51 +4,49 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u32
   as-bytes > @
-  i64 > [] > as-i64
-    00-00-00-00.concat as-bytes
+  i64 > [^] > as-i64
+    00-00-00-00.concat ^.as-bytes
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u32 >> other
         00-00-00-00
       cant-divide
         "Can't divide %d by u32 zero".printf
-          * as-number
+          * ^.as-number
       u32
         slice.
           as-bytes.
-            as-i64.div other.as-i64
+            ^.as-i64.div other.as-i64
           4
           4
-  as-i64.gt x.as-u32.as-i64 > [x] > gt
-  as-i64.gte x.as-u32.as-i64 > [x] > gte
-  as-i64.lt x.as-u32.as-i64 > [x] > lt
-  as-i64.lte x.as-u32.as-i64 > [x] > lte
-  u32 > [x] > minus
+  ^.as-i64.gt x.as-u32.as-i64 > [^ x] > gt
+  ^.as-i64.gte x.as-u32.as-i64 > [^ x] > gte
+  ^.as-i64.lt x.as-u32.as-i64 > [^ x] > lt
+  ^.as-i64.lte x.as-u32.as-i64 > [^ x] > lte
+  u32 > [^ x] > minus
     slice.
       as-bytes.
-        as-i64.minus x.as-u32.as-i64
+        ^.as-i64.minus x.as-u32.as-i64
       4
       4
-  u32 > [x] > plus
+  u32 > [^ x] > plus
     slice.
       as-bytes.
-        as-i64.plus x.as-u32.as-i64
+        ^.as-i64.plus x.as-u32.as-i64
       4
       4
-  u32 > [x] > times
+  u32 > [^ x] > times
     slice.
       as-bytes.
-        as-i64.times x.as-u32.as-i64
+        ^.as-i64.times x.as-u32.as-i64
       4
       4
 
@@ -92,6 +90,12 @@
     00-00-00-06.as-u32.times 00-00-00-07.as-u32
     00-00-00-2A.as-u32
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    00-00-00-02.as-u32.div
+      00-00-00-00.as-u32
+      "recovered" > [message]
+
   eq. ++> can-subtract
     00-00-00-05.as-u32.minus 00-00-00-03.as-u32
     00-00-00-02.as-u32
@@ -99,6 +103,18 @@
   eq. ++> can-subtract-with-underflow
     00-00-00-00.as-u32.minus 00-00-00-01.as-u32
     FF-FF-FF-FF.as-u32
+
+  not. ++> can-tell-it-does-not-equal-a-different-u32
+    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-u32
+    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-u32
+    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
+
+  not. ++> can-tell-it-is-not-less-than-one-with-a-high-bit
+    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
 
   gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
     FF-FF-FF-FF.as-u32
@@ -111,23 +127,5 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
     00-01-00-00.as-u32.times 00-01-00-00.as-u32
     00-00-00-00.as-u32
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u32
-    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
-
-  not. ++> cannot-be-less-than-an-equal-u32
-    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
-
-  not. ++> cannot-be-less-than-one-with-a-high-bit
-    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
-
-  not. ++> cannot-equal-a-different-u32
-    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    00-00-00-02.as-u32.div
-      00-00-00-00.as-u32
-      "recovered" > [message]
 
   00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> stops-on-division-by-zero

--- a/objects/u64.eo
+++ b/objects/u64.eo
@@ -3,56 +3,63 @@
 # interpreted without a sign. Addition, subtraction and multiplication
 # share the bit pattern of their signed `i64` counterparts, while
 # comparisons and division are made unsigned.
+# `as-number` rounds exactly once. Above `2^63` the eight bytes are
+# shifted right by one bit, the bit that falls off is put back as the
+# lowest bit of the shifted value, and the result is doubled. That
+# lowest bit keeps the shifted value odd whenever something was
+# discarded, so it can never sit on a tie and be rounded the wrong way.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u64
   as-bytes > @
-  plus. > [] > as-number
+  if. > [^] > as-number
+    eq.
+      ^.as-bytes.and 80-00-00-00-00-00-00-00
+      80-00-00-00-00-00-00-00
+    times.
+      as-number.
+        i64
+          or.
+            ^.as-bytes.right 1
+            ^.as-bytes.and 00-00-00-00-00-00-00-01
+      2
     as-number.
-      i64 as-bytes
-    if.
-      eq.
-        as-bytes.and 80-00-00-00-00-00-00-00
-        80-00-00-00-00-00-00-00
-      1.8446744073709552e19
-      0
+      i64 ^.as-bytes
   as-bytes.xor 80-00-00-00-00-00-00-00 > flip
-  gt. > [x] > gt
-    i64 flip
+  gt. > [^ x] > gt
+    i64 ^.flip
     i64 x.as-u64.flip
-  gte. > [x] > gte
-    i64 flip
+  gte. > [^ x] > gte
+    i64 ^.flip
     i64 x.as-u64.flip
-  lt. > [x] > lt
-    i64 flip
+  lt. > [^ x] > lt
+    i64 ^.flip
     i64 x.as-u64.flip
-  lte. > [x] > lte
-    i64 flip
+  lte. > [^ x] > lte
+    i64 ^.flip
     i64 x.as-u64.flip
-  [x] > minus
+  [^ x] > minus
     u64 > @
       as-bytes.
         minus. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
-  [x] > plus
+  [^ x] > plus
     u64 > @
       as-bytes.
         plus. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
-  [x] > times
+  [^ x] > times
     u64 > @
       as-bytes.
         times. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
 
   eq. ++> can-add-one-to-one
@@ -83,9 +90,29 @@
     00-00-00-00-00-00-00-2A.as-u64.as-number
     42
 
+  eq. ++> can-convert-a-value-just-above-two-to-the-63rd
+    80-00-00-00-00-00-04-01.as-u64.as-number
+    9.223372036854778e18
+
+  eq. ++> can-convert-a-value-just-below-two-to-the-63rd
+    7F-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    9.223372036854776e18
+
+  eq. ++> can-convert-a-value-with-two-high-bits-to-a-number
+    C0-00-00-00-00-00-04-01.as-u64.as-number
+    1.3835058055282166e19
+
+  eq. ++> can-convert-the-maximum-to-a-number
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    1.8446744073709552e19
+
   gt. ++> can-convert-to-an-unsigned-number
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
     0
+
+  eq. ++> can-convert-two-to-the-63rd-to-a-number
+    80-00-00-00-00-00-00-00.as-u64.as-number
+    9.223372036854776e18
 
   eq. ++> can-equal-the-same-u64
     00-00-00-00-00-00-00-2A.as-u64
@@ -107,6 +134,15 @@
     00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64
 
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-u64
+    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-u64
+    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> can-tell-it-is-not-less-than-one-with-a-high-bit
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64
+
   gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64
     00-00-00-00-00-00-00-01.as-u64
@@ -114,12 +150,3 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
     00-00-00-01-00-00-00-00.as-u64.times 00-00-00-01-00-00-00-00.as-u64
     00-00-00-00-00-00-00-00.as-u64
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u64
-    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
-
-  not. ++> cannot-be-less-than-an-equal-u64
-    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
-
-  not. ++> cannot-be-less-than-one-with-a-high-bit
-    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64

--- a/objects/u64/div.eo
+++ b/objects/u64/div.eo
@@ -6,11 +6,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package u64
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[n x cant-divide] > div
+[^ x cant-divide] > div
   if. > @
     d.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -43,6 +43,7 @@
           u64 q0
           u64 00-00-00-00-00-00-00-01
         u64 q0
+  ^ > n
 
   eq. ++> can-divide-a-small-value-by-a-larger-divisor
     00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64
@@ -64,7 +65,7 @@
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
     7F-FF-FF-FF-FF-FF-FF-FF.as-u64
 
-  eq. ++> rejects-division-by-zero
+  eq. ++> can-recover-from-division-by-zero
     "recovered"
     00-00-00-00-00-00-00-02.as-u64.div
       00-00-00-00-00-00-00-00.as-u64

--- a/objects/u8.eo
+++ b/objects/u8.eo
@@ -4,51 +4,49 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [as-bytes] > u8
   as-bytes > @
-  i16 > [] > as-i16
-    00-.concat as-bytes
+  i16 > [^] > as-i16
+    00-.concat ^.as-bytes
   as-i16.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u8 >> other
         00-
       cant-divide
         "Can't divide %d by u8 zero".printf
-          * as-number
+          * ^.as-number
       u8
         slice.
           as-bytes.
-            as-i16.div other.as-i16
+            ^.as-i16.div other.as-i16
           1
           1
-  as-i16.gt x.as-u8.as-i16 > [x] > gt
-  as-i16.gte x.as-u8.as-i16 > [x] > gte
-  as-i16.lt x.as-u8.as-i16 > [x] > lt
-  as-i16.lte x.as-u8.as-i16 > [x] > lte
-  u8 > [x] > minus
+  ^.as-i16.gt x.as-u8.as-i16 > [^ x] > gt
+  ^.as-i16.gte x.as-u8.as-i16 > [^ x] > gte
+  ^.as-i16.lt x.as-u8.as-i16 > [^ x] > lt
+  ^.as-i16.lte x.as-u8.as-i16 > [^ x] > lte
+  u8 > [^ x] > minus
     slice.
       as-bytes.
-        as-i16.minus x.as-u8.as-i16
+        ^.as-i16.minus x.as-u8.as-i16
       1
       1
-  u8 > [x] > plus
+  u8 > [^ x] > plus
     slice.
       as-bytes.
-        as-i16.plus x.as-u8.as-i16
+        ^.as-i16.plus x.as-u8.as-i16
       1
       1
-  u8 > [x] > times
+  u8 > [^ x] > times
     slice.
       as-bytes.
-        as-i16.times x.as-u8.as-i16
+        ^.as-i16.times x.as-u8.as-i16
       1
       1
 
@@ -90,6 +88,12 @@
     255.as-i64.as-i32.as-i16
     FF-.as-u8.as-i16
 
+  eq. ++> can-recover-from-division-by-zero
+    "recovered"
+    02-.as-u8.div
+      00-.as-u8
+      "recovered" > [message]
+
   eq. ++> can-subtract
     05-.as-u8.minus 03-.as-u8
     02-.as-u8
@@ -97,6 +101,18 @@
   eq. ++> can-subtract-with-underflow
     00-.as-u8.minus 01-.as-u8
     FF-.as-u8
+
+  not. ++> can-tell-it-does-not-equal-a-different-u8
+    2A-.as-u8.eq 2B-.as-u8
+
+  not. ++> can-tell-it-is-not-greater-than-or-equal-to-a-larger-u8
+    00-.as-u8.gte 0A-.as-u8
+
+  not. ++> can-tell-it-is-not-less-than-an-equal-u8
+    0A-.as-u8.lt 0A-.as-u8
+
+  not. ++> can-tell-it-is-not-less-than-one-with-a-high-bit
+    FF-.as-u8.lt 01-.as-u8
 
   FF-.as-u8.gt 01-.as-u8 ++> can-treat-a-high-bit-as-magnitude-when-greater
 
@@ -109,23 +125,5 @@
   eq. ++> can-wrap-a-product-modulo-two-to-the-eighth
     10-.as-u8.times 10-.as-u8
     00-.as-u8
-
-  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u8
-    00-.as-u8.gte 0A-.as-u8
-
-  not. ++> cannot-be-less-than-an-equal-u8
-    0A-.as-u8.lt 0A-.as-u8
-
-  not. ++> cannot-be-less-than-one-with-a-high-bit
-    FF-.as-u8.lt 01-.as-u8
-
-  not. ++> cannot-equal-a-different-u8
-    2A-.as-u8.eq 2B-.as-u8
-
-  eq. ++> rejects-division-by-zero
-    "recovered"
-    02-.as-u8.div
-      00-.as-u8
-      "recovered" > [message]
 
   02-.as-u8.div 00-.as-u8 --> stops-on-division-by-zero

--- a/objects/uri.eo
+++ b/objects/uri.eo
@@ -19,50 +19,67 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
 
 [text] > uri
   text > @
-  if. > authority
-    string.starts-with >> has-authority
-      hier-part
-      "//"
-    if.
-      not. >> has-authority-path
-        eq.
-          string.index-of after-slashes "/" >> authority-path-idx
-          -1
-      slice.
-        has-authority.if >> after-slashes
-          slice.
-            has-query.if >> hier-part
-              before-fragment.slice 0 question-idx
-              before-fragment
-            2
-            hier-part.length.minus
-              number 2
-          ""
-        0
-        authority-path-idx
-      after-slashes
-    ""
-  if. > fragment
-    not. >> has-fragment
-      hash-idx.eq -1
-    slice.
-      text.slice >> rest
-        plus.
-          string.index-of text ":" >> scheme-colon
-          1
-        text.length.minus
-          number
-            scheme-colon.plus 1
+  string > authority
+    has-authority.if >> authority-bytes!
+      if.
+        not. >> has-authority-path
+          eq.
+            after-slashes.index-of "/" >> authority-path-idx
+            -1
+        slice.
+          string >> after-slashes
+            if. >> after-slashes-bytes!
+              hier-part.starts-with "//" >> has-authority
+              slice.
+                string >> hier-part
+                  if. >> hier-bytes!
+                    not. >> has-query
+                      eq.
+                        before-fragment.index-of "?" >> question-idx
+                        -1
+                    slice.
+                      if. >> before-fragment
+                        not. (hash-idx.eq -1) >> has-fragment
+                        slice.
+                          text.slice >> rest
+                            plus.
+                              if. >> scheme-colon
+                                or.
+                                  eq.
+                                    text.index-of ":" >> raw-colon
+                                    -1
+                                  not.
+                                    "/[A-Za-z][A-Za-z0-9+.-]*/".regex.compiled.matches
+                                      text.slice 0 raw-colon
+                                -1
+                                raw-colon
+                              1
+                            text.length.minus
+                              number (scheme-colon.plus 1)
+                          0
+                          hash-idx
+                        rest
+                      0
+                      question-idx
+                    before-fragment
+                2
+                hier-part.length.minus
+                  number 2
+              ""
+          0
+          authority-path-idx
+        after-slashes
+      ""
+  has-fragment.if > fragment
+    rest.slice
       plus.
-        string.index-of rest "#" >> hash-idx
+        rest.index-of "#" >> hash-idx
         1
       rest.length.minus
         number
@@ -70,17 +87,38 @@
     ""
   if. > host
     not. >> has-port
-      port-colon-idx.eq -1
-    slice.
-      has-userinfo.if >> host-port
-        authority.slice
-          plus.
-            string.index-of authority "@" >> userinfo-at-idx
-            1
-          authority.length.minus
-            number
-              userinfo-at-idx.plus 1
-        authority
+      eq.
+        if. >> port-colon-idx
+          host-port.starts-with "[" >>
+          if.
+            eq.
+              index-of. >> rel-colon
+                host-port.slice
+                  bracket-start
+                  host-port.length.minus
+                    number bracket-start
+                ":"
+              -1
+            -1
+            rel-colon.plus
+              plus. >> bracket-start
+                index-of. >>
+                  string >> host-port
+                    if. >> host-port-bytes!
+                      not. >> has-userinfo
+                        eq.
+                          authority.last-index-of "@" >> userinfo-at-idx
+                          -1
+                      authority.slice
+                        userinfo-at-idx.plus 1
+                        authority.length.minus
+                          number (userinfo-at-idx.plus 1)
+                      authority
+                  "]"
+                1
+          host-port.index-of ":"
+        -1
+    host-port.slice
       0
       port-colon-idx
     host-port
@@ -93,54 +131,46 @@
       ""
     hier-part
   has-port.if > port
-    host-port.slice
-      plus.
-        if. >> port-colon-idx
-          string.starts-with host-port "[" >>
-          if.
-            eq.
-              string.index-of >> rel-colon
-                host-port.slice
-                  bracket-start
-                  host-port.length.minus
-                    number bracket-start
-                ":"
-              -1
-            -1
-            rel-colon.plus
-              plus. >> bracket-start
-                string.index-of host-port "]" >>
-                1
-          string.index-of host-port ":"
-        1
-      host-port.length.minus
-        number
-          port-colon-idx.plus 1
+    if.
+      raw-port.is-digit.or
+        eq.
+          host-port.slice >> raw-port
+            port-colon-idx.plus 1
+            host-port.length.minus
+              number
+                port-colon-idx.plus 1
+          ""
+      raw-port
+      ""
     ""
-  if. > query
-    not. >> has-query
-      question-idx.eq -1
-    slice.
-      has-fragment.if >> before-fragment
-        rest.slice 0 hash-idx
-        rest
-      plus.
-        string.index-of before-fragment "?" >> question-idx
-        1
+  has-query.if > query
+    before-fragment.slice
+      question-idx.plus 1
       before-fragment.length.minus
         number
           question-idx.plus 1
     ""
-  text.slice > scheme
-    0
-    scheme-colon
-  if. > userinfo
-    not. >> has-userinfo
-      userinfo-at-idx.eq -1
+  if. > scheme
+    scheme-colon.eq -1
+    ""
+    text.slice
+      0
+      scheme-colon
+  has-userinfo.if > userinfo
     authority.slice
       0
       userinfo-at-idx
     ""
+
+  eq. ++> can-ignore-a-question-mark-that-appears-inside-the-fragment
+    query.
+      uri "http://host/path#frag?not-a-query"
+    ""
+
+  eq. ++> can-keep-extra-hash-characters-inside-the-fragment
+    fragment.
+      uri "http://host/path?x=1#a#b"
+    "a#b"
 
   eq. ++> can-parse-a-bracketed-ipv6-host-with-a-port
     host.
@@ -152,6 +182,11 @@
       uri "http://[2001:db8::1]/p"
     "[2001:db8::1]"
 
+  eq. ++> can-parse-a-fragment-that-is-empty-after-a-trailing-hash
+    fragment.
+      uri "http://host/path#"
+    ""
+
   eq. ++> can-parse-a-fragment-without-a-leading-hash
     fragment.
       uri "http://host/some/path?x=1#top"
@@ -160,6 +195,11 @@
   eq. ++> can-parse-a-host-alongside-userinfo
     host.
       uri "http://user:pass@host:80/some/path"
+    "host"
+
+  eq. ++> can-parse-a-host-past-an-at-sign-inside-userinfo
+    host.
+      uri "http://a@b@host/p"
     "host"
 
   eq. ++> can-parse-a-path-alongside-a-userinfo-authority
@@ -172,10 +212,80 @@
       uri "http://user:pass@host:80/some/path"
     "80"
 
+  eq. ++> can-parse-a-query-that-is-empty-after-a-trailing-question-mark
+    query.
+      uri "http://host/path?"
+    ""
+
   eq. ++> can-parse-a-query-without-a-leading-question-mark
     query.
       uri "http://host/some/path?x=1#top"
     "x=1"
+
+  eq. ++> can-parse-a-scheme-with-a-plus-and-a-dot
+    scheme.
+      uri "a+b.c:part"
+    "a+b.c"
+
+  eq. ++> can-parse-a-scheme-with-uppercase-letters
+    scheme.
+      uri "HTTP://host/path"
+    "HTTP"
+
+  eq. ++> can-parse-a-userinfo-holding-an-at-sign
+    userinfo.
+      uri "http://a@b@host/p"
+    "a@b"
+
+  eq. ++> can-parse-a-userinfo-without-a-password
+    userinfo.
+      uri "http://user@host/path"
+    "user"
+
+  eq. ++> can-parse-an-empty-fragment-when-absent
+    fragment.
+      uri "http://host/path"
+    ""
+
+  eq. ++> can-parse-an-empty-port
+    port.
+      uri "http://host:/"
+    ""
+
+  eq. ++> can-parse-an-empty-query-when-absent
+    query.
+      uri "http://host/path"
+    ""
+
+  eq. ++> can-parse-an-empty-userinfo-of-a-bracketed-ipv6-authority
+    userinfo.
+      uri "http://[::1]:8080/p"
+    ""
+
+  eq. ++> can-parse-an-empty-userinfo-when-absent
+    userinfo.
+      uri "http://host/path"
+    ""
+
+  eq. ++> can-parse-an-ipv4-host-without-a-port
+    host.
+      uri "http://192.168.1.1/path"
+    "192.168.1.1"
+
+  eq. ++> can-parse-the-authority-of-a-bare-authority-uri
+    authority.
+      uri "http://host/path"
+    "host"
+
+  eq. ++> can-parse-the-authority-of-a-bare-scheme-uri
+    authority.
+      uri "pgsql:localhost:899"
+    ""
+
+  eq. ++> can-parse-the-authority-of-a-userinfo-and-port-uri
+    authority.
+      uri "http://user:pass@host:80/some/path"
+    "user:pass@host:80"
 
   eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
     host.
@@ -185,6 +295,26 @@
   eq. ++> can-parse-the-empty-path-of-an-authority-only-uri
     path.
       uri "pgsql://localhost:899"
+    ""
+
+  eq. ++> can-parse-the-host-of-a-bare-authority-uri
+    host.
+      uri "http://host/path"
+    "host"
+
+  eq. ++> can-parse-the-host-of-a-bracketed-ipv6-authority-with-userinfo
+    host.
+      uri "http://user:pass@[::1]:80/path"
+    "[::1]"
+
+  eq. ++> can-parse-the-host-of-a-protocol-relative-uri
+    host.
+      uri "//host/path"
+    "host"
+
+  eq. ++> can-parse-the-host-of-a-schemeless-uri
+    host.
+      uri "foo/bar"
     ""
 
   eq. ++> can-parse-the-host-of-an-authority-with-a-port
@@ -197,15 +327,40 @@
       uri "pgsql:localhost:899"
     "localhost:899"
 
+  eq. ++> can-parse-the-path-of-a-relative-uri-without-a-scheme
+    path.
+      uri "foo/bar"
+    "foo/bar"
+
+  eq. ++> can-parse-the-path-of-a-scheme-only-uri-with-an-at-sign
+    path.
+      uri "mailto:user@example.com"
+    "user@example.com"
+
   eq. ++> can-parse-the-path-of-a-triple-slash-uri
     path.
       uri "file:///etc/passwd"
     "/etc/passwd"
 
+  eq. ++> can-parse-the-path-of-an-authority-with-a-trailing-slash
+    path.
+      uri "http://host/"
+    "/"
+
   eq. ++> can-parse-the-port-of-a-bracketed-ipv6-host
     port.
       uri "http://[::1]:8080/p"
     "8080"
+
+  eq. ++> can-parse-the-port-of-a-bracketed-ipv6-host-without-a-port
+    port.
+      uri "http://[2001:db8::1]/p"
+    ""
+
+  eq. ++> can-parse-the-port-of-a-schemeless-uri-as-empty
+    port.
+      uri "foo/bar"
+    ""
 
   eq. ++> can-parse-the-port-of-an-authority
     port.
@@ -217,12 +372,62 @@
       uri "pgsql:localhost:899"
     "pgsql"
 
+  eq. ++> can-parse-the-scheme-of-a-schemeless-uri
+    scheme.
+      uri "localhost"
+    ""
+
   eq. ++> can-parse-the-scheme-of-a-triple-slash-uri
     scheme.
       uri "file:///etc/passwd"
     "file"
 
+  eq. ++> can-parse-the-scheme-of-a-uri-with-digits-after-the-first-letter
+    scheme.
+      uri "http2://host/path"
+    "http2"
+
+  eq. ++> can-parse-the-scheme-of-an-empty-text
+    scheme.
+      uri ""
+    ""
+
+  eq. ++> can-parse-the-userinfo-of-a-bracketed-ipv6-authority
+    userinfo.
+      uri "http://user:pass@[::1]:80/path"
+    "user:pass"
+
   eq. ++> can-parse-the-userinfo-of-an-authority
     userinfo.
       uri "http://user:pass@host:80/some/path"
     "user:pass"
+
+  eq. ++> can-treat-a-digit-led-prefix-as-schemeless
+    scheme.
+      uri "1http://host/path"
+    ""
+
+  eq. ++> can-treat-a-letter-suffixed-port-as-invalid
+    port.
+      uri "http://host:12x/"
+    ""
+
+  eq. ++> can-treat-a-non-digit-port-as-invalid
+    port.
+      uri "http://host:abc/"
+    ""
+
+  eq. ++> can-treat-a-plus-led-prefix-as-schemeless
+    scheme.
+      uri "+foo:bar"
+    ""
+
+  eq. ++> can-treat-a-scheme-with-an-underscore-as-invalid
+    scheme.
+      uri "ht_tp:foo"
+    ""
+
+  eq. ++> can-treat-a-uri-starting-with-a-colon-as-schemeless
+    scheme.
+      uri ":foo"
+    ""

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -2,7 +2,7 @@
 # Here's how you can use it:
 # ```
 # while > last
-#   i.lt 5 > [i]
+#   i.lt 5 > [^ i]
 #   [i]
 #     "Iteration %d\n".printf > @
 #       * i
@@ -12,38 +12,38 @@
 # ```
 # seq > last
 #   *
+#     dataized "Iteration 0\n"
 #     dataized "Iteration 1\n"
 #     dataized "Iteration 2\n"
 #     dataized "Iteration 3\n"
 #     dataized "Iteration 4\n"
 # ```
 #
-# Only the first three strings are dataized for side effects while the last one
+# Only the first four strings are dataized for side effects while the last one
 # is returned as the result value assigned to the `last` object.
 # The `while` loop example produces identical behavior.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
 
 [condition body] > while
   if. > @
     as-bool.
       condition 0
-    [index] >> loop
+    [^ index] >> loop
       if. > @
         as-bool.
-          condition
+          ^.condition
             index.plus 1
         seq *
           current
-          loop
+          ^.loop
             index.plus 1
         current
-      body index > current
+      ^.body index > current
     | 0
     false
 
@@ -54,7 +54,7 @@
         [m]
           while > @
             i.eq 0 > [i]
-            m.put i > [i] >>
+            ^.m.put i > [^ i] >>
 
   ++> can-iterate-a-tuple-with-an-external-iterator
     data.eq array.length > @
@@ -65,18 +65,18 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             while > @
-              max.gt iter > [i] >>
-              seq * > [i] >>
-                acc.put
-                  acc.as-number.plus
-                    array.at iter
-                iter.put
-                  iter.as-number.plus 1
+              ^.^.^.max.gt ^.iter > [^ i] >>
+              seq * > [^ i] >>
+                ^.^.acc.put
+                  ^.^.acc.as-number.plus
+                    ^.^.^.array.at ^.iter
+                ^.iter.put
+                  ^.iter.as-number.plus 1
     array.length.plus -1 > max
 
   ++> can-iterate-a-tuple-with-an-internal-iterator
@@ -88,22 +88,22 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             if. > @
-              max.eq 0
-              acc.put
-                acc.as-number.plus
-                  array.at 0
+              ^.^.max.eq 0
+              ^.acc.put
+                ^.acc.as-number.plus
+                  ^.^.array.at 0
               while
-                max.gt iter > [i] >>
-                seq * > [i] >>
-                  acc.put
-                    acc.as-number.plus (array.at i)
-                  iter.put
-                    iter.as-number.plus 1
+                ^.^.^.max.gt ^.iter > [^ i] >>
+                seq * > [^ i] >>
+                  ^.^.acc.put
+                    ^.^.acc.as-number.plus (^.^.^.array.at i)
+                  ^.iter.put
+                    ^.iter.as-number.plus 1
     array.length.plus -1 > max
 
   ++> can-iterate-a-tuple-without-a-body-many-times
@@ -114,22 +114,22 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             seq * > @
               while
-                if. > [i] >>
-                  max.gt iter
+                if. > [^ i] >>
+                  ^.^.^.max.gt ^.iter
                   seq *
-                    acc.put
-                      acc.as-number.plus (array.at iter.as-number)
-                    iter.put (iter.as-number.plus 1)
+                    ^.^.acc.put
+                      ^.^.acc.as-number.plus (^.^.^.array.at ^.iter.as-number)
+                    ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
                 true > [i]
-              acc
+              ^.acc
     array.length > max
 
   ++> can-iterate-a-tuple-without-a-body-once
@@ -137,22 +137,22 @@
     * 1 > array
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             seq * > @
               while
-                if. > [i] >>
-                  max.gt iter
+                if. > [^ i] >>
+                  ^.^.^.max.gt ^.iter
                   seq *
-                    acc.put
-                      acc.as-number.plus (array.at iter.as-number)
-                    iter.put (iter.as-number.plus 1)
+                    ^.^.acc.put
+                      ^.^.acc.as-number.plus (^.^.^.array.at ^.iter.as-number)
+                    ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
                 true > [i]
-              acc
+              ^.acc
     array.length > max
 
   ++> can-loop-on-a-bool-expression-kept-in-malloc
@@ -161,8 +161,8 @@
         true
         [m]
           while > @
-            m > [i] >>
-            m.put false > [i] >>
+            ^.m > [^ i] >>
+            ^.m.put false > [^ i] >>
       false
 
   ++> can-loop-over-a-simple-iteration
@@ -172,7 +172,7 @@
         [m]
           while > @
             i.lt 10 > [i]
-            m.put i > [i] >>
+            ^.m.put i > [^ i] >>
       9
 
   not. ++> can-loop-when-the-condition-is-false-first
@@ -186,9 +186,9 @@
         0
         [m]
           while > @
-            2.gt m > [i] >>
-            m.put > [i] >>
-              m.as-number.plus 1
+            2.gt ^.m > [^ i] >>
+            ^.m.put > [^ i] >>
+              ^.m.as-number.plus 1
       3
 
   not. ++> can-return-the-last-dataized-object-with-a-false-condition

--- a/objects/win32.eo
+++ b/objects/win32.eo
@@ -10,18 +10,19 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.62.0
++rt jvm org.eolang:eo-runtime:0.63.0
 +rt node eo2js-runtime:0.0.0
-+version 0.62.0
++version 0.63.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-+unlint redundant-object
 
 [name args] > win32
   [] > @ /Q.win32.return
+    ? > ^
   8 > append
   256 > creat
+  17 > eexist
+  1024 > exclusive
   -1 > failure
   2 > inet
   -1 > invalid
@@ -29,9 +30,10 @@
   -1 > none
   32768 > rdonly
   32770 > rdwr
-  [code output] > return
+  00-00-00-00-00-00-04-00 > reparse
+  [^ code output] > return
     output > @
-    return > called
+    ^.return > called
       code
       output
   [family port address] > sockaddr-in
@@ -49,8 +51,103 @@
   6 > tcp
   [time millitm] > timeb
   512 > trunc
+  4294967295 > unresolved
   02-02 > version
   32769 > wronly
+
+  ++> can-close-a-tcp-socket
+    os.is-windows.not.or > @
+      seq *
+        sd
+        not.
+          eq.
+            code.
+              win32 *1
+                "closesocket"
+                sd
+            -1
+    code. > sd
+      win32 *1
+        "socket"
+        win32.inet
+        win32.stream
+        win32.tcp
+
+  ++> can-compute-the-size-of-a-sockaddr-in
+    addr.size.eq 16 > @
+    win32.sockaddr-in > addr
+      00-00
+      00-00
+      00-00-00-00
+
+  ++> can-open-a-file-with-the-append-flag
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "_close"
+            fd
+        fd.gt -1
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly.plus win32.append
+        0
+
+  ++> can-open-a-file-with-the-trunc-flag
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "_close"
+            fd
+        fd.gt -1
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly.plus win32.trunc
+        0
+
+  ++> can-open-a-tcp-socket
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "closesocket"
+            sd
+        sd.gt 0
+    code. > sd
+      win32 *1
+        "socket"
+        win32.inet
+        win32.stream
+        win32.tcp
+
+  os.is-windows.not.or ++> can-report-a-host-name-as-invalid
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "localhost"
+      win32.unresolved
+
+  os.is-windows.not.or ++> can-report-an-ipv6-address-as-invalid
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "::1"
+      win32.unresolved
+
+  os.is-windows.not.or ++> can-return-an-inet-address-above-the-signed-range
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "10.0.0.200"
+      3355443210
 
   os.is-windows.not.or ++> can-return-an-inet-address-for-localhost
     eq.
@@ -59,3 +156,65 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  ++> can-stat-the-size-of-nul
+    os.is-windows.not.or > @
+      info.size.eq 0
+    output. > info
+      win32 *1
+        "_stat64"
+        "NUL"
+
+  os.is-windows.not.if --> stops-on-creating-an-existing-file-exclusively
+    1.div 0
+    seq *
+      code.
+        win32 *1
+          "_open"
+          "NUL"
+          plus.
+            win32.rdonly.plus win32.creat
+            win32.exclusive
+          win32.mode
+      eq.
+        code.
+          win32
+            "_errno"
+            *
+        win32.eexist
+
+  --> stops-on-write-size-being-negative
+    os.is-windows.not.if > @
+      1.div 0
+      seq *
+        code.
+          win32 *1
+            "_write"
+            fd
+            "ab"
+            -1
+        true
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly
+        0
+
+  --> stops-on-write-size-exceeding-buffer-length
+    os.is-windows.not.if > @
+      1.div 0
+      seq *
+        code.
+          win32 *1
+            "_write"
+            fd
+            "ab"
+            4096
+        true
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly
+        0


### PR DESCRIPTION
A new release `eo-0.63.0` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.