### PR TITLE
New release for eo-0.63.1

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.63.0</eo.version>
+    <eo.version>0.63.1</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bool.eo
+++ b/objects/bool.eo
@@ -7,7 +7,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/buffer.eo
+++ b/objects/buffer.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -14,9 +14,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/array.eo
+++ b/objects/bytes/array.eo
@@ -1,26 +1,24 @@
 # Represents sequence of bytes as array.
-# Here `b` is `bytes` objects, the return value is `tuple` where
+# It is a method of `bytes`, and the return value is `tuple` where
 # each element is one `byte`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > array
-  ^ > b
-  size. >> len!
-    b >> data!
-  if. > [^ tup index] >> slice-byte
-    index.lt len
-    ^.slice-byte
-      tup.with
-        ^.b.slice index 1
-      as-number.
-        index.plus 1
-    tup
+  [^ tup index] >> slice-byte
+    if. > @
+      index.lt ^.^.size!
+      ^.slice-byte
+        tup.with
+          ^.^.slice index 1
+        as-number.
+          index.plus 1
+      tup
   | > @
     *
     0

--- a/objects/bytes/as-bool.eo
+++ b/objects/bytes/as-bool.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-bytes.eo
+++ b/objects/bytes/as-bytes.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/as-hex.eo
+++ b/objects/bytes/as-hex.eo
@@ -1,15 +1,14 @@
-# Writes the bytes `b` as uppercase hexadecimal pairs joined by a hyphen,
+# Writes the bytes as uppercase hexadecimal pairs joined by a hyphen,
 # so that the two bytes `0x4A 0x65` become `4A-65`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-hex
-  ^ > b
   if. > [h] >> hex-digit
     h.lt 10
     as-char.
@@ -18,7 +17,7 @@
       h.plus 55
   [^ index acc] >> rec-hex
     if. > @
-      index.eq ^.b.size
+      index.eq ^.^.size
       acc
       ^.rec-hex
         as-number.
@@ -26,7 +25,7 @@
         next
     as-ascii. > bval
       string
-        ^.b.slice index 1
+        ^.^.slice index 1
     if. > next!
       index.eq 0
       pair

--- a/objects/bytes/as-i16.eo
+++ b/objects/bytes/as-i16.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-i16
   if. > @
-    b.size.eq 2
-    i16 b
+    ^.size.eq 2
+    i16 ^
     cant-convert
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
 

--- a/objects/bytes/as-i32.eo
+++ b/objects/bytes/as-i32.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-i32
   if. > @
-    b.size.eq 4
-    i32 b
+    ^.size.eq 4
+    i32 ^
     cant-convert
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
 

--- a/objects/bytes/as-i64.eo
+++ b/objects/bytes/as-i64.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-i64
   if. > @
-    b.size.eq 8
-    i64 b
+    ^.size.eq 8
+    i64 ^
     cant-convert
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> can-convert-bytes-to-i64
 

--- a/objects/bytes/as-i8.eo
+++ b/objects/bytes/as-i8.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-i8
   if. > @
-    b.size.eq 1
-    i8 b
+    ^.size.eq 1
+    i8 ^
     cant-convert
       "Can't convert non 1 length bytes to i8, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
 

--- a/objects/bytes/as-input.eo
+++ b/objects/bytes/as-input.eo
@@ -1,6 +1,6 @@
 # Makes an `input` from bytes.
-# Here `b` is sequence of bytes or an object that can be dataized
-# via `as-bytes`.
+# It is taken off a sequence of bytes, or off any object that can be
+# dataized via `as-bytes`.
 # Here's how you can read portions of bytes from the input:
 # ```
 # as-input > i
@@ -24,16 +24,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-input
-  ^ > b
   [^ size] > read
     @. > @
       read.
-        input-block ^.b --
+        input-block ^.^ --
         size
     [^ data buffer] > input-block
       buffer > @

--- a/objects/bytes/as-number.eo
+++ b/objects/bytes/as-number.eo
@@ -5,28 +5,27 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-number
   if. > @
-    b.size.eq 8
+    ^.size.eq 8
     if.
       is-nan.
-        number b
+        number ^
       nan
       if.
-        b.eq pinf.as-bytes
+        ^.eq pinf.as-bytes
         pinf
         if.
-          b.eq ninf.as-bytes
+          ^.eq ninf.as-bytes
           ninf
-          number b
+          number ^
     cant-convert
       "Can't convert non 8 length bytes to a number, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-a-number
     "recovered"

--- a/objects/bytes/as-u16.eo
+++ b/objects/bytes/as-u16.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-u16
   if. > @
-    b.size.eq 2
-    u16 b
+    ^.size.eq 2
+    u16 ^
     cant-convert
       "Can't convert non 2 length bytes to u16, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
 

--- a/objects/bytes/as-u32.eo
+++ b/objects/bytes/as-u32.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-u32
   if. > @
-    b.size.eq 4
-    u32 b
+    ^.size.eq 4
+    u32 ^
     cant-convert
       "Can't convert non 4 length bytes to u32, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
 

--- a/objects/bytes/as-u64.eo
+++ b/objects/bytes/as-u64.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-u64
   if. > @
-    b.size.eq 8
-    u64 b
+    ^.size.eq 8
+    u64 ^
     cant-convert
       "Can't convert non 8 length bytes to u64, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   eq. ++> can-convert-bytes-to-u64-and-back
     00-00-00-00-00-00-00-33.as-u64.as-bytes

--- a/objects/bytes/as-u8.eo
+++ b/objects/bytes/as-u8.eo
@@ -5,18 +5,17 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-convert] > as-u8
   if. > @
-    b.size.eq 1
-    u8 b
+    ^.size.eq 1
+    u8 ^
     cant-convert
       "Can't convert non 1 length bytes to u8, bytes are %x".printf
-        * b
-  ^ > b
+        * ^
 
   2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
 

--- a/objects/bytes/hash.eo
+++ b/objects/bytes/hash.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/bytes/left.eo
+++ b/objects/bytes/left.eo
@@ -1,15 +1,20 @@
 # Left bit shift of the byte chain `b` by `x` bits, expressed as a
-# right shift by the negated amount.
+# right shift by the negated amount. The smallest count has no negation
+# that fits into an `int`, and a shift by that many bits leaves nothing
+# of any chain, so it is answered by the largest right shift instead.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > left
-  ^.right x.neg > @
+  if. > @
+    x.eq -2147483648
+    ^.right 2147483647
+    ^.right x.neg
 
   eq. ++> can-shift-left-an-even-negative
     FF-FF-FF-FF-FF-FF-FF-EE.left 2
@@ -26,6 +31,10 @@
   eq. ++> can-shift-left-an-odd-positive
     5.as-bytes.left 3
     00-A0-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-by-the-smallest-count
+    -1.as-bytes.left -2147483648
+    00-00-00-00-00-00-00-00
 
   eq. ++> can-shift-left-by-zero
     2.as-bytes.left 0

--- a/objects/bytes/xor.eo
+++ b/objects/bytes/xor.eo
@@ -1,18 +1,26 @@
-# Bitwise exclusive OR of the byte chain `bts` with another chain `b`,
+# Bitwise exclusive OR of the byte chain with another chain `x`,
 # derived from the `and`, `or`, and `not` atoms.
+#
+# The lengths are compared here first, ahead of the derivation, because
+# `and` requires operands of the same length and would otherwise report a
+# mismatched `xor` under the name of an atom the caller never called.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package bytes
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > xor
-  or. > @
-    b.and x.not
-    b.not.and x
-  ^ > b
+  if. > @
+    ^.size.eq x.size
+    or.
+      ^.and x.not
+      ^.not.and x
+    T
+      "bytes.xor requires operands of the same length, got %d and %d".printf
+        * ^.size x.size
 
   eq. ++> can-xor-negative-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00

--- a/objects/chunk.eo
+++ b/objects/chunk.eo
@@ -21,9 +21,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/chunk/to-output.eo
+++ b/objects/chunk/to-output.eo
@@ -1,5 +1,5 @@
-# Makes an output from a `chunk` of memory. It is a method of `chunk`, and
-# `allocated` is the chunk it is taken off:
+# Makes an output from a `chunk` of memory. It is a method of `chunk`,
+# taken off the chunk it writes into:
 #
 # ```
 # malloc.of > result
@@ -15,12 +15,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package chunk
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > to-output
-  ^ > allocated
   [^ buffer] > write
     write. > @
       [^ offset] >> output-block
@@ -29,13 +28,13 @@
           if.
             gt.
               ^.offset.plus buffer.size
-              ^.^.^.allocated.size
+              ^.^.^.^.size
             write.
-              ^.^.^.allocated.resized
+              ^.^.^.^.resized
                 ^.offset.plus buffer.size
               ^.offset
               buffer
-            ^.^.^.allocated.write ^.offset buffer
+            ^.^.^.^.write ^.offset buffer
           ^.^.output-block
             ^.offset.plus buffer.size
       | 0

--- a/objects/clock.eo
+++ b/objects/clock.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/console.eo
+++ b/objects/console.eo
@@ -35,10 +35,12 @@
 # prints it to the operating system console and returns the next output block
 # ready to `write` again.
 #
-# Console operations are platform-specific, with different implementations
-# for POSIX and Windows systems. Each access to the `console` object creates
-# a new console instance, so reusing returned input/output blocks improves
-# performance by maintaining the same console session:
+# One implementation does the reading and the writing, and the platform
+# enters it as an adapter carrying the raw syscall object and, for each of
+# the two streams, the name of the call and the descriptor. Each access
+# to the `console` object creates a new console instance, so reusing the
+# returned input/output blocks improves performance by maintaining the
+# same console session:
 #
 # Efficient (recommended):
 # ```
@@ -58,14 +60,14 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [] > console
   os.is-windows.if > @
-    [] >>
-      [size] > read
+    [sys] >> impl
+      [^ size] > read
         @. > @
           read.
             [^ buffer] >> input-block
@@ -80,13 +82,13 @@
                   received
                   ^.^.input-block chunk
                 called. > received
-                  win32 *1
-                    "_read"
-                    win32.stdin
+                  ^.^.^.sys.raw *1
+                    ^.^.^.sys.input.name
+                    ^.^.^.sys.input.descriptor
                     size
             | --
             size
-      [buffer] > write
+      [^ buffer] > write
         @. > @
           write.
             [^] >> output-block
@@ -101,9 +103,9 @@
                   code
                   remainder
                 code. > code
-                  win32 *1
-                    "_write"
-                    win32.stdout
+                  ^.^.^.sys.raw *1
+                    ^.^.^.sys.output.name
+                    ^.^.^.sys.output.descriptor
                     buffer
                     buffer.size
                 if. > remainder
@@ -112,54 +114,24 @@
                     buffer.slice code (buffer.size.minus code)
                   ^.^.output-block
             buffer
-    [] >>
-      [size] > read
-        @. > @
-          read.
-            [^ buffer] >> input-block
-              buffer > @
-              [^ size] > read
-                seq * > @
-                  if. >> chunk!
-                    received.code.eq -1
-                    T
-                      "Failed to read from standard input"
-                    received.output
-                  received
-                  ^.^.input-block chunk
-                called. > received
-                  posix *1
-                    "read"
-                    posix.stdin
-                    size
-            | --
-            size
-      [buffer] > write
-        @. > @
-          write.
-            [^] >> output-block
-              true > @
-              [^ buffer] > write
-                seq * > @
-                  if. >>!
-                    code.eq -1
-                    T
-                      "Failed to write to standard output"
-                    ^.^.output-block
-                  code
-                  remainder
-                code. > code
-                  posix *1
-                    "write"
-                    posix.stdout
-                    buffer
-                    buffer.size
-                if. > remainder
-                  code.lt buffer.size
-                  ^.^.output-block.write
-                    buffer.slice code (buffer.size.minus code)
-                  ^.^.output-block
-            buffer
+    |
+      []
+        [] > input
+          win32.stdin > descriptor
+          "_read" > name
+        [] > output
+          win32.stdout > descriptor
+          "_write" > name
+        win32 > raw
+    impl
+      []
+        [] > input
+          posix.stdin > descriptor
+          "read" > name
+        [] > output
+          posix.stdout > descriptor
+          "write" > name
+        posix > raw
 
   ++> can-chain-writes-across-output-blocks
     seq * > @

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -31,9 +31,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/directory.eo
+++ b/objects/directory.eo
@@ -4,9 +4,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/directory/deleted.eo
+++ b/objects/directory/deleted.eo
@@ -1,15 +1,15 @@
 # Recursively deletes a directory and all of its contents. It is a method of
-# `directory`, and `d` is the directory it is taken off. The walk that feeds
-# `entries` reports everything underneath `d` and never `d` itself, so the
-# recursion below empties the directory but leaves it standing. The root is
-# removed by the step after it, once the walk is done and the directory is
-# empty, through `file.deleted`, which reaches for `rmdir` over `unlink`
-# when the path it is given is a directory.
+# `directory`, taken off the directory it deletes. The walk that feeds
+# `entries` reports everything underneath that directory and never the
+# directory itself, so the recursion below empties it but leaves it standing.
+# The root is removed by the step after it, once the walk is done and the
+# directory is empty, through `file.deleted`, which reaches for `rmdir` over
+# `unlink` when the path it is given is a directory.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -22,13 +22,12 @@
         tup.head.deleted
         ^.r tup.tail
     | entries
-    d.as-path.as-file.deleted
-    d
-  ^ > d
+    ^.as-path.as-file.deleted
+    ^
   recovered > [^] > entries
-    ^.d.walk "**"
-    ^.d.exists.if
-      ^.d.walk "**"
+    ^.^.walk "**"
+    ^.^.exists.if
+      ^.^.walk "**"
       *
 
   ++> can-delete-a-directory-containing-a-dangling-symlink

--- a/objects/directory/made.eo
+++ b/objects/directory/made.eo
@@ -1,5 +1,5 @@
 # Creates a directory, making missing parent directories as needed. It is a
-# method of `directory`, and `d` is the directory it is taken off. When the
+# method of `directory`, taken off the directory it creates. When the
 # path already exists, it must already be a directory: if a regular file (or
 # any non-directory entry) occupies the path, the computation terminates
 # instead of returning that entry decorated as a directory.
@@ -12,41 +12,40 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > made
-  d.exists.if > @
-    d.is-directory.if
-      d
+  ^.exists.if > @
+    ^.is-directory.if
+      ^
       T
         "Cant make the directory '%s': a file already occupies that path".printf
-          * d.path
+          * ^.path
     seq *
       made.
         directory
-          file d.as-path.dirname
+          file ^.as-path.dirname
       if.
         or.
           created.code.eq 0
           and.
             errno.eq eexist
-            d.is-directory
-        d
+            ^.is-directory
+        ^
         T
           "Cant make the directory '%s': %s".printf
-            * d.path created.output
+            * ^.path created.output
   called. > created
     os.is-windows.if
       win32 *1
         "_mkdir"
-        d.path
+        ^.path
       posix *1
         "mkdir"
-        d.path
+        ^.path
         posix.permissions
-  ^ > d
   os.is-windows.if > eexist
     win32.eexist
     posix.eexist

--- a/objects/directory/open.eo
+++ b/objects/directory/open.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package directory
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/e.eo
+++ b/objects/e.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/eol.eo
+++ b/objects/eol.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/file.eo
+++ b/objects/file.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -67,11 +67,11 @@
   [^ mode scope cant-open] > open
     known.not.if > @
       T
-        "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+        "Wrong access mode. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
         existing.and ^.exists.not
         cant-open
-          "File must exist for given access mod: '%s'".printf
+          "File must exist for given access mode: '%s'".printf
             *
               mode >> access!
         seq *
@@ -353,12 +353,39 @@
       I
       "recovered" > [reason]
 
+  eq. ++> can-represent-a-file-as-a-path
+    as-path.
+      file "abc"
+    "abc"
+
   ++> can-resolve-a-path-and-touch-it
     resolved.as-dir.made.tmpfile.exists.and > @
       resolved.contains
         Q.path.separator.joined
           * "foo" "bar"
     mktemp.as-path.resolved "foo/bar" > resolved
+
+  eq. ++> can-shrink-a-file-when-reopened-with-w-plus-mode
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [^ f]
+        "w+"
+        f.write "Hi" > [^ f]
+    2
+
+  ++> can-tell-that-a-dangling-symbolic-link-exists
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d.resolved "absent"
+            link
+        link.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "dangling-symlink" > link
 
   ++> can-tell-that-a-directory-beside-a-symbolic-link-is-not-one
     os.is-windows.or > @
@@ -371,6 +398,8 @@
         not.
           d.as-file.is-symlink true
     mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+
+  mktemp.tmpfile.is-directory.not ++> can-tell-that-a-regular-file-is-not-a-directory
 
   not. ++> can-tell-that-a-regular-file-is-not-a-symbolic-link
     mktemp.tmpfile.is-symlink true
@@ -390,6 +419,8 @@
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.
       file "absent.txt"
+
+  mktemp.tmpfile.exists ++> can-tell-that-an-existing-file-exists
 
   is-directory. ++> can-tell-that-the-current-directory-is-a-directory
     file "."
@@ -433,6 +464,24 @@
         "w+"
         true > [f]
     0
+
+  ++> can-write-and-read-a-file-opened-with-r-plus-mode
+    eq. > @
+      malloc.of
+        5
+        [^ m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [^ f]
+              "r+"
+              ^.m.put > [^ f] >>
+                seq *
+                  f.write "HELLO"
+                  f.read 5
+            m
+      ", wor"
 
   eq. ++> can-write-data-to-a-file
     size.

--- a/objects/file/deleted.eo
+++ b/objects/file/deleted.eo
@@ -1,37 +1,36 @@
 # Deletes a file from the filesystem, returning the same file, unchanged, if it
-# does not exist. It is a method of `file`, and `f` is the file it is taken off.
+# does not exist. It is a method of `file`, taken off the file it deletes.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package file
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > deleted
-  f.exists.if > @
+  ^.exists.if > @
     if.
       or.
         removed.code.eq 0
-        f.exists.not
-      f
+        ^.exists.not
+      ^
       T
         "Cant delete the file '%s': %s".printf
-          * f.path removed.output
-    f
-  ^ > f
+          * ^.path removed.output
+    ^
   called. > removed
     os.is-windows.if
       win32 *1
-        f.is-symlink.if
+        ^.is-symlink.if
           "_unlink"
-          f.is-directory.if "_rmdir" "_unlink"
-        f.path
+          ^.is-directory.if "_rmdir" "_unlink"
+        ^.path
       posix *1
-        f.is-symlink.if
+        ^.is-symlink.if
           "unlink"
-          f.is-directory.if "rmdir" "unlink"
-        f.path
+          ^.is-directory.if "rmdir" "unlink"
+        ^.path
 
   ++> can-delete-a-dangling-symlink
     os.is-windows.or > @

--- a/objects/file/moved.eo
+++ b/objects/file/moved.eo
@@ -1,10 +1,10 @@
 # Moves a file to `target` on the filesystem, returning the file at its new
-# location. It is a method of `file`, and `f` is the file it is taken off.
+# location. It is a method of `file`, taken off the file it moves.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package file
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,20 +15,28 @@
     T
       "Cant move the file '%s' to '%s': %s".printf
         *
-          f.path
+          ^.path
           target
           renamed.output
-  ^ > f
   called. > renamed
     os.is-windows.if
       win32 *1
         "rename"
-        f.path
+        ^.path
         target
       posix *1
         "rename"
-        f.path
+        ^.path
         target
+
+  ++> can-move-a-directory
+    and. > @
+      exists.
+        d.as-file.moved
+          "%s.dest".printf
+            * d
+      d.as-file.exists.not
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
 
   ++> can-move-a-file
     and. > @
@@ -38,3 +46,53 @@
             * temp.path
       temp.exists.not
     mktemp.tmpfile > temp
+
+  ++> can-overwrite-an-existing-destination-on-moving
+    os.is-windows.or > @
+      seq *
+        source.open
+          "w"
+          f.write "first" > [f]
+        target.open
+          "w"
+          f.write "second" > [f]
+        source.moved dest
+        "first".eq
+          malloc.of
+            5
+            [^ m] >>
+              seq * > @
+                open.
+                  file ^.dest
+                  "r"
+                  ^.m.put > [^ f] >>
+                    f.read 5
+                m
+    target.path > dest
+    mktemp.tmpfile > source
+    mktemp.tmpfile > target
+
+  ++> can-preserve-content-after-moving
+    seq * > @
+      temp.open
+        "w"
+        f.write > [f]
+          "Hello, world"
+      temp.moved dest
+      "Hello, world".eq
+        malloc.of
+          12
+          [^ m] >>
+            seq * > @
+              open.
+                file ^.dest
+                "r"
+                ^.m.put > [^ f] >>
+                  f.read 12
+              m
+    "%s.dest".printf > dest
+      * temp.path
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.moved --> stops-on-moving-an-absent-file
+    "irrelevant-target"

--- a/objects/file/size.eo
+++ b/objects/file/size.eo
@@ -1,10 +1,10 @@
 # Size of a file in bytes, or `cant-measure` if the file does not exist. It is
-# a method of `file`, and `f` is the file it is taken off.
+# a method of `file`, taken off the file it measures.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package file
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -13,15 +13,67 @@
     info.code.eq 0
     info.output.size
     cant-measure
-  ^ > f
   called. > info
     os.is-windows.if
       win32 *1
         "_stat64"
-        f.path
+        ^.path
       posix *1
         "stat"
-        f.path
+        ^.path
+
+  eq. ++> can-ignore-the-fallback-when-a-file-exists
+    0
+    mktemp.tmpfile.touched.size -1
+
+  ++> can-measure-a-directory-without-falling-back
+    not. > @
+      eq.
+        d.as-file.size -1
+        -1
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+
+  eq. ++> can-measure-a-file-after-appending-more-data
+    12
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello" > [^ f]
+        "a"
+        f.write > [^ f]
+          ", world"
+
+  eq. ++> can-measure-a-file-after-truncating-it
+    0
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [^ f]
+        "w"
+        true > [^ f]
+
+  eq. ++> can-measure-a-file-with-content
+    12
+    size.
+      mktemp.tmpfile.open
+        "w"
+        f.write > [^ f]
+          "Hello, world"
+
+  ++> can-measure-a-symbolic-link-by-its-target-size
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.size.eq target.as-file.size
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "link-to-file" > link
+    mktemp.tmpfile.touched.as-path > target
 
   mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
     0

--- a/objects/file/touched.eo
+++ b/objects/file/touched.eo
@@ -1,6 +1,6 @@
 # Touches a file, creating it if it does not exist yet, and returning the same
-# file, unchanged, if it already does. It is a method of `file`, and `f` is the
-# file it is taken off. `f.exists` counts any symbolic link, dangling or not,
+# file, unchanged, if it already does. It is a method of `file`, taken off the
+# file it touches. `file.exists` counts any symbolic link, dangling or not,
 # as existing, so this checks reachability directly instead: an ordinary
 # absent path or a dangling symlink both get created. On POSIX, opening a
 # symlink is done without the exclusive flag, since POSIX defines
@@ -8,23 +8,23 @@
 # whether or not its target exists; the exclusivity that guards the
 # plain-file race stays for every other path, and win32 keeps its exclusive
 # open unconditionally, since its reparse points do not share that rule.
-#
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package file
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > touched
   reachable.if > @
-    f
+    ^
     if.
       or.
         descriptor.gte 0
-        linked.not.and
+        and.
           errno.eq eexist
+          linked.not
       seq *
         if.
           descriptor.gte 0
@@ -37,19 +37,19 @@
                 "close"
                 descriptor
           0
-        f
+        ^
       T
         "Cant touch the file '%s': %s".printf
-          * f.path opened.output
+          * ^.path opened.output
   code. > accessible
     os.is-windows.if
       win32 *1
         "_access"
-        f.path
+        ^.path
         0
       posix *1
         "access"
-        f.path
+        ^.path
         0
   opened.code > descriptor
   os.is-windows.if > eexist
@@ -66,30 +66,95 @@
   linked.not.if > exclusive
     posix.exclusive
     0
-  ^ > f
-  f.is-symlink false > linked
+  ^.is-symlink false > linked
   called. > opened
     os.is-windows.if
       win32 *1
         "_open"
-        f.path
+        ^.path
         plus.
           win32.creat.plus win32.exclusive
           win32.wronly
         win32.mode
       posix *1
         "open"
-        f.path
+        ^.path
         plus.
           posix.creat.plus exclusive
           posix.wronly
         posix.mode
   accessible.eq 0 > reachable
 
+  ++> can-keep-the-symlink-path-after-touching-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.touched.path.eq link
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "broken-link-2" > link
+    d.resolved "missing-target-2" > target
+
+  eq. ++> can-preserve-content-of-an-existing-file-when-touched
+    13
+    size.
+      touched.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world!" > [^ f]
+
   ++> can-return-itself-after-touching
     temp.deleted.touched.path.eq temp.path > @
     mktemp.tmpfile > temp
 
+  ++> can-touch-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.touched.exists.and target.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "broken-link" > link
+    d.resolved "missing-target" > target
+
   mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
 
   mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
+
+  ++> can-touch-a-file-with-a-long-name
+    target.as-file.touched.exists > @
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    "a".repeated 200 > name
+    d.resolved name > target
+
+  ++> can-touch-a-file-with-a-unicode-name
+    target.as-file.touched.exists > @
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "файл-тест.txt" > target
+
+  ++> can-touch-a-non-dangling-symlink-without-truncating-its-target
+    os.is-windows.or > @
+      seq *
+        target.as-file.open
+          "w"
+          f.write "seed-content" > [^ f]
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.touched.exists.and
+          link.as-file.size.eq 12
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "existing-link" > link
+    d.resolved "target.txt" > target
+
+  touched. --> stops-on-touching-a-file-in-a-missing-directory
+    as-file.
+      mktemp.tmpfile.deleted.as-path.resolved "missing-dir/file"

--- a/objects/getenv.eo
+++ b/objects/getenv.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -10,7 +10,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/i64/div.eo
+++ b/objects/i64/div.eo
@@ -1,12 +1,14 @@
-# Integer division of the `i64` number `n` by the `i64` number `x`, truncated
+# Integer division of an `i64` number by the `i64` number `x`, truncated
 # toward zero. The quotient is built by restoring long division over the
 # magnitudes of both operands, with the sign applied afterwards. When `x` is
-# zero, the caller-supplied `cant-divide` fallback is returned.
+# zero, the caller-supplied `cant-divide` fallback is returned, and so it is
+# when the smallest `i64` is divided by minus one, since that quotient is one
+# past the largest `i64` and has no answer here.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package i64
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -16,18 +18,12 @@
     cant-divide
       "i64 cannot be divided by zero"
     if.
-      eq.
-        and.
-          n.as-bytes.xor x.as-bytes
-          80-00-00-00-00-00-00-00
-        80-00-00-00-00-00-00-00
-      as-bytes.
-        plus.
-          i64
-            not.
-              looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
-          i64 00-00-00-00-00-00-00-01
-      i64 quotient
+      and.
+        ^.as-bytes.eq 80-00-00-00-00-00-00-00
+        x.as-bytes.eq FF-FF-FF-FF-FF-FF-FF-FF
+      cant-divide
+        "the smallest i64 divided by minus one is past the largest i64"
+      quotiented
   00-00-00-00-00-00-00-01.left i > [i] >> bit
   [^ index remainder quot] >> looped
     if. > @
@@ -57,11 +53,23 @@
             remainder.left 1
             and.
               right.
-                magnitude ^.n.as-bytes
+                magnitude ^.^.as-bytes
                 index
               00-00-00-00-00-00-00-01
           quot
-  ^ > n
+  if. > quotiented
+    eq.
+      and.
+        ^.as-bytes.xor x.as-bytes
+        80-00-00-00-00-00-00-00
+      80-00-00-00-00-00-00-00
+    as-bytes.
+      plus.
+        i64
+          not.
+            looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
+        i64 00-00-00-00-00-00-00-01
+    i64 quotient
   as-bytes. >> subtrahend
     plus.
       i64
@@ -112,14 +120,19 @@
       0.as-i64
       "recovered" > [message]
 
+  eq. ++> can-recover-from-min-divided-by-minus-one
+    "recovered"
+    div.
+      i64 80-00-00-00-00-00-00-00
+      -1.as-i64
+      "recovered" > [message]
+
   eq. ++> can-truncate-toward-zero
     -13.as-i64.div 5.as-i64
     -2.as-i64
 
-  eq. ++> can-wrap-min-divided-by-minus-one
-    div.
-      i64 80-00-00-00-00-00-00-00
-      -1.as-i64
-    i64 80-00-00-00-00-00-00-00
-
   2.as-i64.div 0.as-i64 --> stops-on-division-by-zero
+
+  div. --> stops-on-min-divided-by-minus-one
+    i64 80-00-00-00-00-00-00-00
+    -1.as-i64

--- a/objects/i8.eo
+++ b/objects/i8.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input.eo
+++ b/objects/input.eo
@@ -7,7 +7,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/as-bytes.eo
+++ b/objects/input/as-bytes.eo
@@ -1,5 +1,5 @@
 # Reads all bytes from an input and returns them as bytes. It is a method of
-# `input`, and `origin` is the input it is taken off.
+# `input`, taken off the input it reads.
 #
 # Example usage:
 # ```
@@ -11,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -19,9 +19,8 @@
   malloc.of > @
     0
     seq * > [^ m] >>
-      ^.origin.copied m.to-output
+      ^.^.copied m.to-output
       m
-  ^ > origin
 
   ++> can-convert-bytes-to-an-input-and-back
     eq. > @

--- a/objects/input/copied.eo
+++ b/objects/input/copied.eo
@@ -14,7 +14,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/dead.eo
+++ b/objects/input/dead.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/input/length.eo
+++ b/objects/input/length.eo
@@ -1,5 +1,5 @@
 # Reads all the bytes from an input and returns its length. It is a method of
-# `input`, and `origin` is the input it is taken off. Bytes are pulled in
+# `input`, taken off the input it reads. Bytes are pulled in
 # 1 MiB chunks: since each chunk costs one level of recursion, a chunk this
 # large keeps an ordinary multi-megabyte or few-gigabyte input well inside
 # the evaluation stack instead of one recursive call per 4 KiB.
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -23,9 +23,8 @@
       read.
         input.read 1048576
   | > @
-    origin
+    ^
     0
-  ^ > origin
 
   eq. ++> can-read-all-bytes-and-return-the-length
     length.

--- a/objects/input/tee.eo
+++ b/objects/input/tee.eo
@@ -1,6 +1,6 @@
 # Tee input is an input that reads from the input it is taken off, writes to
 # provided `output` and behaves as that same input. It is a method of
-# `input`, and `origin` is the input it is taken off.
+# `input`.
 # To copy bytes input to memory you can do:
 # ```
 # malloc.of > copied
@@ -18,16 +18,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package input
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ output] > tee
-  ^ > origin
   [^ size] > read
     read. > @
       input-block
-        ^.origin
+        ^.^
         ^.output
         --
       size

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -54,9 +54,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/map.eo
+++ b/objects/map.eo
@@ -11,7 +11,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -50,18 +50,14 @@
           if. > @
             tup.length.eq 0
             ^.not-found
-            prev.exists.if
-              prev
-              if.
-                and.
-                  tup.head.hash.eq hash
-                  tup.head.kbts.eq kbts
-                [^] >>
-                  true > exists
-                  ^.^.tup.head.value > [^ cant-get] > get
-                ^.not-found
-          @. > prev
-            ^.rec-key-search tup.tail
+            if.
+              and.
+                tup.head.hash.eq hash
+                tup.head.kbts.eq kbts
+              [^] >>
+                true > exists
+                ^.^.tup.head.value > [^ cant-get] > get
+              ^.rec-key-search tup.tail
         | ^.entries
       hash. >> hash!
         key.as-bytes >> kbts!

--- a/objects/mktemp.eo
+++ b/objects/mktemp.eo
@@ -9,7 +9,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ninf.eo
+++ b/objects/ninf.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -14,7 +14,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -3,9 +3,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/abs.eo
+++ b/objects/number/abs.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/arc-cosine.eo
+++ b/objects/number/arc-cosine.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/arc-sine.eo
+++ b/objects/number/arc-sine.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/as-char.eo
+++ b/objects/number/as-char.eo
@@ -1,12 +1,17 @@
-# Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
-# The receiver must be an integer within the range [0, 255]; any other value
-# (negative, above 255, or fractional) terminates the computation instead of
+# Writes the ASCII `code` (0-127) as its single byte, the inverse of `as-ascii`.
+# The receiver must be an integer within the range [0, 127]; any other value
+# (negative, above 127, or fractional) terminates the computation instead of
 # being silently truncated to its least-significant byte.
+#
+# The range stops at 127 because that is where ASCII stops. A byte from `80-`
+# to `FF-` is never a character on its own in UTF-8, it is a continuation byte
+# or the lead of a sequence, so a string holding one alone is one that
+# `length`, `slice` and `at` all terminate on.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,10 +20,10 @@
     or.
       or.
         0.gt ^
-        ^.gt 255
+        ^.gt 127
       ^.is-integer.not
     T
-      "The receiver of as-char must be an integer within the range [0, 255]"
+      "The receiver of as-char must be an integer within the range [0, 127]"
     ^.as-i64.as-bytes.slice
       7
       1
@@ -51,7 +56,7 @@
     "0"
     string 48.as-char
 
-  256.as-char --> stops-on-a-code-past-the-byte-range
+  128.as-char --> stops-on-a-code-past-the-ascii-range
 
   3.5.as-char --> stops-on-a-fractional-code
 

--- a/objects/number/as-decimal.eo
+++ b/objects/number/as-decimal.eo
@@ -1,35 +1,42 @@
-# Writes the number `n` as signed decimal digits, truncating its fraction
+# Writes the number as signed decimal digits, truncating its fraction
 # towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
 #
 # The digits are peeled off an `i64`, where division by ten is exact, so every
 # magnitude below `2^63` is written exactly, and not only the magnitudes below
 # `2^53` that a double divides without losing a digit.
+#
+# The sign of an exact negative zero is kept, as `as-fixed` and `as-scientific`
+# keep it, so `-0.0` becomes `-0` and not `0`. A negative number whose fraction
+# is truncated away loses its sign, since `-0.5` is written as the `0` it
+# truncates to.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-decimal
-  n.is-finite.not.if > @
+  ^.is-finite.not.if > @
     T
       "Can't write a non-finite number as decimal"
     if.
-      n.eq -9.223372036854776e18
+      ^.eq -9.223372036854776e18
       "-9223372036854775808".as-bytes
       if.
-        n.abs.gte 9.223372036854776e18
+        ^.abs.gte 9.223372036854776e18
         T
           "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"
         if.
-          n.abs.lt 9007199254740992
+          ^.abs.lt 9007199254740992
           if.
-            and.
-              n.lt 0
-              not.
-                truncated.eq 0
+            or.
+              ^.as-bytes.eq 80-00-00-00-00-00-00-00
+              and.
+                ^.lt 0
+                not.
+                  truncated.eq 0
             "-".as-bytes.concat
               [^ m] >> quick
                 if. > @
@@ -47,16 +54,13 @@
               | truncated
             quick truncated
           if.
-            n.lt 0
+            ^.lt 0
             if. > [^ m] >> negative
               m.as-number.eq 0
               digits m
               "-".as-bytes.concat
                 digits m
-            |
-              as-i64.
-                n.times -1
-                T message > [message] >> failure
+            | ((^.times -1).as-i64 I)
             [^ n] >> digits
               if. > @
                 n.lt ^.ten
@@ -66,12 +70,11 @@
                   ^.digits q
                   as-char.
                     plus. (n.minus (q.times ^.ten)).as-number 48
-              n.div ^.ten failure > bits!
+              n.div ^.ten I > bits!
               i64 bits > q
-            | (n.as-i64 failure)
-  ^ > n
-  10.as-i64 failure > ten!
-  n.abs.floor > truncated
+            | (^.as-i64 I)
+  10.as-i64 I > ten!
+  ^.abs.floor > truncated
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"
@@ -80,6 +83,10 @@
   eq. ++> can-drop-the-sign-of-a-negative-truncating-to-zero
     "0"
     string -0.5.as-decimal
+
+  eq. ++> can-keep-the-sign-of-an-exact-negative-zero
+    "-0"
+    string 0.neg.as-decimal
 
   eq. ++> can-truncate-a-negative-fraction
     "-7"

--- a/objects/number/as-fixed.eo
+++ b/objects/number/as-fixed.eo
@@ -1,4 +1,4 @@
-# Writes the number `n` as fixed-point decimal with exactly `places` fraction
+# Writes the number as fixed-point decimal with exactly `places` fraction
 # digits, rounding to the nearest unit in the last place, so that `2.5` with
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
 # If `places` is not a finite non-negative integer below 2^53 (negative,
@@ -22,20 +22,20 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ places cant-print] > as-fixed
   if. > @
-    n.is-finite.not.or
+    ^.is-finite.not.or
       huge.or
         or.
           0.gt places
           places.is-integer.not.or
             places.gt 9007199254740991
     cant-print
-      n.is-finite.not.if
+      ^.is-finite.not.if
         "Can't write a non-finite number as a fixed-point decimal"
         huge.if
           "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
@@ -44,7 +44,7 @@
               * places
             "Can't write a fixed-point decimal with a non-finite number of fraction places"
     if.
-      n.as-bytes.eq 80-00-00-00-00-00-00-00
+      ^.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
         [^ a] >> positive
           if. > @
@@ -73,7 +73,7 @@
           a.floor > whole
         | 0
       if.
-        n.lt 0
+        ^.lt 0
         if. > [^ a] >> signed
           eq.
             floor.
@@ -85,10 +85,9 @@
           positive a
           "-".as-bytes.concat
             positive a
-        | (n.times -1)
-        positive n
-  n.abs.gte 9.223372036854776e18 > huge
-  ^ > n
+        | (^.times -1)
+        positive ^
+  ^.abs.gte 9.223372036854776e18 > huge
   if. > [^ p] >> pow10
     p.eq 0
     1

--- a/objects/number/as-i64.eo
+++ b/objects/number/as-i64.eo
@@ -1,13 +1,13 @@
-# Converts the number `n` to an `i64`, truncating the fractional part toward
-# zero. The exponent and the mantissa are pulled out of the IEEE 754 layout of
-# `n` and the magnitude is shifted into place, with the two's complement taken
-# when `n` is negative. When `n` does not fit into the bounds of an `i64`,
+# Converts the number to an `i64`, truncating the fractional part toward
+# zero. The exponent and the mantissa are pulled out of its IEEE 754 layout
+# and the magnitude is shifted into place, with the two's complement taken
+# when it is negative. When it does not fit into the bounds of an `i64`,
 # the caller-supplied `cant-convert` fallback is returned.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -18,7 +18,7 @@
         as-number. >> exp
           as-i64.
             right.
-              n.as-bytes.and 7F-F0-00-00-00-00-00-00
+              ^.as-bytes.and 7F-F0-00-00-00-00-00-00
               52
         2047
       or.
@@ -28,17 +28,17 @@
           not.
             and.
               eq. >> negative
-                n.as-bytes.and 80-00-00-00-00-00-00-00
+                ^.as-bytes.and 80-00-00-00-00-00-00-00
                 80-00-00-00-00-00-00-00
               eq.
                 or. >> mantissa
-                  n.as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF
+                  ^.as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF
                   00-10-00-00-00-00-00-00
                 00-10-00-00-00-00-00-00
     cant-convert
       "Can't convert number %s to i64 because it's out of i64 bounds".printf
         *
-          string n.as-scientific
+          string ^.as-scientific
     if.
       exp.lt 1023
       00-00-00-00-00-00-00-00.as-i64
@@ -54,7 +54,6 @@
                 exp.minus 1075
               mantissa.right
                 1075.minus exp
-  ^ > n
 
   eq. ++> can-convert-a-fraction-below-one-to-zero
     0.5.as-i64.as-bytes

--- a/objects/number/as-scientific.eo
+++ b/objects/number/as-scientific.eo
@@ -1,6 +1,6 @@
-# Writes the number `n` in scientific notation, as a mantissa with six fraction
-# digits, the letter `e`, and the power of ten that scales the mantissa back to
-# `n`, so that `1.0e19` becomes `1.000000e19`, and `1e-7` becomes
+# Writes the number in scientific notation, as a mantissa with six fraction
+# digits, the letter `e`, and the power of ten that scales the mantissa back,
+# so that `1.0e19` becomes `1.000000e19`, and `1e-7` becomes
 # `1.000000e-7`. A magnitude past the range of a signed 64-bit integer is
 # named this way, since `as-decimal` writes only what it spells out digit by
 # digit, and a non-finite number becomes `nan`, `infinity` or `-infinity`,
@@ -13,16 +13,16 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-scientific
-  n.is-finite.not.if > @
-    n.is-nan.if
+  ^.is-finite.not.if > @
+    ^.is-nan.if
       "nan".as-bytes
       if.
-        n.lt 0
+        ^.lt 0
         "-infinity".as-bytes
         "infinity".as-bytes
     if.
@@ -49,7 +49,6 @@
       10.power
         number raw
     6
-  ^ > n
   carried.as-bool.if > normalized!
     "-1.000000".as-bytes
     "1.000000".as-bytes
@@ -74,16 +73,16 @@
         as-number.
           count.plus 1
   tiny.as-bool.if > scaled
-    n.times boost
-    n
+    ^.times boost
+    ^
   tiny.as-bool.if > shift!
     300
     0
   and. > tiny!
-    n.abs.lt
+    ^.abs.lt
       1.div boost
     not.
-      n.eq 0
+      ^.eq 0
 
   eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
     "1.000000e1"

--- a/objects/number/cosine.eo
+++ b/objects/number/cosine.eo
@@ -1,23 +1,22 @@
-# Cosine of `num` radians as `org.eolang.number`, taken from the sine of the
-# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2). The
-# finite approximation of `pi` used in that shift misses the exact extremum
-# at zero, so zero is special-cased to return the exact unit value.
+# Cosine of the angle in radians as `org.eolang.number`, taken from the sine
+# of the angle advanced by a quarter turn, since cos(x) equals sin(x + pi/2).
+# The finite approximation of `pi` used in that shift misses the exact
+# extremum at zero, so zero is special-cased to return the exact unit value.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > cosine
   if. > @
-    num.eq 0
+    ^.eq 0
     1
     sine.
-      num.plus
+      ^.plus
         pi.div 2
-  ^ > num
 
   lt. ++> can-behave-as-an-even-function
     abs.

--- a/objects/number/degrees.eo
+++ b/objects/number/degrees.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/eq.eo
+++ b/objects/number/eq.eo
@@ -1,4 +1,4 @@
-# TRUE when the number `n` equals `x`, FALSE otherwise. The comparison follows
+# TRUE when the number equals `x`, FALSE otherwise. The comparison follows
 # IEEE 754: a not-a-number value is equal to nothing, not even to itself, while
 # positive and negative zero are equal to each other. Everything else is
 # compared byte by byte, so a value of any other type is simply not equal.
@@ -6,13 +6,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > eq
   if. > @
-    n.is-nan.or
+    ^.is-nan.or
       is-nan.
         number
           x >> xbts!
@@ -26,11 +26,10 @@
             -0.as-bytes >> nzero
         or.
           eq.
-            n.as-bytes >> b!
+            ^.as-bytes >> b!
             pzero
           b.eq nzero
       b.eq xbts
-  ^ > n
 
   eq. ++> can-compare-two-different-number-types
     68.eq "12345678"

--- a/objects/number/exp.eo
+++ b/objects/number/exp.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/floor.eo
+++ b/objects/number/floor.eo
@@ -1,30 +1,29 @@
-# Largest integer not greater than `n`. Non-finite numbers and magnitudes
-# beyond the range of exact integers are returned unchanged.
+# Largest integer not greater than the number. Non-finite numbers and
+# magnitudes beyond the range of exact integers are returned unchanged.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > floor
   if. > @
-    n.as-bytes.eq 80-00-00-00-00-00-00-00
-    n
+    ^.as-bytes.eq 80-00-00-00-00-00-00-00
+    ^
     if.
-      n.is-finite.not.or
+      ^.is-finite.not.or
         or.
-          n.gte 4503599627370496
-          n.lte -4503599627370496
-      n
+          ^.gte 4503599627370496
+          ^.lte -4503599627370496
+      ^
       if.
         gt.
-          n.as-i64.as-number >> trunc
-          n
+          ^.as-i64.as-number >> trunc
+          ^
         trunc.minus 1
-        n.as-i64.as-number
-  ^ > n
+        ^.as-i64.as-number
 
   -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
 

--- a/objects/number/gte.eo
+++ b/objects/number/gte.eo
@@ -1,18 +1,17 @@
-# TRUE when `n` is greater than or equal to `x`.
+# TRUE when the number is greater than or equal to `x`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > gte
   or. > @
-    n.gt
+    ^.gt
       x >> value!
-    n.eq value
-  ^ > n
+    ^.eq value
 
   eq. ++> can-be-greater-than-or-equal-to-a-float-when-positive-infinity
     pinf.gte 42.5

--- a/objects/number/integral.eo
+++ b/objects/number/integral.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/is-finite.eo
+++ b/objects/number/is-finite.eo
@@ -1,24 +1,23 @@
-# TRUE when `n` is a valid eight-byte IEEE-754 value that is neither infinite
-# nor not-a-number. A byte sequence of any other width can never represent a
-# number, so it is not finite: `is-nan` returns FALSE for such widths, which
-# would otherwise let them fall through as finite.
+# TRUE when the number is a valid eight-byte IEEE-754 value that is neither
+# infinite nor not-a-number. A byte sequence of any other width can never
+# represent a number, so it is not finite: `is-nan` returns FALSE for such
+# widths, which would otherwise let them fall through as finite.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-finite
   and. > @
-    n.as-bytes.size.eq 8
-    n.is-nan.not.and
+    ^.as-bytes.size.eq 8
+    ^.is-nan.not.and
       not.
         or.
-          n.as-bytes.eq 7F-F0-00-00-00-00-00-00
-          n.as-bytes.eq FF-F0-00-00-00-00-00-00
-  ^ > n
+          ^.as-bytes.eq 7F-F0-00-00-00-00-00-00
+          ^.as-bytes.eq FF-F0-00-00-00-00-00-00
 
   32.is-finite ++> can-be-finite-when-a-simple-number
 

--- a/objects/number/is-integer.eo
+++ b/objects/number/is-integer.eo
@@ -1,16 +1,15 @@
-# TRUE when `n` is finite and equal to its own floor.
+# TRUE when the number is finite and equal to its own floor.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-integer
-  n.is-finite.and > @
-    n.eq n.floor
-  ^ > n
+  ^.is-finite.and > @
+    ^.eq ^.floor
 
   32.is-integer ++> can-be-an-integer-when-a-whole-number
 

--- a/objects/number/is-nan.eo
+++ b/objects/number/is-nan.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/ln.eo
+++ b/objects/number/ln.eo
@@ -9,7 +9,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/lt.eo
+++ b/objects/number/lt.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/lte.eo
+++ b/objects/number/lte.eo
@@ -1,18 +1,17 @@
-# TRUE when `n` is less than or equal to `x`.
+# TRUE when the number is less than or equal to `x`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > lte
   or. > @
-    n.lt
+    ^.lt
       x >> value!
-    n.eq value
-  ^ > n
+    ^.eq value
 
   eq. ++> can-be-less-than-or-equal-to-a-float-when-negative-infinity
     ninf.lte 42.5

--- a/objects/number/minus.eo
+++ b/objects/number/minus.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/mod.eo
+++ b/objects/number/mod.eo
@@ -1,7 +1,7 @@
 # Calculate MOD.
-# An operation that finds the remainder after dividing `x` by `y`. When `y`
-# is zero, the result is the caller-supplied `cant-mod` fallback, or the
-# terminator when none was provided, which terminates on use. Otherwise
+# An operation that finds the remainder after dividing the number by `y`.
+# When `y` is zero, the result is the caller-supplied `cant-mod` fallback, or
+# the terminator when none was provided, which terminates on use. Otherwise
 # the divisor is doubled until it reaches the dividend and then halved back
 # down, subtracting it from the dividend whenever it fits. Doubling and
 # halving a double are exact, and every subtraction happens while the
@@ -14,7 +14,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -28,13 +28,13 @@
     dividend.is-finite.not.if
       nan
       divisor.is-finite.not.if
-        divisor.is-nan.if nan x
+        divisor.is-nan.if nan ^
         if.
-          x.as-bytes.eq 80-00-00-00-00-00-00-00
-          x
+          ^.as-bytes.eq 80-00-00-00-00-00-00-00
+          ^
           if.
             gte.
-              number x.as-bytes >> dividend
+              number ^.as-bytes >> dividend
               0
             [^] >> abs-mod
               shrink > @
@@ -57,7 +57,6 @@
                     rest.minus chunk
                     rest
             abs-mod.neg
-  ^ > x
 
   eq. ++> can-recover-from-a-modulo-by-zero
     "recovered"

--- a/objects/number/neg.eo
+++ b/objects/number/neg.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/power.eo
+++ b/objects/number/power.eo
@@ -1,13 +1,13 @@
-# Raises `num` to the power of `x` as `org.eolang.number`. A zero exponent gives
-# one, an integer exponent is expanded by exponentiation-by-squaring so integer
-# results stay exact, and a fractional exponent of a positive base is taken as
-# e raised to `x` times the natural logarithm of the base. Zeros, infinities and
-# nan follow the same IEEE rules that Math.pow obeys.
+# Raises the number to the power of `x` as `org.eolang.number`. A zero exponent
+# gives one, an integer exponent is expanded by exponentiation-by-squaring so
+# integer results stay exact, and a fractional exponent of a positive base is
+# taken as e raised to `x` times the natural logarithm of the base. Zeros,
+# infinities and nan follow the same IEEE rules that Math.pow obeys.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -25,11 +25,11 @@
           base.is-finite.if
             if.
               eq.
-                number num.as-bytes >> base
+                number ^.as-bytes >> base
                 0
               if.
                 and.
-                  num.as-bytes.eq 80-00-00-00-00-00-00-00
+                  ^.as-bytes.eq 80-00-00-00-00-00-00-00
                   odd
                 if.
                   expo.gt 0
@@ -110,7 +110,6 @@
                 base.abs.eq 1
                 nan
                 pinf
-  ^ > num
 
   gt. ++> can-avoid-underflow-for-a-negative-exponent-that-overflows-positive
     10.power -315

--- a/objects/number/radians.eo
+++ b/objects/number/radians.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/random.eo
+++ b/objects/number/random.eo
@@ -3,12 +3,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > random
-  seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
+  ^.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
   [clock] > clocked
     random. > @
       as-number.
@@ -41,17 +41,16 @@
                   left.
                     and.
                       as-bytes.
-                        ((seed.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                        ((^.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
                           25214903917.as-i64
                       00-00-00-00-03-FF-FF-FF
                     26
                 as-i64.
-                  (seed.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                  (^.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
                     25214903917.as-i64
               11.as-i64
           00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
-  ^ > seed
 
   not. ++> can-differ-between-two-draws
     eq.

--- a/objects/number/sine.eo
+++ b/objects/number/sine.eo
@@ -10,7 +10,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/number/sqrt.eo
+++ b/objects/number/sqrt.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package number
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/os.eo
+++ b/objects/os.eo
@@ -2,9 +2,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/output.eo
+++ b/objects/output.eo
@@ -6,7 +6,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/output/dead.eo
+++ b/objects/output/dead.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package output
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/path.eo
+++ b/objects/path.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -59,10 +59,12 @@
               if.
                 len.eq 0
                 ^.separator
-                as-bytes.
-                  text.slice
-                    0
-                    text.last-index-of ^.separator >> len!
+                ^.stripped
+                  string
+                    as-bytes.
+                      text.slice
+                        0
+                        text.last-index-of ^.separator >> len!
       tail.index-of ^.separator > first!
       ^.stripped ^.driveless > pth!
       and. > root
@@ -329,6 +331,17 @@
     not.
       is-absolute.
         path.win32 "temp\\var"
+
+  and. ++> can-detect-drive-relative-win32-paths-as-not-absolute
+    not.
+      is-absolute.
+        path.win32 "C:.\\foo"
+    and.
+      not.
+        is-absolute.
+          path.win32 "C:..\\foo"
+      is-absolute.
+        path.win32 "C:\\foo"
 
   path.separator.eq ++> can-determine-the-separator-from-the-os
     os.is-windows.if
@@ -680,10 +693,25 @@
       path ""
     "."
 
+  eq. ++> can-return-the-dirname-collapsing-a-longer-run-of-separators
+    dirname.
+      path.posix "a///b"
+    "a"
+
+  eq. ++> can-return-the-dirname-collapsing-a-run-of-separators
+    dirname.
+      path.posix "a//b"
+    "a"
+
   eq. ++> can-return-the-dirname-ignoring-repeated-trailing-separators
     dirname.
       path.posix "foo//"
     "."
+
+  eq. ++> can-return-the-dirname-keeping-an-earlier-run-of-separators
+    dirname.
+      path.posix "a//b//c"
+    "a//b"
 
   eq. ++> can-return-the-dirname-of-a-directory-path
     dirname.
@@ -743,6 +771,11 @@
     dirname.
       path.win32 "\\\\server\\share\\folder"
     "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-an-absolute-path-with-a-run-of-separators
+    dirname.
+      path.posix "/a//b"
+    "/a"
 
   eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
     dirname.

--- a/objects/pi.eo
+++ b/objects/pi.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/pinf.eo
+++ b/objects/pinf.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/posix.eo
+++ b/objects/posix.eo
@@ -5,9 +5,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/range.eo
+++ b/objects/range.eo
@@ -22,7 +22,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/range/naturals.eo
+++ b/objects/range/naturals.eo
@@ -9,29 +9,28 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package range
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > naturals
   if. > @
     and.
-      r.start.is-integer.and r.end.is-integer
+      ^.start.is-integer.and ^.end.is-integer
       and.
-        r.start.abs.lt safe
-        r.end.abs.lt safe
+        ^.start.abs.lt safe
+        ^.end.abs.lt safe
     range
       [^] >>
-        build ^.r.start > @
+        build ^.^.start > @
         [^ num] > build
           num > @
           ^.build > next
             1.plus @
-      r.end
+      ^.end
     T
       "Range bounds must be integers within the safe unit-step range (|x| < 2^53), but were %f and %f".printf
-        * r.start r.end
-  ^ > r
+        * ^.start ^.end
   2.power 53 > safe
 
   eq. ++> can-build-a-range-of-negatives

--- a/objects/recovered.eo
+++ b/objects/recovered.eo
@@ -5,9 +5,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -13,7 +13,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/set.eo
+++ b/objects/set.eo
@@ -2,7 +2,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/socket.eo
+++ b/objects/socket.eo
@@ -44,7 +44,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -78,16 +78,15 @@
               connected.eq -1
               ^.cant-connect
                 "Couldn't connect to %s:%d on socket #%d because %s".printf
-                  * sock.address sock.port sock.sd sock.sys.message
+                  * ^.^.^.address ^.^.^.port ^.^.^.sd ^.^.^.sys.message
               ^.scope
-                sock.scoped-socket sock.sd
+                ^.^.^.scoped-socket ^.^.^.sd
             code. > connected
-              sock.sys.raw *1
+              ^.^.^.sys.raw *1
                 "connect"
-                sock.sd
-                sock.sockaddr
-                sock.sockaddr.size
-            ^.^.^ > sock
+                ^.^.^.sd
+                ^.^.^.sockaddr
+                ^.^.^.sockaddr.size
           cant-connect
       [^ scope cant-listen] > listen
         ^.safe-socket > @
@@ -96,42 +95,41 @@
               bound.eq -1
               ^.cant-listen
                 "Couldn't bind the socket #%d to %s:%d because %s".printf
-                  * sock.sd sock.address sock.port sock.sys.message
+                  * ^.^.^.sd ^.^.^.address ^.^.^.port ^.^.^.sys.message
               if.
                 listened.eq -1
                 ^.cant-listen
                   "Failed to listen to %s:%d on the socket #%d because %s".printf
-                    * sock.address sock.port sock.sd sock.sys.message
+                    * ^.^.^.address ^.^.^.port ^.^.^.sd ^.^.^.sys.message
                 ^.scope
                   [^] >>
-                    ^.sock.scoped-socket ^.sock.sd > @
+                    ^.^.^.^.scoped-socket ^.^.^.^.sd > @
                     [^ scope cant-accept] > accept
                       if. > @
                         client.eq -1
                         cant-accept
                           "Failed to accept a connection on the socket #%d because %s".printf
-                            * ^.^.sock.sd ^.^.sock.sys.message
-                        ^.^.sock.guarded
-                          scope (^.^.sock.scoped-socket client)
-                          ^.^.sock.closed-socket client
+                            * ^.^.^.^.^.sd ^.^.^.^.^.sys.message
+                        ^.^.^.^.^.guarded
+                          scope (^.^.^.^.^.scoped-socket client)
+                          ^.^.^.^.^.closed-socket client
                       code. > client
-                        ^.^.sock.sys.raw *1
+                        ^.^.^.^.^.sys.raw *1
                           "accept"
-                          ^.^.sock.sd
-                          ^.^.sock.sockaddr
-                          ^.^.sock.sockaddr.size
+                          ^.^.^.^.^.sd
+                          ^.^.^.^.^.sockaddr
+                          ^.^.^.^.^.sockaddr.size
             code. > bound
-              sock.sys.raw *1
+              ^.^.^.sys.raw *1
                 "bind"
-                sock.sd
-                sock.sockaddr
-                sock.sockaddr.size
+                ^.^.^.sd
+                ^.^.^.sockaddr
+                ^.^.^.sockaddr.size
             code. > listened
-              sock.sys.raw *1
+              ^.^.^.sys.raw *1
                 "listen"
-                sock.sd
+                ^.^.^.sd
                 2048
-            ^.^.^ > sock
           cant-listen
       [^ scope cant] > safe-socket
         if. > @

--- a/objects/stderr.eo
+++ b/objects/stderr.eo
@@ -8,13 +8,13 @@
 # ```
 #
 # Here the "Something went wrong!" string is printed to the operating
-# system standard error stream (file descriptor 2). The object writes to
-# the console in a platform-specific way, with different implementations
-# for POSIX and Windows systems.
+# system standard error stream (file descriptor 2). One output block does
+# the writing, and the platform enters it as an adapter carrying the raw
+# syscall object, the name of the call and the descriptor to write to.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -22,8 +22,8 @@
   seq * > @
     write.
       os.is-windows.if
-        [] >>
-          [buffer] > write
+        [sys] >> impl
+          [^ buffer] > write
             @. > @
               output-block.write buffer
             [^] > output-block
@@ -38,9 +38,9 @@
                   code
                   remainder
                 code. > code
-                  win32 *1
-                    "_write"
-                    win32.stderr
+                  ^.^.^.sys.raw *1
+                    ^.^.^.sys.name
+                    ^.^.^.sys.descriptor
                     buffer
                     buffer.size
                 if. > remainder
@@ -48,32 +48,16 @@
                   ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
                   ^.^.output-block
-        [] >>
-          [buffer] > write
-            @. > @
-              output-block.write buffer
-            [^] > output-block
-              true > @
-              [^ buffer] > write
-                seq * > @
-                  if. >>!
-                    code.eq -1
-                    T
-                      "Failed to write to standard error"
-                    ^.^.output-block
-                  code
-                  remainder
-                code. > code
-                  posix *1
-                    "write"
-                    posix.stderr
-                    buffer
-                    buffer.size
-                if. > remainder
-                  code.lt buffer.size
-                  ^.^.output-block.write
-                    buffer.slice code (buffer.size.minus code)
-                  ^.^.output-block
+        |
+          []
+            win32.stderr > descriptor
+            "_write" > name
+            win32 > raw
+        impl
+          []
+            posix.stderr > descriptor
+            "write" > name
+            posix > raw
       text
     true
 

--- a/objects/stdin.eo
+++ b/objects/stdin.eo
@@ -37,7 +37,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/stdout.eo
+++ b/objects/stdout.eo
@@ -10,7 +10,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -19,7 +19,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string/as-ascii.eo
+++ b/objects/string/as-ascii.eo
@@ -1,27 +1,26 @@
-# Reads the single character `char` as its ASCII numeric value (0-255).
-# The byte of `char` is left-padded with a zero byte into a 16-bit word,
-# read as an integer and then expressed as a number. If `char` is not
-# exactly one byte wide (an empty string, or a multi-byte UTF-8
+# Reads the single character as its ASCII numeric value (0-255).
+# The byte of the character is left-padded with a zero byte into a 16-bit
+# word, read as an integer and then expressed as a number. If the character
+# is not exactly one byte wide (an empty string, or a multi-byte UTF-8
 # character), the `cant-read` fallback is returned, or the terminator
 # when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-read] > as-ascii
   if. > @
-    char.as-bytes.size.eq 1
+    ^.as-bytes.size.eq 1
     as-number.
       as-i16.
-        00-.concat char.as-bytes
+        00-.concat ^.as-bytes
     cant-read
       "Can't read %x as an ASCII code, it is not a single byte".printf
-        * char.as-bytes
-  ^ > char
+        * ^.as-bytes
 
   97.eq "a".as-ascii ++> can-read-the-code-of-a-lowercase-letter
 

--- a/objects/string/as-number.eo
+++ b/objects/string/as-number.eo
@@ -1,7 +1,7 @@
-# Returns the original `text` as `number`.
+# Returns the original string as `number`.
 # If the text is not numeric, the `cant-parse` fallback is returned,
 # or the terminator when unbound.
-# The whole `text` must be the number: `scanf` matches its `%f` pattern
+# The whole string must be the number: `scanf` matches its `%f` pattern
 # unanchored (via `find`), so on its own it would accept any text that
 # merely contains a number-shaped substring, e.g. `"$100"` or `"12.34.56"`.
 # The text is therefore validated against the anchored equivalent of that
@@ -10,19 +10,18 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-parse] > as-number
   if. > @
     not.
-      "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/".regex.compiled.matches text
+      "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/".regex.compiled.matches ^
     cant-parse
       "Can't convert text %s to number".printf
-        * text
-    head. ("%f".scanf text).at.^
-  ^ > text
+        * ^
+    head. ("%f".scanf ^).at.^
 
   1000.eq "1e3".as-number ++> can-convert-exponent-text
 

--- a/objects/string/at.eo
+++ b/objects/string/at.eo
@@ -1,13 +1,13 @@
-# Retrieve symbol by given index as `text`.
-# A negative `index` counts from the end of `text` (`length + index`).
+# Retrieve symbol by given index as `string`.
+# A negative `index` counts from the end of the string (`length + index`).
 # If `index` is not a finite integer (fractional, nan or infinite), or the
-# resolved index is still negative or is >= `text.length`, the `fallback`
-# value is returned, or the terminator when unbound.
+# resolved index is still negative or is >= the string's `length`, the
+# `fallback` value is returned, or the terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -37,12 +37,11 @@
         0.gt index
         gte.
           number index
-          text.length >> len!
+          ^.length >> len!
       fallback
         "Given index %f is out of text bounds".printf
           * i
-      text.slice index 1
-  ^ > text
+      ^.slice index 1
 
   eq. ++> can-format-the-error-message-of-a-fractional-index-in-bounds
     "Index must be an integer, but was 1.500000"

--- a/objects/string/chained.eo
+++ b/objects/string/chained.eo
@@ -1,22 +1,21 @@
-# Returns concatenation of `text` with all `other` strings.
+# Returns concatenation of the string with all `other` strings.
 # Here `others` must be a `tuple` of `strings`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ others] > chained
   if. > @
     0.eq others.length
-    text
+    ^
     string
       others.reduced
-        text.as-bytes
+        ^.as-bytes
         accum.concat str.as-bytes > [accum str]
-  ^ > text
 
   eq. ++> can-chain-with-other-strings
     "Hello, world!"

--- a/objects/string/contains-all.eo
+++ b/objects/string/contains-all.eo
@@ -1,19 +1,18 @@
-# Checks if `text` contains all elements from `substrings`.
+# Checks if the string contains all elements from `substrings`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ substrings] > contains-all
   reduced. > @
     substrings.mapped
-      ^.text.contains x > [^ x] >>
+      ^.^.contains x > [^ x] >>
     true
     x.and a > [a x]
-  ^ > text
 
   contains-all. ++> can-contain-all-of-no-substrings
     "xyz"

--- a/objects/string/contains-any.eo
+++ b/objects/string/contains-any.eo
@@ -1,19 +1,18 @@
-# Checks if `text` contains any element from `substrings`.
+# Checks if the string contains any element from `substrings`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ substrings] > contains-any
   reduced. > @
     substrings.mapped
-      ^.text.contains x > [^ x] >>
+      ^.^.contains x > [^ x] >>
     false
     x.or a > [a x]
-  ^ > text
 
   contains-any. ++> can-contain-any-substring
     "Good morning"

--- a/objects/string/contains.eo
+++ b/objects/string/contains.eo
@@ -1,9 +1,9 @@
-# Checks if `text` contains `substring`.
+# Checks if the string contains `substring`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -17,13 +17,14 @@
       and.
         length.eq size
         eq.
-          text >> txt!
+          ^ >> txt!
           substring >> part!
       [^ index] >> rec-contains
         if. > @
           end.eq index
           includes
-          includes.or
+          includes.if
+            true
             ^.rec-contains (index.plus 1).as-number
         eq. > includes
           txt.slice index size
@@ -32,11 +33,15 @@
   minus. >> end!
     number length
     size
-  ^ > text
 
   contains. ++> can-contain-a-substring
     "Hello, world!"
     "o, wo"
+
+  not. ++> can-tell-a-long-text-does-not-contain-an-absent-substring
+    contains.
+      "x".repeated 500
+      "y"
 
   not. ++> can-tell-it-does-not-contain-an-absent-substring
     "Hello, world!".contains

--- a/objects/string/ends-with.eo
+++ b/objects/string/ends-with.eo
@@ -1,9 +1,9 @@
-# Checks that `text` ends with `substring`.
+# Checks that the string ends with `substring`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,13 +15,12 @@
       txt.size >> length!
     eq.
       slice.
-        text >> txt!
+        ^ >> txt!
         minus.
           number length
           size
         size
       substring >> part!
-  ^ > text
 
   ends-with. ++> can-end-with-a-substring
     "Hello world!"

--- a/objects/string/english.eo
+++ b/objects/string/english.eo
@@ -1,5 +1,5 @@
 # English locale wrapping a `string` and exposing case conversion for it.
-# Being a decorator of its `s` string, an `english` object behaves like the
+# Being a decorator of its string, an `english` object behaves like the
 # string itself (`.length`, `.eq`, `.slice` and so on pass through), while
 # adding `lower` and `upper` that map the ASCII letters `A`-`Z` and `a`-`z`
 # to their counterparts one-to-one. Every other byte, including accented
@@ -13,15 +13,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > english
-  s > @
+  ^ > @
   [^] > lower
     string > @
-      ^.s.as-bytes.array.reduced
+      ^.^.as-bytes.array.reduced
         --
         [^ accum byte] >>
           accum.concat > @
@@ -40,10 +40,9 @@
           as-ascii. > code
             string byte
     "A".as-ascii >> mincode!
-  ^ > s
   [^] > upper
     string > @
-      ^.s.as-bytes.array.reduced
+      ^.^.as-bytes.array.reduced
         --
         [^ accum byte] >>
           accum.concat > @

--- a/objects/string/index-of.eo
+++ b/objects/string/index-of.eo
@@ -1,10 +1,10 @@
-# Returns index of `substring` in `text`.
+# Returns index of `substring` in the string.
 # If no `substring` was found, it returns -1.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -21,7 +21,7 @@
           not.
             eq.
               substring >> part!
-              text >> txt!
+              ^ >> txt!
       found.eq -1
     -1
     length.
@@ -42,7 +42,6 @@
     eq. > includes
       txt.slice idx size
       part
-  ^ > text
 
   eq. ++> can-find-a-present-substring-in-utf-text
     3
@@ -52,6 +51,12 @@
   eq. ++> can-find-no-index-of-a-longer-substring
     -1
     "Hello".index-of "Somebody"
+
+  eq. ++> can-find-no-index-of-an-absent-substring-in-a-long-text
+    -1
+    index-of.
+      "x".repeated 500
+      "y"
 
   eq. ++> can-find-no-index-of-an-absent-substring-in-utf-text
     -1

--- a/objects/string/is-alpha.eo
+++ b/objects/string/is-alpha.eo
@@ -1,16 +1,17 @@
-# Check that all signs in `text` are letters.
+# Check that all signs in the string are letters.
 # Works only for english letters.
+# An empty string is not a letter and is not accepted, since the pattern
+# asks for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-alpha
-  "/^[a-zA-Z]+$/".regex.matches text > @
-  ^ > text
+  "/^[a-zA-Z]+$/".regex.matches ^ > @
 
   "eEo".is-alpha ++> can-be-alphabetic-when-simple-text
 

--- a/objects/string/is-alphanumeric.eo
+++ b/objects/string/is-alphanumeric.eo
@@ -1,16 +1,17 @@
-# Check that all signs in `text` are numbers or letters.
+# Check that all signs in the string are numbers or letters.
 # Works only for english letters.
+# An empty string is neither and is not accepted, since the pattern asks
+# for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-alphanumeric
-  "/^[A-Za-z0-9]+$/".regex.matches text > @
-  ^ > text
+  "/^[A-Za-z0-9]+$/".regex.matches ^ > @
 
   "eEo".is-alphanumeric ++> can-be-alphanumeric-when-simple-text
 

--- a/objects/string/is-ascii.eo
+++ b/objects/string/is-ascii.eo
@@ -1,15 +1,16 @@
-# Check that all signs in `text` are ASCII characters.
+# Check that all signs in the string are ASCII characters.
+# An empty string is not accepted, since the pattern asks for one sign at
+# least, which is what its three siblings answer for the empty text too.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-ascii
-  "/^[\\x00-\\x7F]+$/".regex.matches text > @
-  ^ > text
+  "/^[\\x00-\\x7F]+$/".regex.matches ^ > @
 
   "123".is-ascii ++> can-be-ascii-when-digits
 

--- a/objects/string/is-digit.eo
+++ b/objects/string/is-digit.eo
@@ -1,16 +1,17 @@
-# Check that all signs in `text` are decimal digits.
+# Check that all signs in the string are decimal digits.
 # Works only for english digits.
+# An empty string is not a digit and is not accepted, since the pattern
+# asks for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > is-digit
-  "/^[0-9]+$/".regex.matches text > @
-  ^ > text
+  "/^[0-9]+$/".regex.matches ^ > @
 
   "2026".is-digit ++> can-be-digits-when-a-number
 

--- a/objects/string/joined.eo
+++ b/objects/string/joined.eo
@@ -1,10 +1,10 @@
-# Joins `items`, which is a `tuple` of strings, using current `text`
+# Joins `items`, which is a `tuple` of strings, using the string itself
 # as a delimiter.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -19,11 +19,10 @@
           acc
           ^.with-delimiter
             concat.
-              concat. (dataized tup.head) ^.text!
+              concat. (dataized tup.head) ^.^!
               acc
             tup.tail
       | items.head items.tail
-  ^ > text
 
   matches. ++> can-apply-regex-to-a-joined-string
     compiled.

--- a/objects/string/last-index-of.eo
+++ b/objects/string/last-index-of.eo
@@ -1,10 +1,10 @@
-# Returns last index of `substring` in `text`.
+# Returns last index of `substring` in the string.
 # If no element was found, it returns -1.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -21,7 +21,7 @@
           not.
             eq.
               substring >> part!
-              text >> txt!
+              ^ >> txt!
       found.eq -1
     -1
     length.
@@ -42,7 +42,6 @@
     eq. > includes
       txt.slice idx size
       part
-  ^ > text
 
   eq. ++> can-find-no-last-index-of-an-absent-substring
     -1

--- a/objects/string/length.eo
+++ b/objects/string/length.eo
@@ -1,4 +1,4 @@
-# Counts the characters in the `text`, and not its bytes. The UTF-8 sequence
+# Counts the characters in the string, and not its bytes. The UTF-8 sequence
 # is walked character by character, so a multi-byte character counts as one.
 # Every multi-byte sequence is validated against the UTF-8 rules of the
 # Unicode standard (Table 3-7): the leading byte fixes the character width and
@@ -13,14 +13,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > length
   if. > @
     eq.
-      text.as-bytes.size >> size!
+      ^.as-bytes.size >> size!
       0
     0
     [^ index accum] >> reclen
@@ -56,7 +56,7 @@
                 T
                   "Unknown byte format (%x), can't recognize character".printf
                     * lead
-      ^.text.as-bytes.slice > b1
+      ^.^.as-bytes.slice > b1
         index.plus 1
         1
       eq. > b1808f
@@ -78,13 +78,13 @@
       eq. > b1cont
         b1.and C0-
         80-
-      ^.text.as-bytes.slice > b2
+      ^.^.as-bytes.slice > b2
         index.plus 2
         1
       eq. > b2cont
         b2.and C0-
         80-
-      ^.text.as-bytes.slice > b3
+      ^.^.as-bytes.slice > b3
         index.plus 3
         1
       eq. > b3cont
@@ -92,7 +92,7 @@
         80-
       b2cont.and > fourvalid
         b3cont.and second4
-      ^.text.as-bytes.slice index 1 > lead
+      ^.^.as-bytes.slice index 1 > lead
       eq. > leadc0c1
         lead.and FE-
         C0-
@@ -125,7 +125,7 @@
         *
           csize
           idx
-          ^.text.as-bytes
+          ^.^.as-bytes
     valid.if
       reclen
         idx.plus csize
@@ -133,9 +133,8 @@
       T
         "Malformed UTF-8 sequence (%x) at %d index".printf
           *
-            ^.text.as-bytes.slice idx csize
+            ^.^.as-bytes.slice idx csize
             idx
-  ^ > text
 
   eq. ++> can-count-a-text-of-spaces-only
     " ".length

--- a/objects/string/lower.eo
+++ b/objects/string/lower.eo
@@ -1,4 +1,4 @@
-# Returns the `text` in lower case, using the default English casing rules.
+# Returns the string in lower case, using the default English casing rules.
 # This is a thin string method: `"HELLO".lower` is the same as
 # `(string.english "HELLO").lower`. Only the ASCII letters `A`-`Z` are
 # folded; every other byte, including accented Latin, Cyrillic and Greek
@@ -9,13 +9,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > lower
-  text.english.lower > @
-  ^ > text
+  ^.english.lower > @
 
   "äöü".eq "äöü".lower ++> can-keep-non-ascii-letters-when-lower-casing
 

--- a/objects/string/nsplit.eo
+++ b/objects/string/nsplit.eo
@@ -1,4 +1,5 @@
-# Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
+# Returns a `tuple` of `strings`: the string is split by `delimiter` with a
+# maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
 # If `delimiter` is empty, or `limit` is not a finite integer of at least 1
 # (fractional, nan, infinite, zero or negative), the `cant-split` fallback is
@@ -7,7 +8,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -32,17 +33,17 @@
               string limit.as-scientific
     if.
       1.eq limit
-      * text
+      * ^
       [^ accum start current count] >> rec-nsplit
         if. > @
-          ^.text.size.eq current
+          ^.^.size.eq current
           appended
           if.
             or.
               size.eq 0
               gt.
                 current.plus size
-                ^.text.size
+                ^.^.size
             ^.rec-nsplit
               accum
               start
@@ -80,8 +81,7 @@
         0
         0
         0
-  text.as-bytes >> bts!
-  ^ > text
+  ^.as-bytes >> bts!
 
   eq. ++> can-format-the-error-message-of-a-fractional-limit
     "Invalid limit 1.500000 for nsplit, must be at least 1"

--- a/objects/string/padded-left.eo
+++ b/objects/string/padded-left.eo
@@ -1,7 +1,7 @@
-# Returns `text` padded on the left with `fill` until it counts `width`
+# Returns the string padded on the left with `fill` until it counts `width`
 # characters, so that `42` padded to five characters with a space
 # becomes `   42`. Characters are counted, and not bytes, so a multi-byte
-# character widens the text by one. A `text` of `width` characters
+# character widens the text by one. A string of `width` characters
 # or longer is returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), or `fill` is not a single character, the `cant-pad` fallback
@@ -10,7 +10,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -32,14 +32,13 @@
             fill
     if.
       width.gt
-        text.length >> len!
+        ^.length >> len!
       string
         concat.
           as-bytes.
             fill.repeated (width.minus len).as-number cant-pad
-          text.as-bytes
-      text
-  ^ > text
+          ^.as-bytes
+      ^
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-left
     "  Ж"

--- a/objects/string/padded-right.eo
+++ b/objects/string/padded-right.eo
@@ -1,7 +1,7 @@
-# Returns `text` padded on the right with `fill` until it counts `width`
+# Returns the string padded on the right with `fill` until it counts `width`
 # characters, so that `x` padded to five characters with a space
 # becomes `x    `. Characters are counted, and not bytes, so a multi-byte
-# character widens the text by one. A `text` of `width` characters
+# character widens the text by one. A string of `width` characters
 # or longer is returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), or `fill` is not a single character, the `cant-pad` fallback
@@ -10,7 +10,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -32,13 +32,12 @@
             fill
     if.
       width.gt
-        text.length >> len!
+        ^.length >> len!
       string
-        text.as-bytes.concat
+        ^.as-bytes.concat
           as-bytes.
             fill.repeated (width.minus len).as-number cant-pad
-      text
-  ^ > text
+      ^
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-right
     "Ж  "

--- a/objects/string/padded-zeros.eo
+++ b/objects/string/padded-zeros.eo
@@ -1,7 +1,7 @@
-# Returns `text` padded on the left with zeros until it counts `width`
+# Returns the string padded on the left with zeros until it counts `width`
 # characters, keeping a leading minus sign in front of them, so that `-42`
 # padded to five characters becomes `-0042` and not `00-42`. Characters are
-# counted, and not bytes. A `text` of `width` characters or longer is
+# counted, and not bytes. A string of `width` characters or longer is
 # returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-pad` fallback is returned, or the terminator
@@ -10,7 +10,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -29,14 +29,14 @@
     if.
       and.
         0.lt
-          text.length >> len!
+          ^.length >> len!
         "-".eq
-          text.slice 0 1
+          ^.slice 0 1
       string
         2D-.concat
           as-bytes.
             padded-left.
-              text.slice 1 ((number len).minus 1).as-number
+              ^.slice 1 ((number len).minus 1).as-number
               if.
                 1.gt width
                 0
@@ -44,11 +44,10 @@
                   width.minus 1
               "0"
               cant-pad
-      text.padded-left
+      ^.padded-left
         width
         "0"
         cant-pad
-  ^ > text
 
   eq. ++> can-count-characters-and-not-bytes-when-padding-with-zeros
     "00Ж"

--- a/objects/string/printf.eo
+++ b/objects/string/printf.eo
@@ -39,14 +39,28 @@
 # is printed as that control character instead of being rejected, and `%b`
 # remains the conversion to reach for a boolean.
 #
+# The `%b` conversion refuses an argument whose bytes are neither `00-` nor
+# `01-`, so a text or a number reaching it terminates instead of being
+# printed as `false`. The coin lands the other way up as well: the
+# one-character texts of U+0000 and U+0001 are accepted as booleans, since
+# their bytes are the bytes of `false` and `true`.
+#
 # The `%d` guard names the number it rejects through `as-scientific` and not
 # through `%f`, because every magnitude it rejects is past the range `as-fixed`
 # writes, and a reason rendered with `%f` destroyed itself instead of arriving.
+#
+# The `%f` conversion leaves the `cant-print` fallback of `as-fixed` unbound,
+# so a number it refuses, a non-finite one or a magnitude of 2^63 or larger,
+# terminates with the reason `as-fixed` gives, instead of that reason standing
+# in the text where the number was meant to be. Its tests recover from that
+# termination instead of declaring it with `-->`, because a returned text of
+# more than one byte fails to dataize as a boolean exactly as a termination
+# does, and a `-->` test would pass either way.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -111,7 +125,6 @@
           minus.
             code from
             48
-  T message > [message] >> failure
   if. > [^ i] >> flags-end
     i.gte
       number span
@@ -126,11 +139,10 @@
         as-number.
           i.plus 1
       i
-  ^ > format
   2.power 63 >> limit!
   size. >> span!
     bytes
-      format.as-bytes >> raw!
+      ^.as-bytes >> raw!
   [^ index auto acc] >> spec
     if. > @
       gte.
@@ -138,7 +150,7 @@
         number span
       T
         "The format %s ends with an incomplete specifier, a conversion character is missing".printf
-          * ^.format
+          * ^.^
       if.
         25-.eq conv
         if.
@@ -155,7 +167,7 @@
             acc.concat 25-
           T
             "The escaped %% conversion does not take flags, width or precision".printf
-              * ^.format
+              * ^.^
         walk
           as-number.
             plus.
@@ -179,7 +191,7 @@
           truncated.
             string text
             number ^.precision
-            failure
+            I
           text
       |
         seq *
@@ -211,18 +223,24 @@
             precise.as-bool.if
               number precision
               6
-            failure
           if.
             78-.eq conv
             capped (bytes datum).as-hex
             if.
               62-.eq conv
-              capped
-                arg.as-bool.if "true" "false"
+              if.
+                or.
+                  01-.eq datum
+                  00-.eq datum
+                capped
+                  arg.as-bool.if "true" "false"
+                T
+                  "The argument %x is not a boolean, the %%b conversion takes true or false".printf
+                    * datum
               T
-                "The conversion %x in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
+                "The conversion %s in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
                   *
-                    bytes conv
+                    string conv
     arg.as-bytes > datum!
     flags-end > digits!
       number flags
@@ -242,7 +260,7 @@
       padded-zeros.
         string value
         number width
-        failure
+        I
     positional.as-bool.if > flags!
       as-number.
         plus.
@@ -280,7 +298,7 @@
           string value
           number width
           " "
-          failure
+          I
       zero.as-bool.if
         filled
         as-bytes.
@@ -288,7 +306,7 @@
             string value
             number width
             " "
-            failure
+            I
     and. > positional!
       gt.
         number dollar
@@ -324,7 +342,7 @@
             index.plus 1
       T
         "The positional argument index in the format %s is too large".printf
-          * ^.format
+          * ^.^
       if.
         positional.as-bool.and
           lt.
@@ -361,9 +379,9 @@
                     64-.eq conv
                     66-.eq conv
               T
-                "The zero flag can't be applied to the %x conversion, only to %%d and %%f".printf
+                "The zero flag can't be applied to the %s conversion, only to %%d and %%f".printf
                   *
-                    bytes conv
+                    string conv
               converted
     digits-value > width!
       number digits
@@ -372,6 +390,12 @@
     flagged > zero!
       number flags
       30-
+
+  eq. ++> can-answer-the-length-of-the-formatted-text
+    2
+    length.
+      "%s".printf
+        * "ab"
 
   eq. ++> can-answer-the-size-of-the-formatted-text
     size.
@@ -493,6 +517,14 @@
     "%s %s %2$s is after %1$s".printf
       * "first" "second"
 
+  eq. ++> can-format-the-length-of-another-formatted-text
+    "2"
+    "%d".printf
+      *
+        length.
+          "%s".printf
+            * "ab"
+
   eq. ++> can-ignore-extra-arguments
     "Hey"
     "%s".printf
@@ -546,6 +578,34 @@
     "1.000000"
     "%f".printf
       * 0.9999999
+
+  eq. ++> can-stop-formatting-a-huge-number-as-a-fixed-point
+    "stopped"
+    recovered
+      "%f".printf
+        * 1.0e30
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-non-finite-number-as-a-fixed-point
+    "stopped"
+    recovered
+      "value=%f".printf
+        * nan
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-number-as-a-boolean
+    "stopped"
+    recovered
+      "%b".printf
+        * 0
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-string-as-a-boolean
+    "stopped"
+    recovered
+      "%b".printf
+        * "x"
+      "stopped"
 
   eq. ++> can-truncate-a-negative-float-toward-zero
     "-7"

--- a/objects/string/regex.eo
+++ b/objects/string/regex.eo
@@ -1,11 +1,23 @@
 # Regular expression in Perl format.
-# Here `expression` is a string pattern.
+# The pattern is the string it is taken off.
 # It starts and ends with slash (e.g. "/(your-expression)/"),
 # Also it can be specified by the flag option,
 # e.g.
 # ```
 # (`Q.string.regex "/(word)/i").compiled.matches "WORD"
 # ```
+#
+# There are two entry points and one letter between their names.
+# `matches` answers whether the whole text matches: the block it finds has
+# to start at zero and end at the length of the text, so a pattern that
+# covers only part of it answers `false`.
+# `match` searches instead: it hands back the first block found anywhere in
+# the text, and `next` moves to the one after it.
+# ```
+# (`Q.string.regex "/[a-z]+/").compiled.matches "1abc"  # false
+# (`Q.string.regex "/[a-z]+/").compiled.match "1abc"    # the block "abc"
+# ```
+#
 # Supported flags:
 # /d - Enables Unix lines mode.
 # /i - Enables case-insensitive matching.
@@ -17,9 +29,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -28,28 +40,26 @@
   [] > compile /Q.string.regex.pattern
     ? > ^
     ? > cant-compile /{Q.string}
-  ^ > expression
   [^ serialized] > pattern
     ^.pattern serialized > compiled
     [^ txt] > match
-      [^ position start from to groups] > matched
+      [^ position start from to groups existing] > matched
         groups.length > count
         start.gte 0 > exists
         ^.groups.at index > [^ index] > group
-        $ > matched
+        ^.existing.at index > [^ index] > group-exists
         exists.if > next
           if.
             and.
               from.eq to
               to.eq ^.txt.length
             ^.missing
-            matched.
-              ^.matched-from-index
-                position.plus 1
-                if.
-                  from.eq to
-                  to.plus 1
-                  to
+            ^.matched-from-index
+              position.plus 1
+              if.
+                from.eq to
+                to.plus 1
+                to
           T
             "Matched block does not exist, can't get next"
         exists.if > text
@@ -63,11 +73,15 @@
       [] > missing
         T > count
           "Matched block does not exist, can't get count"
+        T > existing
+          "Matched block does not exist, can't get groups"
         start.gte 0 > exists
         T > from
           "Matched block does not exist, can't get 'from' position"
         T > [index] > group
           "Matched block does not exist, can't get group"
+        T > [index] > group-exists
+          "Matched block does not exist, can't get group-exists"
         T > groups
           "Matched block does not exist, can't get groups"
         T > next
@@ -78,8 +92,7 @@
           "Matched block does not exist, can't get text"
         T > to
           "Matched block does not exist, can't get 'to' position"
-      matched. > next
-        matched-from-index 1 0
+      matched-from-index 1 0 > next
     [^ txt] > matches
       found.exists.and > @
         and.
@@ -96,7 +109,7 @@
       parsed.group 1 > group1!
       parsed.group 2 > group2!
       next. > parsed
-        "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match ^.^.expression
+        "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match ^.^.^
       "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
         * group1 group2
       ^.commented.regex.compile ^.retry-quoted > [^ message] > retry-commented
@@ -117,6 +130,17 @@
     next. > first
       "/./".regex.compiled.match "😀x"
     first.next > second
+
+  ++> can-expose-group-exists-for-a-non-participating-group
+    not. > @
+      first.group-exists 1
+    next. > first
+      "/(x)?y/".regex.compiled.match "y"
+
+  ++> can-expose-group-exists-for-a-participating-group
+    first.group-exists 1 > @
+    next. > first
+      "/(x*)y/".regex.compiled.match "y"
 
   ++> can-expose-groups-on-each-matched-block
     and. > @
@@ -154,6 +178,12 @@
 
   "/[0-9]/\\d+/".regex.compiled.matches "2/75" ++> can-match-an-entire-pattern
 
+  exists. ++> can-match-with-serialized-bytes-of-the-right-type
+    next.
+      match.
+        regex.pattern "/h.llo/".regex.compiled.serialized
+        "hello"
+
   matches. ++> can-match-with-the-case-insensitive-option
     "/(string)/i".regex.compiled
     "StRiNg"
@@ -177,6 +207,14 @@
   matches. ++> can-match-with-the-unix-lines-option
     "/(.+)/d".regex.compiled
     "A\\r\\nB\\rC\\nD"
+
+  eq. ++> can-name-the-construct-and-the-offset-of-an-invalid-pattern
+    "/a**/".regex.compile I
+    "regex syntax is invalid: Dangling meta character '*' at offset 2 of the pattern"
+
+  eq. ++> can-name-the-offset-inside-a-pattern-that-carries-flags
+    "/a**/i".regex.compile I
+    "regex syntax is invalid: Dangling meta character '*' at offset 2 of the pattern"
 
   eq. ++> can-recover-from-a-pattern-with-a-missing-slash
     "no-slash"
@@ -220,6 +258,10 @@
   not. ++> can-stop-at-a-terminal-zero-width-match
     exists. ("/$/".regex.match "x").next.next
 
+  eq. ++> can-tell-an-unclosed-group-from-a-dangling-repetition
+    "/(/".regex.compile I
+    "regex syntax is invalid: Unclosed group at offset 1 of the pattern"
+
   not. ++> can-tell-it-does-not-match-a-text-against-a-wrong-pattern
     "/[a-z]+/".regex.compiled.matches "123"
 
@@ -229,16 +271,22 @@
   not. ++> can-tell-it-does-not-match-with-unmatched-leading-characters
     "/[a-z]+/".regex.compiled.matches "1abc"
 
-  next. --> rejects-serialized-bytes-of-the-wrong-type
-    match.
-      ^.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
-      "hello"
+  exists. --> rejects-serialized-bytes-of-the-wrong-type
+    next.
+      match.
+        regex.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
+        "hello"
 
   "/pattern".regex.compiled --> stops-on-a-missing-closing-slash
 
   "(.)+".regex.compiled --> stops-on-a-missing-first-slash
 
   "/[a-z/".regex.compile --> stops-on-compiling-an-invalid-pattern
+
+  group-exists. --> stops-on-taking-a-group-exists-of-an-unmatched-block
+    next.
+      "/[a-z]+/".regex.match "123"
+    1
 
   group. --> stops-on-taking-a-group-of-a-terminal-zero-width-match
     next.

--- a/objects/string/repeated.eo
+++ b/objects/string/repeated.eo
@@ -1,4 +1,4 @@
-# Returns `text` repeated `times` times.
+# Returns the string repeated `times` times.
 # If `times` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-repeat` fallback is returned,
 # or the terminator when unbound.
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -35,9 +35,8 @@
             concat.
               half.concat >> twice
                 ^.rec-repeated (n.div 2).floor >> half!
-              ^.text.as-bytes
+              ^.^.as-bytes
       | times
-  ^ > text
 
   eq. ++> can-format-the-error-message-of-a-negative-count
     "Can't repeat text -1.000000 times"

--- a/objects/string/replaced.eo
+++ b/objects/string/replaced.eo
@@ -1,4 +1,4 @@
-# Returns `text` where all regex target changed to replacement.
+# Returns the string where all regex target changed to replacement.
 # Here `target` must be a `org.eolang.string.regex` object.
 # The `replacement` here is a `string` that would be pasted instead of
 # matched text in original one.
@@ -6,13 +6,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ target replacement] > replaced
   matched.exists.not.if > @
-    string text! >> reinit
+    string ^! >> reinit
     block.exists.if > [^ block accum start] >> rec-replaced
       ^.rec-replaced
         block.next
@@ -34,7 +34,6 @@
       start.
         next. >> matched
           target.match reinit
-  ^ > text
 
   eq. ++> can-replace-a-nullable-pattern-like-java
     "abc".replaced

--- a/objects/string/scanf.eo
+++ b/objects/string/scanf.eo
@@ -1,12 +1,13 @@
-# Reads formatted input from a string.
-# This object has two free attributes:
-# 1. `format` - is a formatter string (e.g. "Hello, %s!")
-# 2. `read` - is a string where data exists (e.g. "Hello, John!")
-# returns a `org.eolang.tuple` of formatted values (e.g. * "John").
+# Reads formatted input from a string. It is a method of the formatter
+# string (e.g. "Hello, %s!"), with one free attribute `read`, the string
+# where the data exists (e.g. "Hello, John!"). It returns a
+# `org.eolang.tuple` of formatted values (e.g. * "John").
 # Supported formatters are:
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
+# A space in the format matches a run of one or more spaces in the input, so
+# extra spaces between fields never shift or drop the values that follow.
 #
 # The `%f` conversion never materializes the whole power of ten at once,
 # because `10.power 309` is already infinity: a single multiplication by it
@@ -27,12 +28,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ read] > scanf
-  ^ > format
   [^ pattern specifiers] >>
     [^ text] > as-float
       negative.if negated scaled > @
@@ -193,21 +193,19 @@
           text
         "/^0+/".regex
         ""
-    [^ group acc] >> convert
-      ^.matched.exists.not.if > @
-        *
-        if.
-          group.gt ^.specifiers.length
-          acc
-          next
-      ^.convert > next
-        group.plus 1
-        acc.with
-          ^.converted
-            ^.specifiers.at
-              group.minus 1
-              T
-            ^.matched.group group
+    ^.matched.exists.not.if > [^ group acc] >> convert
+      *
+      if.
+        group.gt ^.specifiers.length
+        acc
+        ^.convert
+          group.plus 1
+          acc.with
+            ^.converted
+              ^.specifiers.at
+                group.minus 1
+                T
+              ^.matched.group group
     | > @
       1
       *
@@ -219,12 +217,10 @@
         ^.as-integer text
         ^.as-float text
     [text] > fold-digits
-      [^ index acc] >> rec
-        if. > @
-          index.eq ^.text.length
-          acc
-          next
-        ^.rec > next
+      if. > [^ index acc] >> rec
+        index.eq ^.text.length
+        acc
+        ^.rec
           index.plus 1
           plus.
             acc.times 10
@@ -270,7 +266,7 @@
     ch
   [^ position accumulated found pending] >> tokenize
     if. > @
-      position.gte ^.format.length
+      position.gte ^.^.length
       pending.if *1
         T
           "The format string ends with a dangling percent and no specifier after it"
@@ -317,14 +313,22 @@
             accumulated
             found
             true
-          ^.tokenize
-            position.plus 1
-            accumulated.chained
-              *
-                escaped ch
-            found
-            false
-    ^.format.slice > ch
+          if.
+            ch.eq " "
+            ^.tokenize
+              position.plus 1
+              accumulated.chained
+                * "\\s+"
+              found
+              false
+            ^.tokenize
+              position.plus 1
+              accumulated.chained
+                *
+                  escaped ch
+              found
+              false
+    ^.^.slice > ch
       position
       1
   | >> tokens
@@ -433,6 +437,21 @@
     "hello"
     head.
       "%s!".scanf "hello!"
+
+  eq. ++> can-scan-two-fields-separated-by-extra-spaces
+    "%s %s".scanf
+      "a  b"
+    *
+      "a"
+      "b"
+
+  eq. ++> can-scan-three-fields-separated-by-extra-spaces
+    "%s %s %s".scanf
+      "a  b c"
+    *
+      "a"
+      "b"
+      "c"
 
   eq. ++> can-scan-while-ignoring-trailing-text
     42

--- a/objects/string/slice.eo
+++ b/objects/string/slice.eo
@@ -1,10 +1,10 @@
-# Takes a piece of the `text` as another `text`, counting characters and not
+# Takes a piece of the string as another string, counting characters and not
 # bytes. Here `start` must be a non-negative integer index to start slicing
 # from, while `len` must be a non-negative integer amount of characters to
 # take. A fractional, `nan` or infinite `start` or `len` terminates the
 # computation immediately. Both of them walk the UTF-8 sequence character by
 # character, so a multi-byte character counts as one. An index outside the
-# bounds of the `text` terminates the computation. Every multi-byte sequence is
+# bounds of the string terminates the computation. Every multi-byte sequence is
 # validated against the UTF-8 rules of the Unicode standard (Table 3-7), the
 # same way `length` does: each following byte must be a `10xxxxxx` continuation
 # byte, and the second byte is range-checked so that overlong encodings
@@ -17,7 +17,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -56,7 +56,7 @@
           nlen.eq 0
           ""
           string
-            text.as-bytes.slice bstart blen
+            ^.as-bytes.slice bstart blen
   minus. > blen
     [^ index accum result cause] >> recidx
       if. > @
@@ -102,7 +102,7 @@
                   T
                     "Unknown byte format (%x), can't recognize character".printf
                       * byte
-      ^.text.as-bytes.slice > b1
+      ^.^.as-bytes.slice > b1
         index.plus 1
         1
       eq. > b1808f
@@ -124,19 +124,19 @@
       eq. > b1cont
         b1.and C0-
         80-
-      ^.text.as-bytes.slice > b2
+      ^.^.as-bytes.slice > b2
         index.plus 2
         1
       eq. > b2cont
         b2.and C0-
         80-
-      ^.text.as-bytes.slice > b3
+      ^.^.as-bytes.slice > b3
         index.plus 3
         1
       eq. > b3cont
         b3.and C0-
         80-
-      ^.text.as-bytes.slice index 1 > byte
+      ^.^.as-bytes.slice index 1 > byte
       b2cont.and > fourvalid
         b3cont.and second4
       eq. > leadc0c1
@@ -178,13 +178,13 @@
         *
           csize
           index
-          ^.text.as-bytes
+          ^.^.as-bytes
     valid.if
       index.plus csize
       T
         "Malformed UTF-8 sequence (%x) at %d index".printf
           *
-            ^.text.as-bytes.slice index csize
+            ^.^.as-bytes.slice index csize
             index
   number len! > nlen
   number start! > nstart
@@ -196,8 +196,7 @@
   C0- > r2
   E0- > r3
   F0- > r4
-  text.as-bytes.size >> size!
-  ^ > text
+  ^.as-bytes.size >> size!
 
   eq. ++> can-slice-a-line-break-escape-sequence
     "\n".slice

--- a/objects/string/split.eo
+++ b/objects/string/split.eo
@@ -1,11 +1,11 @@
-# Returns a `tuple` of `strings`: `text` separated by `delimiter`.
+# Returns a `tuple` of `strings`: the string separated by `delimiter`.
 # If `delimiter` is empty, the `cant-split` fallback is returned, or the
 # terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -17,7 +17,7 @@
     if.
       eq.
         size. >> len!
-          text >> bts!
+          ^ >> bts!
         0
       * ""
       [^ accum start current] >> rec-split
@@ -56,7 +56,6 @@
         0
   size. >> size!
     delimiter >> delim!
-  ^ > text
 
   eq. ++> can-recover-from-an-empty-delimiter
     "recovered"

--- a/objects/string/starts-with.eo
+++ b/objects/string/starts-with.eo
@@ -1,9 +1,9 @@
-# Checks that `text` starts with `substring`.
+# Checks that the string starts with `substring`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,11 +15,10 @@
       txt.size >> length!
     eq.
       slice.
-        text >> txt!
+        ^ >> txt!
         0
         size
       substring >> part!
-  ^ > text
 
   starts-with. ++> can-start-with-a-substring
     "Hello, world"

--- a/objects/string/trimmed-left.eo
+++ b/objects/string/trimmed-left.eo
@@ -1,4 +1,4 @@
-# Returns `text` trimmed from left side.
+# Returns the string trimmed from left side.
 # Removes all leading ASCII whitespace bytes: `20-` (space), `09-`
 # (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
 # (form feed), and `0D-` (carriage return). Matches the strip-set
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,10 +15,10 @@
   if. > @
     0.eq
       b.size >> len!
-    text
+    ^
     string
       slice.
-        text >> b!
+        ^ >> b!
         first-non-ws-index 0 >> idx!
         minus.
           number len
@@ -42,7 +42,6 @@
           or.
             c.eq 0C-
             c.eq 0D-
-  ^ > text
 
   "\rvalue".trimmed-left.eq "value" ++> can-trim-a-leading-carriage-return
 

--- a/objects/string/trimmed-right.eo
+++ b/objects/string/trimmed-right.eo
@@ -1,4 +1,4 @@
-# Returns `text` trimmed from right side.
+# Returns the string trimmed from right side.
 # Removes all trailing ASCII whitespace bytes: `20-` (space), `09-`
 # (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
 # (form feed), and `0D-` (carriage return). Matches the strip-set
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,10 +15,10 @@
   if. > @
     0.eq
       b.size >> len!
-    text
+    ^
     string
       slice.
-        text >> b!
+        ^ >> b!
         0
         [^ index] >> first-non-ws-index
           if. > @
@@ -40,7 +40,6 @@
           or.
             c.eq 0C-
             c.eq 0D-
-  ^ > text
 
   eq. ++> can-trim-a-text-of-trailing-spaces-only
     "     ".trimmed-right

--- a/objects/string/trimmed.eo
+++ b/objects/string/trimmed.eo
@@ -1,4 +1,4 @@
-# Returns `text` trimmed from both sides.
+# Returns the string trimmed from both sides.
 # Removes all leading and trailing ASCII whitespace bytes: `20-`
 # (space), `09-` (horizontal tab), `0A-` (line feed), `0B-` (vertical
 # tab), `0C-` (form feed), and `0D-` (carriage return). Delegates to
@@ -8,16 +8,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > trimmed
   if. > @
-    0.eq text.as-bytes.size
-    text
-    text.trimmed-right.trimmed-left
-  ^ > text
+    0.eq ^.as-bytes.size
+    ^
+    ^.trimmed-right.trimmed-left
 
   "no-whitespace".trimmed.eq "no-whitespace" ++> can-preserve-inner-content
 

--- a/objects/string/truncated.eo
+++ b/objects/string/truncated.eo
@@ -1,8 +1,9 @@
-# Returns the first `limit` characters of `text`, so that `Jeffrey` truncated
-# to three characters becomes `Jef`. Characters are counted, and not bytes,
-# so a multi-byte character counts as one. A `text` of `limit` characters
-# or shorter is returned unchanged, which is how this differs from `slice`,
-# where a `limit` beyond the end of the `text` terminates the computation.
+# Returns the first `limit` characters of the string, so that `Jeffrey`
+# truncated to three characters becomes `Jef`. Characters are counted, and
+# not bytes, so a multi-byte character counts as one. A string of `limit`
+# characters or shorter is returned unchanged, which is how this differs
+# from `slice`, where a `limit` beyond the end of the string terminates the
+# computation.
 # If `limit` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-truncate` fallback is returned, or the terminator
 # when unbound.
@@ -10,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -27,10 +28,9 @@
           *
             string limit.as-scientific
     if.
-      limit.lt text.length
-      text.slice 0 limit
-      text
-  ^ > text
+      limit.lt ^.length
+      ^.slice 0 limit
+      ^
 
   eq. ++> can-count-characters-and-not-bytes-when-truncating
     "Жу"

--- a/objects/string/turkish.eo
+++ b/objects/string/turkish.eo
@@ -1,6 +1,6 @@
 # Turkish locale specializing the default `english` casing with the dotted
 # and dotless I mappings that Turkish and Azeri override the default with.
-# Being a decorator of its `s` string, a `turkish` object behaves like the
+# Being a decorator of its string, a `turkish` object behaves like the
 # string itself (`.length`, `.eq` and so on pass through), while adding
 # `lower` and `upper` that honour those mappings. Lower casing maps capital
 # dotless I (U+0049) to small dotless i (U+0131) and capital dotted I
@@ -15,23 +15,22 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > turkish
-  s > @
+  ^ > @
   lower. > [^] > lower
     english.
       replaced.
-        ^.s.replaced "/I/".regex "ı"
+        ^.^.replaced "/I/".regex "ı"
         "/İ/".regex
         "i"
-  ^ > s
   upper. > [^] > upper
     english.
       replaced.
-        ^.s.replaced "/i/".regex "İ"
+        ^.^.replaced "/i/".regex "İ"
         "/ı/".regex
         "I"
 

--- a/objects/string/upper.eo
+++ b/objects/string/upper.eo
@@ -1,4 +1,4 @@
-# Returns the `text` in upper case, using the default English casing rules.
+# Returns the string in upper case, using the default English casing rules.
 # This is a thin string method: `"hello".upper` is the same as
 # `(string.english "hello").upper`. Only the ASCII letters `a`-`z` are
 # folded; every other byte, including accented Latin, Cyrillic and Greek
@@ -9,13 +9,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package string
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^] > upper
-  text.english.upper > @
-  ^ > text
+  ^.english.upper > @
 
   "ÄÖÜ".eq "ÄÖÜ".upper ++> can-keep-non-ascii-letters-when-upper-casing
 

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -20,7 +20,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -29,25 +29,16 @@
     cases.length.eq 0
     fallback
       "Switch cases are empty"
-    if.
-      true.eq
-        match.
-          @. >> found
-            [^ tup] >> rec-case
-              if. > @
-                and.
-                  tup.length.gt 1
-                  previous.match
-                previous
-                [^] >>
-                  ^.tup.head.head > head
-                  ^.tup.head.tail.head > match!
-              @. > previous
-                ^.rec-case tup.tail
-            | cases
-      found.head
-      fallback
-        "No switch case matched"
+    [^ rest] >> rec-case
+      if. > @
+        rest.length.eq 0
+        ^.fallback
+          "No switch case matched"
+        if.
+          true.eq rest.head.tail.head!
+          rest.head.head
+          ^.rec-case rest.tail
+    | cases.reversed
 
   eq. ++> can-recover-from-an-empty-switch
     "recovered"

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -3,7 +3,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -43,9 +43,10 @@
       if. > [^ first second] >> receq
         first.length.eq 0
         true
-        and.
+        if.
           first.head.eq second.head
           ^.receq first.tail second.tail
+          false
       | ^ other
   tuple > [^ x] > with
     ^

--- a/objects/tuple/back.eo
+++ b/objects/tuple/back.eo
@@ -1,10 +1,10 @@
-# Last `index` elements of `list` (an `index` larger than `list.length`
-# returns the whole `list`).
+# Last `index` elements of the tuple (an `index` larger than its `length`
+# returns the whole tuple).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -12,9 +12,9 @@
   index.is-integer.if > @
     if.
       0.gt
-        list.length.minus index! >> start!
-      list
-      list.reducedi
+        ^.length.minus index! >> start!
+      ^
+      ^.reducedi
         *
         if. > [^ accum item idx] >>
           idx.gte start
@@ -22,7 +22,6 @@
           accum
     T
       "Given index must be an integer"
-  ^ > list
 
   eq. ++> can-take-a-back-slice
     back.

--- a/objects/tuple/concat.eo
+++ b/objects/tuple/concat.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/contains.eo
+++ b/objects/tuple/contains.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/each.eo
+++ b/objects/tuple/each.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/eachi.eo
+++ b/objects/tuple/eachi.eo
@@ -7,16 +7,25 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ func] > eachi
-  ^.reducedi > @
+  if. > [^ rest index] >> rec
+    rest.length.eq 0
     true
-    seq * > [^ acc item index] >>
-      acc
-      ^.func item index
+    if.
+      rest.length.eq 1
+      ^.func rest.head index
+      seq *
+        ^.func rest.head index
+        ^.rec
+          rest.tail
+          index.plus 1
+  | > @
+    ^.reversed
+    0
 
   ++> can-iterate-over-a-list-with-indexes
     eq. > @

--- a/objects/tuple/filtered.eo
+++ b/objects/tuple/filtered.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/filteredi.eo
+++ b/objects/tuple/filteredi.eo
@@ -8,21 +8,29 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ func] > filteredi
-  [^ tup] >> recfilter
+  [^ rest acc index] >> recfilter
     if. > @
-      tup.length.eq 0
-      *
-      if.
-        ^.func tup.head tup.tail.length
-        next.with tup.head
-        next
-    ^.recfilter tup.tail > next
-  | ^ > @
+      rest.length.eq 0
+      acc
+      seq *
+        next.length
+        ^.recfilter
+          rest.tail
+          next
+          index.plus 1
+    if. > next
+      ^.func rest.head index
+      acc.with rest.head
+      acc
+  | > @
+    ^.reversed
+    *
+    0
 
   eq. ++> can-filter-by-a-less-than-condition
     filteredi.

--- a/objects/tuple/front.eo
+++ b/objects/tuple/front.eo
@@ -1,9 +1,9 @@
-# Elements of `list` before `index` (supports negative indices).
+# Elements of the tuple before `index` (supports negative indices).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,20 +15,19 @@
       if.
         0.gt
           index >> idx!
-        list.back (number idx).neg
+        ^.back (number idx).neg
         if.
           gte.
             number idx
-            list.length
-          list
+            ^.length
+          ^
           if. > [^ tup] >> rechead
             tup.length.eq idx
             tup
             ^.rechead tup.tail
-          | list
+          | ^
     T
       "Given index must be an integer"
-  ^ > list
 
   eq. ++> can-take-a-front-slice
     front.

--- a/objects/tuple/index-of.eo
+++ b/objects/tuple/index-of.eo
@@ -4,24 +4,25 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ wanted] > index-of
   number > @
-    [^ tup] >> recidx
+    [^ tup found] >> recidx
       if. > @
         tup.length.eq 0
-        -1
+        found
+        seq *
+          found
+          ^.recidx tup.tail next
+      as-number. > next
         if.
-          next.eq -1
-          if.
-            tup.head.eq ^.wanted
-            tup.length.minus 1
-            -1
-          ^.recidx tup.tail >> next!
-    | ^
+          tup.head.eq ^.wanted
+          tup.length.minus 1
+          found
+    | ^ -1
 
   eq. ++> can-find-no-index-of-an-absent-item
     -1

--- a/objects/tuple/is-empty.eo
+++ b/objects/tuple/is-empty.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/last-index-of.eo
+++ b/objects/tuple/last-index-of.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/mapped.eo
+++ b/objects/tuple/mapped.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/mappedi.eo
+++ b/objects/tuple/mappedi.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/maximum.eo
+++ b/objects/tuple/maximum.eo
@@ -1,26 +1,25 @@
-# Maximum `number` in `sequence`, which must be a `tuple` or any `tuple`
+# Maximum `number` in the sequence, which must be a `tuple` or any `tuple`
 # decorator of `number` objects. An empty sequence has no maximum, so `cant-max`
 # is dataized with an explanatory message and stands in as the result.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-max] > maximum
-  sequence.is-empty.if > @
+  ^.is-empty.if > @
     cant-max
       "cannot get the maximum number from an empty sequence"
-    sequence.reduced
+    ^.reduced
       ninf
       if. > [max item]
         item.as-number.is-nan.or
           item.as-number.gt max
         item
         max
-  ^ > sequence
 
   is-nan. ++> can-be-nan-when-taking-the-maximum-of-a-lone-nan
     maximum.

--- a/objects/tuple/minimum.eo
+++ b/objects/tuple/minimum.eo
@@ -1,26 +1,25 @@
-# Minimum `number` in `sequence`, which must be a `tuple` or any `tuple`
+# Minimum `number` in the sequence, which must be a `tuple` or any `tuple`
 # decorator of `number` objects. An empty sequence has no minimum, so `cant-min`
 # is dataized with an explanatory message and stands in as the result.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ cant-min] > minimum
-  sequence.is-empty.if > @
+  ^.is-empty.if > @
     cant-min
       "cannot get the minimum number from an empty sequence"
-    sequence.reduced
+    ^.reduced
       pinf
       if. > [min item]
         item.as-number.is-nan.or
           min.gt item.as-number
         item
         min
-  ^ > sequence
 
   is-nan. ++> can-be-nan-when-taking-the-minimum-of-a-lone-nan
     minimum.

--- a/objects/tuple/reduced.eo
+++ b/objects/tuple/reduced.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/reducedi.eo
+++ b/objects/tuple/reducedi.eo
@@ -6,12 +6,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ start func] > reducedi
-  list.is-empty.if > @
+  ^.is-empty.if > @
     start
     if. > [^ tup] >> rec-reducedi
       tup.length.eq 1
@@ -23,8 +23,7 @@
         ^.rec-reducedi tup.tail
         tup.head
         tup.tail.length
-    | list
-  ^ > list
+    | ^
 
   eq. ++> can-reduce-a-list-with-indexes
     6

--- a/objects/tuple/reversed.eo
+++ b/objects/tuple/reversed.eo
@@ -1,0 +1,34 @@
+# Reverses the order of the items in the tuple.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.63.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > reversed
+  [^ rest acc] >> rec
+    if. > @
+      rest.length.eq 0
+      acc
+      seq *
+        next.length
+        ^.rec rest.tail next
+    acc.with rest.head > next
+  | > @
+    ^
+    *
+
+  eq. ++> can-reverse-a-tuple
+    reversed.
+      *
+        1
+        2
+        3
+    *
+      3
+      2
+      1
+
+  0.eq tuple.empty.reversed.length ++> can-reverse-an-empty-tuple

--- a/objects/tuple/shifted.eo
+++ b/objects/tuple/shifted.eo
@@ -1,23 +1,23 @@
-# Drop the first `shift` elements of `list` (a negative `shift` drops nothing).
+# Drop the first `shift` elements of the tuple (a negative `shift` drops
+# nothing).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 [^ shift] > shifted
   shift.is-integer.if > @
-    list.slice
+    ^.slice
       if.
         shift.lt 0
         0
         shift
-      list.length
+      ^.length
     T
       "Given shift must be an integer"
-  ^ > list
 
   eq. ++> can-ignore-a-negative-shift
     shifted.

--- a/objects/tuple/slice.eo
+++ b/objects/tuple/slice.eo
@@ -1,10 +1,10 @@
-# Sublist of `list` from `start` (inclusive) to `end` (exclusive).
-# Supports negative indices and clamps to list bounds.
+# Sublist of the tuple from `start` (inclusive) to `end` (exclusive).
+# Supports negative indices and clamps to the bounds of the tuple.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -17,25 +17,25 @@
           if. >> s!
             start.gte 0
             if.
-              start.gte list.length
-              list.length
+              start.gte ^.length
+              ^.length
               start
             if.
-              list.length.neg.lte start
-              start.plus list.length
+              ^.length.neg.lte start
+              start.plus ^.length
               0
         if. >> e!
           end.gte 0
           if.
-            end.gte list.length
-            list.length
+            end.gte ^.length
+            ^.length
             end
           if.
-            list.length.neg.lte end
-            end.plus list.length
+            ^.length.neg.lte end
+            end.plus ^.length
             0
       *
-      list.reducedi
+      ^.reducedi
         *
         if. > [^ accum item index] >>
           and.
@@ -45,7 +45,6 @@
           accum
     T
       "Given slice start and end must both be integers"
-  ^ > list
 
   eq. ++> can-slice-a-list
     slice.

--- a/objects/tuple/withi.eo
+++ b/objects/tuple/withi.eo
@@ -1,4 +1,4 @@
-# Insert `item` into collection `list` at the given `index`.
+# Insert `item` into the tuple at the given `index`.
 # The `index` must be an integer, the same requirement `tuple.front` and
 # `tuple.back` make; anything else terminates. A negative index is clamped
 # to the front of the list and an index past the end appends the item.
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -14,20 +14,19 @@
   index.is-integer.if > @
     concat.
       with.
-        list.front bounded
+        ^.front bounded
         item
-      list.back
-        list.length.minus bounded
+      ^.back
+        ^.length.minus bounded
     T
       "Given index must be an integer"
   if. > bounded
     0.gt index
     0
     if.
-      index.gt list.length
-      list.length
+      index.gt ^.length
+      ^.length
       index
-  ^ > list
 
   eq. ++> can-clamp-a-negative-index-to-the-front-without-duplicating
     withi.

--- a/objects/tuple/without.eo
+++ b/objects/tuple/without.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tuple/withouti.eo
+++ b/objects/tuple/withouti.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tuple
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u16.eo
+++ b/objects/u16.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u32.eo
+++ b/objects/u32.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u64.eo
+++ b/objects/u64.eo
@@ -11,7 +11,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/u64/div.eo
+++ b/objects/u64/div.eo
@@ -1,4 +1,4 @@
-# Unsigned division of the `u64` number `n` by the `u64` number `x`. The
+# Unsigned division of a `u64` number by the `u64` number `x`. The
 # dividend is halved first, so the signed `i64` division underneath never
 # sees a negative operand, and the quotient is corrected back afterwards.
 # When `x` is zero, the caller-supplied `cant-divide` fallback is returned.
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package u64
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,24 +15,24 @@
     d.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
       "Can't divide %d by u64 zero".printf
-        * n.as-number
+        * ^.as-number
     if.
       eq.
         d.as-bytes.and 80-00-00-00-00-00-00-00
         80-00-00-00-00-00-00-00
       if.
-        n.gte x.as-u64
+        ^.gte x.as-u64
         u64 00-00-00-00-00-00-00-01
         u64 00-00-00-00-00-00-00-00
       if.
         gte.
-          n.minus
+          ^.minus
             times.
               u64
                 left. >> q0
                   as-bytes.
                     div.
-                      i64 (n.as-bytes.right 1)
+                      i64 (^.as-bytes.right 1)
                       i64
                         as-bytes.
                           x.as-u64 >> d
@@ -43,7 +43,6 @@
           u64 q0
           u64 00-00-00-00-00-00-00-01
         u64 q0
-  ^ > n
 
   eq. ++> can-divide-a-small-value-by-a-larger-divisor
     00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64

--- a/objects/u8.eo
+++ b/objects/u8.eo
@@ -4,7 +4,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/uri.eo
+++ b/objects/uri.eo
@@ -19,7 +19,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -25,7 +25,7 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -36,14 +36,13 @@
     [^ index] >> loop
       if. > @
         as-bool.
-          ^.condition
-            index.plus 1
+          ^.condition next
         seq *
           current
-          ^.loop
-            index.plus 1
+          ^.loop next
         current
       ^.body index > current
+      index.plus 1 > next
     | 0
     false
 
@@ -195,3 +194,12 @@
     while
       1.gt 2 > [i]
       true > [i]
+
+  ++> can-run-hundreds-of-cycles
+    199.eq > @
+      malloc.for
+        0
+        [m]
+          while > @
+            i.lt 200 > [i]
+            ^.m.put i > [^ i] >>

--- a/objects/win32.eo
+++ b/objects/win32.eo
@@ -10,9 +10,9 @@
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.63.0
++rt jvm org.eolang:eo-runtime:0.63.1
 +rt node eo2js-runtime:0.0.0
-+version 0.63.0
++version 0.63.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.63.1` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.